### PR TITLE
docs: align public copy with brand system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All notable changes to cxthub are documented here.
+All notable changes to CXTHub are documented here.
 
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and releases follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,6 +1,6 @@
 # Code of conduct
 
-We want cxthub collaboration to be technically rigorous, welcoming, and safe.
+We want CXTHub collaboration to be technically rigorous, welcoming, and safe.
 
 ## Expected behavior
 
@@ -14,7 +14,7 @@ We want cxthub collaboration to be technically rigorous, welcoming, and safe.
 ## Scope
 
 This policy applies in repository issues, pull requests, discussions, review
-threads, project chat, and public events where someone represents cxthub.
+threads, project chat, and public events where someone represents CXTHub.
 
 ## Reporting and enforcement
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to cxthub
+# Contributing to CXTHub
 
 Thank you for helping make coding-agent context portable, inspectable, and
 safe to share.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,6 +1,6 @@
 # Governance
 
-cxthub uses a maintainer-led governance model during its alpha stage.
+CXTHub uses a maintainer-led governance model during its alpha stage.
 
 ## Roles
 
@@ -71,4 +71,4 @@ evidence, user impact, and project invariants.
 
 The Apache License 2.0 permits forks. Forks must follow
 [TRADEMARKS.md](TRADEMARKS.md) and must not imply that they are official
-cxthub services or releases.
+CXTHub services or releases.

--- a/NOTICE
+++ b/NOTICE
@@ -1,7 +1,7 @@
-cxthub
-Copyright 2026 cxthub contributors
+CXTHub
+Copyright 2026 CXTHub contributors
 
-This product includes software developed by the cxthub contributors.
+This product includes software developed by the CXTHub contributors.
 
 Third-party component notices are recorded in THIRD_PARTY_NOTICES.md and in
 the dependency lockfiles distributed with the source.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="frontend/web/public/cxt-logo-dark-theme.svg">
     <source media="(prefers-color-scheme: light)" srcset="frontend/web/public/cxt-logo-light-theme.svg">
-    <img src="frontend/web/public/cxt-logo-light-theme.svg" alt="CXTHub logo" width="38" align="absmiddle">
+    <img src="frontend/web/public/cxt-logo-light-theme.svg" alt="" width="38" align="absmiddle">
   </picture>
   CXTHub
 </h1>
@@ -24,9 +24,9 @@ Git preserves outcomes with extraordinary discipline: commits, diffs,
 branches, authors, and dates. The investigation and judgment that made those
 outcomes necessary still disappear inside temporary agent conversations.
 
-CXTHub versions that missing context alongside the code. A developer or agent
-can return to a branch, hand work to a teammate, or continue in another
-supported agent without reconstructing the reasoning from scratch.
+CXTHub captures and versions the missing context alongside the code. A
+developer or agent can return to a branch, hand work to a teammate, or continue
+in another supported agent without reconstructing the reasoning from scratch.
 
 It is not a chat archive, a project wiki, or a second workflow beside Git. It
 is a context layer that follows the lifecycle of the code.

--- a/README.md
+++ b/README.md
@@ -1,44 +1,78 @@
-# cxthub
+<h1>
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="frontend/web/public/cxt-logo-dark-theme.svg">
+    <source media="(prefers-color-scheme: light)" srcset="frontend/web/public/cxt-logo-light-theme.svg">
+    <img src="frontend/web/public/cxt-logo-light-theme.svg" alt="CXTHub logo" width="38" align="absmiddle">
+  </picture>
+  CXTHub
+</h1>
 
-[![CI](https://github.com/wnsdy95/cxthub/actions/workflows/ci.yml/badge.svg)](https://github.com/wnsdy95/cxthub/actions/workflows/ci.yml)
-[![Release](https://img.shields.io/github/v/release/wnsdy95/cxthub?display_name=tag&sort=semver)](https://github.com/wnsdy95/cxthub/releases)
-[![License](https://img.shields.io/github/license/wnsdy95/cxthub)](LICENSE)
+**Where the code goes, the context follows.**
 
-cxthub is Git-style version control for coding-agent context. It captures
-Claude Code and Codex sessions, connects them to Git history, restores them
-across branches or providers, and synchronizes them through a self-hostable
-server.
+Git-native shared memory for coding agents.
+
+[![CI](https://github.com/wnsdy95/cxthub/actions/workflows/ci.yml/badge.svg)](https://github.com/wnsdy95/cxthub/actions/workflows/ci.yml) [![Release](https://img.shields.io/github/v/release/wnsdy95/cxthub?display_name=tag&sort=semver)](https://github.com/wnsdy95/cxthub/releases) [![License](https://img.shields.io/github/license/wnsdy95/cxthub)](LICENSE)
 
 > [!WARNING]
-> cxthub is alpha software. Back up important data, review captured context
+> CXTHub is alpha software. Back up important data, review captured context
 > before sharing it, and never rely on automatic secret scrubbing as your only
 > security control.
 
-## What it does
+## The repository remembers the change. It should remember the reason.
 
-- Captures agent sessions automatically through Git and provider hooks.
-- Stores normalized context as content-addressed snapshots.
-- Keeps context aligned with commits, branches, rebases, resets, and stashes.
-- Restores sessions in full, reconstructed, or distilled-memory form.
-- Converts supported context between Claude Code and Codex.
-- Synchronizes immutable objects and mutable refs through `cxtd`.
-- Provides a web UI for history, comparison, review, and workspace management.
-- Shares selected agent settings and end-to-end encrypted secret-mask lists.
+Git preserves outcomes with extraordinary discipline: commits, diffs,
+branches, authors, and dates. The investigation and judgment that made those
+outcomes necessary still disappear inside temporary agent conversations.
+
+CXTHub versions that missing context alongside the code. A developer or agent
+can return to a branch, hand work to a teammate, or continue in another
+supported agent without reconstructing the reasoning from scratch.
+
+It is not a chat archive, a project wiki, or a second workflow beside Git. It
+is a context layer that follows the lifecycle of the code.
+
+## No new workflow
+
+CXTHub follows Git actions developers already use:
+
+| Git action | CXTHub behavior |
+|---|---|
+| `git commit` | Capture staged active agent sessions and link them to the commit |
+| `git switch` / `git checkout` | Restore the destination branch context |
+| `git branch` | Create the corresponding context branch |
+| `git rebase` / `git commit --amend` | Track rewritten commit links |
+| `git stash` / `git stash pop` | Preserve or restore unfinished agent work |
+| `git push` / `git pull` | Synchronize context with the configured remote |
+
+Install the hooks once with `cxt init`. After that, the code and the context
+move together.
+
+## What CXTHub carries forward
+
+- **Sessions** — capture Claude Code and Codex work through provider and Git
+  hooks.
+- **Snapshots** — store normalized context as immutable, content-addressed
+  states.
+- **Commit links** — connect the session state to the code change it shaped.
+- **Branches and stashes** — reorient or resume when repository work moves.
+- **Agent transfer** — materialize supported context for Claude Code or Codex,
+  regardless of which one created it.
+- **Team history** — push and pull shared context through a self-hostable
+  `cxtd` remote.
+- **Retrieval** — let compatible agents inspect repository context through the
+  read-only MCP server.
+- **Review** — inspect history, comparisons, pending sessions, and workspace
+  state in the web interface.
+
+The underlying model is deliberately Git-like:
+
+```text
+agent session → cxt snapshot → Git commit → cxtd remote → person or agent
+```
 
 Natural snapshot parents are immutable. Repairs and session placement use
-versioned overlay edges, so synchronization never rewrites a snapshot's
-content identity.
-
-## Components
-
-| Path | Purpose |
-|---|---|
-| `cli/` | Go `cxt` CLI, capture adapters, codecs, local object store, and MCP server |
-| `backend/` | Go `cxtd` HTTP server with filesystem and PostgreSQL stores |
-| `frontend/web/` | React and TypeScript web application |
-| `schemas/` | OpenAPI, JSON Schema, and ordered PostgreSQL migrations |
-| `integrations/` | Claude Code and Codex integration assets |
-| `deploy/` | Optional self-hosting infrastructure |
+versioned overlay edges, so synchronization can preserve reachability without
+rewriting a snapshot's content identity.
 
 ## Install
 
@@ -71,18 +105,6 @@ cxt login
 cxt remote -v
 ```
 
-`cxt init` installs Git hooks by default. Once installed, normal Git actions
-capture and move context:
-
-| Git action | cxt behavior |
-|---|---|
-| `git commit` | Capture staged active agent sessions and link the Git commit |
-| `git switch` / `git checkout` | Restore the destination branch context |
-| `git branch` | Create the corresponding context branch |
-| `git rebase` / `git commit --amend` | Track rewritten Git commit links |
-| `git stash` / `git stash pop` | Save or restore the active session |
-| `git push` / `git pull` | Synchronize context with the configured origin |
-
 Useful manual commands:
 
 ```bash
@@ -94,30 +116,46 @@ cxt fsck
 cxt --help
 ```
 
-Use `cxt init --no-hooks` to opt out, or `cxt hooks uninstall` to remove the
-managed hooks.
+Use `cxt init --no-hooks` to opt out of automatic Git integration, or
+`cxt hooks uninstall` to remove the managed hooks.
 
 ## Provider integrations
 
-- `integrations/claude-code/` contains Claude Code plugin, command, MCP, and
-  hook assets.
-- `integrations/codex/` contains Codex MCP, prompt, and hook configuration.
+- `integrations/claude-code/` contains the Claude Code plugin, command, MCP,
+  and hook assets.
+- `integrations/codex/` contains the Codex MCP, prompt, and hook
+  configuration.
 
-The CLI can also wrap either provider directly:
+The CLI can also start either provider with repository context:
 
 ```bash
 cxt claude
 cxt codex
 ```
 
-## Secret handling
+## Privacy is architecture
+
+CXTHub processes coding-agent conversations, which may contain source code,
+credentials, customer data, or internal decisions.
 
 Place exact secret values, one per line, in `.cxtsecrets`. The CLI masks those
 values before writing a capture. The file is ignored by Git and is not uploaded
-in plaintext.
+in plaintext. Shared secret-mask lists are end-to-end encrypted.
 
 Pattern-based scrubbing and `.cxtsecrets` are defense in depth. If a credential
-may have entered an agent session or Git history, revoke it immediately.
+may have entered an agent session or Git history, revoke it immediately. See
+[SECURITY.md](SECURITY.md) for the disclosure process and security boundaries.
+
+## Components
+
+| Path | Purpose |
+|---|---|
+| `cli/` | Go `cxt` CLI, capture adapters, codecs, local object store, and MCP server |
+| `backend/` | Go `cxtd` HTTP server with filesystem and PostgreSQL stores |
+| `frontend/web/` | React and TypeScript web application |
+| `schemas/` | OpenAPI, JSON Schema, and ordered PostgreSQL migrations |
+| `integrations/` | Claude Code and Codex integration assets |
+| `deploy/` | Optional self-hosting infrastructure |
 
 ## Self-hosting
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # Security policy
 
-cxthub stores coding-agent conversations and may process sensitive repository
+CXTHub stores coding-agent conversations and may process sensitive repository
 context. Treat suspected vulnerabilities as confidential.
 
 ## Reporting a vulnerability

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,13 +1,13 @@
 # Support
 
-cxthub is alpha software.
+CXTHub is alpha software.
 
 | Need | Channel |
 |---|---|
 | Reproducible bug | GitHub Issue |
 | Usage or design question | GitHub Discussions |
 | Vulnerability | Private process in `SECURITY.md` |
-| Hosted-service account or billing issue | Official cxthub support channel |
+| Hosted-service account or billing issue | Official CXTHub support channel |
 
 Self-hosting is permitted and documented, but community support is best-effort
 and has no SLA. Include versions, operating system, storage adapter, relevant

--- a/TRADEMARKS.md
+++ b/TRADEMARKS.md
@@ -1,18 +1,18 @@
 # Trademark policy
 
 The Apache License 2.0 grant applies to source code and does not grant rights
-to cxthub names, logos, domains, or other brand assets.
+to CXTHub names, logos, domains, or other brand assets.
 
 You may:
 
-- truthfully state that software is compatible with or based on cxthub;
+- truthfully state that software is compatible with or based on CXTHub;
 - link to the official project;
 - use the name in commentary, reviews, and community discussion.
 
 You may not:
 
-- present a fork, hosted service, or binary as an official cxthub release;
-- use cxthub logos or a confusingly similar name as the primary branding of a
+- present a fork, hosted service, or binary as an official CXTHub release;
+- use CXTHub logos or a confusingly similar name as the primary branding of a
   modified distribution;
 - imply endorsement, partnership, or certification without permission.
 

--- a/docs/BRANCHING.md
+++ b/docs/BRANCHING.md
@@ -1,6 +1,6 @@
 # Branching and integration
 
-cxthub follows a trunk-based GitHub Flow. `main` is the only long-lived
+CXTHub follows a trunk-based GitHub Flow. `main` is the only long-lived
 development branch and should remain releasable.
 
 ## Branch names

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,6 +1,6 @@
-# Releasing cxthub
+# Releasing CXTHub
 
-cxthub uses Semantic Versioning tags:
+CXTHub uses Semantic Versioning tags:
 
 ```text
 vMAJOR.MINOR.PATCH
@@ -17,7 +17,7 @@ release authority. Release automation uses the repository-scoped
 `GITHUB_TOKEN`; no personal access token is required.
 
 Service deployment and open-source releases are separate operations. Creating a
-tag does not deploy a hosted cxthub service.
+tag does not deploy a hosted CXTHub service.
 
 ## Before tagging
 
@@ -45,7 +45,7 @@ Use a release candidate for changes that need broader installation or
 compatibility testing:
 
 ```bash
-git tag -s v0.2.0-rc.1 -m "cxthub v0.2.0-rc.1"
+git tag -s v0.2.0-rc.1 -m "CXTHub v0.2.0-rc.1"
 git push origin v0.2.0-rc.1
 ```
 
@@ -54,7 +54,7 @@ git push origin v0.2.0-rc.1
 Create a signed annotated tag on the verified `main` commit:
 
 ```bash
-git tag -s v0.2.0 -m "cxthub v0.2.0"
+git tag -s v0.2.0 -m "CXTHub v0.2.0"
 git push origin v0.2.0
 ```
 


### PR DESCRIPTION
## Summary

- rewrite the README around the CXTHub brand promise and Git-native product model
- add the existing light/dark logo beside the README title
- normalize the public-facing `CXTHub` name across project policy documents
- keep repository names, URLs, commands, and package identifiers lowercase where required

## Validation

- `make public-check-full`
- `go test ./internal/adapters/delivery/cli -run 'TestUsage|TestHelp|TestUnknownCommand'`\n- `go run ./cmd/cxt -h`\n- GitHub Markdown API render check\n- README local-link check\n- `git diff --check`\n\n## Scope\n\nDocumentation and existing brand assets only. No runtime code or deployment changes.