### PR TITLE
fix(docs): use readable README logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 <h1>
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="frontend/web/public/cxt-logo-dark-theme.svg">
-    <source media="(prefers-color-scheme: light)" srcset="frontend/web/public/cxt-logo-light-theme.svg">
-    <img src="frontend/web/public/cxt-logo-light-theme.svg" alt="" width="38" align="absmiddle">
-  </picture>
+  <img src="frontend/web/src/assets/cxt-logo-light-theme.png" alt="" width="38" align="absmiddle">
   CXTHub
 </h1>
 


### PR DESCRIPTION
## Summary

- replace the malformed theme-switched SVG logo in the README header
- use the existing black logo PNG from `frontend/web/src/assets`
- preserve its small white square canvas so the mark remains readable in light and dark GitHub themes

## Validation

- rendered the asset at the actual 38 px README size
- verified the output with the GitHub Markdown API
- checked every README-local asset target
- ran `make public-check-full`
- ran `git diff --check`

No runtime code or deployment changes.