### PR TITLE
docs: add installation and CLI references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,11 +112,12 @@ Thumbs.db
 /.mcp.json
 
 # Private design, research, planning, and deployment notes. Public project
-# policy belongs in the tracked top-level files and docs/BRANCHING.md or
-# docs/RELEASING.md.
+# documentation is explicitly allowlisted below.
 /docs/internal/
 /docs/*.md
 !/docs/BRANCHING.md
+!/docs/CLI.md
+!/docs/INSTALLATION.md
 !/docs/RELEASING.md
 
 # Vim / Emacs

--- a/README.md
+++ b/README.md
@@ -78,9 +78,14 @@ Release binaries support macOS and Linux on arm64 and amd64:
 curl -fsSL https://raw.githubusercontent.com/wnsdy95/cxthub/main/distrib/install | sh
 ```
 
-Pin a version with `CXT_VERSION=v0.1.0`.
+Pin a version by passing the variable to the installer shell:
 
-To build from source, install Go 1.26+, Node.js 22+, npm, and Git 2.28+:
+```bash
+curl -fsSL https://raw.githubusercontent.com/wnsdy95/cxthub/main/distrib/install |
+  CXT_VERSION=v0.1.0 sh
+```
+
+To build the Go binaries from source, install Go 1.26.5+ and Git 2.28+:
 
 ```bash
 git clone https://github.com/wnsdy95/cxthub.git
@@ -90,16 +95,22 @@ make build
 
 The binaries are written to `bin/cxt` and `bin/cxtd`.
 
+See the [installation guide](docs/INSTALLATION.md) for manual archive
+verification, custom install directories, upgrades, removal, source builds,
+and the separate `cxtd` server.
+
 ## Quick start
 
 Run these commands inside an existing Git repository:
 
 ```bash
-cxt init
-cxt remote add origin https://<host>/<username>/<workspace>
-cxt login
+cxt setup https://<host>/<username>/<workspace>
 cxt remote -v
 ```
+
+`cxt setup` initializes the local store, installs Git hooks, registers the
+workspace, starts browser login, merges provider hooks, and pulls team settings.
+It is safe to rerun. Use `cxt init` instead for local-only operation.
 
 Useful manual commands:
 
@@ -114,6 +125,9 @@ cxt --help
 
 Use `cxt init --no-hooks` to opt out of automatic Git integration, or
 `cxt hooks uninstall` to remove the managed hooks.
+
+The complete command and option reference is in
+[docs/CLI.md](docs/CLI.md).
 
 ## Provider integrations
 
@@ -181,6 +195,11 @@ make public-check
 
 PostgreSQL changes should also run `make test-postgres` against PostgreSQL 16.
 See [CONTRIBUTING.md](CONTRIBUTING.md) before opening an issue or pull request.
+
+## Documentation
+
+- [Installation](docs/INSTALLATION.md)
+- [CLI reference](docs/CLI.md)
 
 ## Project policy
 

--- a/cli/internal/adapters/delivery/cli/root.go
+++ b/cli/internal/adapters/delivery/cli/root.go
@@ -111,7 +111,7 @@ func Run(c *Container, args []string) error {
 			}
 		}
 		if _, ok := remotecfg.Origin(cwd); !ok {
-			fmt.Println("hint: to connect to team server → cxt setup https://<host>/<username>/<workspace>/<repo>")
+			fmt.Println("hint: to connect to team server → cxt setup https://<host>/<username>/<workspace>")
 		}
 		return nil
 
@@ -293,7 +293,7 @@ func Run(c *Container, args []string) error {
 			}
 			return nil
 		default:
-			return fmt.Errorf("supported keys: checkout.mode | load.mode | boundary.enforce | secrets.redact | secrets.minlen")
+			return fmt.Errorf("supported keys: checkout.mode | load.mode | boundary.enforce | capture.debounce | secrets.scrub | secrets.redact | secrets.minlen")
 		}
 
 	case "login":
@@ -967,9 +967,10 @@ usage: cxt <command> [flags]
   Getting started:
   setup [remote-url]        initialize everything: repository → Git hooks → remote → login → agent hooks → team settings
                             (safe to rerun; use --no-login to skip login)
-  init [--no-hooks]         initialize the local context store and install Git hooks
+  init [--no-hooks] [--remote <url>]
+                            initialize the local context store and install Git hooks
   repo create <url>         initialize and connect a server repository
-  login [token]             authenticate with the configured origin
+  login [token|-t token]    authenticate with the configured origin
   logout                    remove the saved origin credential
 
   Agent commands:
@@ -985,8 +986,10 @@ usage: cxt <command> [flags]
   remote remove <name>      remove a configured remote
   add [claude|codex]        stage providers for the next commit (defaults to both)
   commit [-m msg]           capture the active session (also run automatically by the Git commit hook)
-  checkout <ref> [-b new]   restore or branch context (also run automatically by Git checkout)
-  switch <branch> [-c new]  alias for checkout (equivalent to Git switch)
+  checkout [<ref>] [-b new] [--provider claude|codex] [--mode full|reconstructed|memory]
+                            restore or branch context (also run automatically by Git checkout)
+  switch [<branch>] [-c new] [--mode full|reconstructed|memory]
+                            alias for checkout (equivalent to Git switch)
   push [--force|--append]   synchronize local context to origin
   pull [--force]            synchronize origin context locally
   tag [<name> [ref]]        list or create immutable tags (equivalent to Git tags)
@@ -994,16 +997,20 @@ usage: cxt <command> [flags]
 
   Context commands:
   save [-m msg] [--provider claude|codex]
-                            create a snapshot without resolving pending state
+                            create a single-provider snapshot without commit staging or remote pending sync
   list | log [--branch B]   list snapshots
-  fork <ref> --as <branch>  fork and restore a context branch
-  load <ref> [--mode full|reconstructed|memory]
-                            restore a snapshot
-  memorize | memory         distill head context into reusable memory
+  fork <ref> --as <branch> [--provider claude|codex] [--mode full|reconstructed|memory]
+                            fork and restore a context branch
+  load [<ref>] [--provider claude|codex] [--mode full|reconstructed|memory]
+                            restore a snapshot (current head when ref is omitted)
+  memorize | memory [<ref>] [--provider claude|codex]
+                            distill context into reusable memory
 
   Configuration and maintenance:
-  settings pull|list|restore  apply team defaults, list backups, or restore a backup
-  secrets push|pull -p <pw> share .cxtsecrets with end-to-end encryption
+  settings pull|list|restore [n]
+                            apply team defaults, list backups, or restore a backup
+  secrets push|pull [-p <pw>] [--remember] [--rotate]
+                            share .cxtsecrets with end-to-end encryption
   hooks install|uninstall   manage Git hooks manually
   config <key> [value]      inspect or set checkout, load, boundary, capture, or scrub behavior
   fsck                      audit repository integrity

--- a/cli/internal/adapters/delivery/cli/root_help_test.go
+++ b/cli/internal/adapters/delivery/cli/root_help_test.go
@@ -1,6 +1,10 @@
 package cli
 
 import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -40,5 +44,32 @@ func TestUnknownCommandUsesPublicCommandCatalog(t *testing.T) {
 	}
 	if strings.Contains(err.Error(), "git-hook") {
 		t.Errorf("unknown-command error exposed internal git-hook command: %v", err)
+	}
+}
+
+func TestCLIReferenceCoversEveryPublicCommand(t *testing.T) {
+	_, sourceFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("cannot locate test source")
+	}
+	docPath := filepath.Clean(filepath.Join(filepath.Dir(sourceFile), "../../../../../docs/CLI.md"))
+	raw, err := os.ReadFile(docPath)
+	if errors.Is(err, os.ErrNotExist) {
+		// A separately packaged cli module may not include repository-level
+		// documentation. The public repository preflight requires the file.
+		t.Skip("repository-level CLI reference is not present in this module package")
+	}
+	if err != nil {
+		t.Fatalf("read CLI reference: %v", err)
+	}
+	doc := string(raw)
+
+	for _, command := range publicCommandNames {
+		if !strings.Contains(doc, "cxt "+command) {
+			t.Errorf("CLI reference does not mention public command %q", command)
+		}
+	}
+	if strings.Contains(doc, "cxt git-hook") {
+		t.Error("CLI reference exposed internal git-hook command")
 	}
 }

--- a/distrib/README.md
+++ b/distrib/README.md
@@ -18,7 +18,16 @@ curl -fsSL https://raw.githubusercontent.com/wnsdy95/cxthub/main/distrib/install
 ```
 
 Supports macOS (arm64/amd64) and Linux (arm64/amd64).
-Pin a version with the `CXT_VERSION=v0.1.0` environment variable.
+Pin a version by passing the variable to the installer shell:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/wnsdy95/cxthub/main/distrib/install |
+  CXT_VERSION=v0.1.0 sh
+```
+
+The release installer installs the `cxt` client only. See the full
+[installation guide](../docs/INSTALLATION.md) for manual verification, source
+builds, upgrades, removal, and `cxtd`.
 
 ## Getting started
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,0 +1,487 @@
+# `cxt` CLI reference
+
+`cxt` is the Git-integrated client for capturing, restoring, and synchronizing
+coding-agent context. This reference describes the public command surface on
+the `main` branch.
+
+Check the installed version and built-in command catalog first:
+
+```bash
+cxt --version
+cxt --help
+```
+
+For installation and first-run setup, see
+[Installing CXTHub](INSTALLATION.md).
+
+## Conventions
+
+- Run repository commands inside an existing Git working tree.
+- A workspace remote uses
+  `https://<host>/<username>/<workspace>` with exactly two path segments.
+- `<ref>` accepts `HEAD`, a branch name, a tag name, or a full
+  `sha256:<64-hex-character>` snapshot ID. An omitted ref resolves to the
+  current context head where supported.
+- Providers are `claude` and `codex`.
+- Restore modes are:
+  - `full`: materialize the native session when possible;
+  - `reconstructed`: rebuild a provider-compatible session from normalized
+    context; and
+  - `memory`: inject the distilled memory representation.
+- Git and provider hooks are fail-open: a capture or sync failure is reported
+  but does not block the Git or agent operation.
+
+## Recommended onboarding
+
+### `cxt setup`
+
+```text
+cxt setup [remote-url] [--no-login]
+```
+
+Runs the complete, idempotent onboarding sequence:
+
+1. initialize the local `.cxt` store;
+2. install managed Git hooks;
+3. register the workspace remote when supplied;
+4. authenticate through the browser device flow unless `--no-login` is set;
+5. merge Claude Code and Codex lifecycle hooks; and
+6. pull team settings when authenticated.
+
+Example:
+
+```bash
+cxt setup https://cxthub.example/alice/platform
+```
+
+Rerunning the command reports and repairs missing setup steps without replacing
+an existing remote that points somewhere else.
+
+## Repository and authentication
+
+### `cxt init`
+
+```text
+cxt init [--no-hooks] [--remote <workspace-url>]
+```
+
+Initializes `.cxt/`, updates local ignore protections, creates `.cxtsecrets`
+from eligible `.env` values when appropriate, and installs managed Git hooks.
+
+- `--no-hooks` skips Git hook installation.
+- `--remote` also registers `origin`.
+
+Local-only initialization:
+
+```bash
+cxt init
+```
+
+### `cxt repo create`
+
+```text
+cxt repo create <workspace-url>
+```
+
+Convenience alias for initialization plus `origin` registration.
+
+### `cxt remote`
+
+```text
+cxt remote [-v]
+cxt remote add <name> <workspace-url>
+cxt remote remove <name>
+```
+
+The `origin` URL determines both the server API endpoint and the content
+repository identity.
+
+```bash
+cxt remote add origin https://cxthub.example/alice/platform
+cxt remote -v
+cxt remote remove origin
+```
+
+Changing an existing remote requires removing it and adding the replacement.
+
+### `cxt login`
+
+```text
+cxt login [token]
+cxt login -t <token>
+```
+
+Without a token, starts the browser device flow for the configured `origin`.
+The manual token form is intended as a fallback and may leave the token in
+shell history. `CXT_TOKEN` is the non-interactive override.
+
+### `cxt logout`
+
+```text
+cxt logout
+```
+
+Removes the locally stored credential for the configured origin host. It does
+not revoke the token on the server.
+
+## Agent and integration commands
+
+### `cxt claude`
+
+```text
+cxt claude [claude-arguments...]
+```
+
+Runs Claude Code with branch-context seeding and passes remaining arguments to
+the installed `claude` executable.
+
+### `cxt codex`
+
+```text
+cxt codex [codex-arguments...]
+```
+
+Runs Codex with branch-context seeding and passes remaining arguments to the
+installed `codex` executable.
+
+### `cxt mcp`
+
+```text
+cxt mcp
+```
+
+Starts the read-only MCP server on standard input/output. It exposes:
+
+| Tool | Purpose |
+|---|---|
+| `context_list` | List local repository snapshots |
+| `context_fetch` | Fetch snapshot metadata, memory, and recent conversation context |
+| `memory_load` | Load the nearest available memory digest for a ref |
+| `context_search` | Search synchronized team context through the configured origin |
+
+### `cxt hook`
+
+```text
+cxt hook --provider <claude|codex> --event <event>
+```
+
+Provider-integration entry point. `cxt setup` writes these invocations into
+provider hook settings; users normally do not call it directly. Hook failures
+are reported without blocking the provider.
+
+## Capture and commit commands
+
+### `cxt add`
+
+```text
+cxt add [claude|codex]...
+cxt add .
+```
+
+Stages the providers to capture on the next `cxt commit` or Git post-commit
+hook. With no provider, or with `.`, both providers are staged. The staging
+selection is cleared after a successful commit capture.
+
+### `cxt commit`
+
+```text
+cxt commit [-m <message>]
+```
+
+Captures active sessions from the staged providers, or from both providers
+when nothing is staged. Each successful capture is distilled into reusable
+memory. The command also schedules synchronization that resolves matching
+remote pending-session pointers.
+
+Ordinary `git commit` invokes the same capture path and adds the Git commit
+message and short SHA link automatically.
+
+### `cxt save`
+
+```text
+cxt save [-m <message>] [--provider <claude|codex>]
+```
+
+Creates a manual snapshot for one provider; the default is `claude`. It does
+not consume `cxt add` staging and does not schedule the commit path's detached
+remote pending synchronization.
+
+Use `cxt commit` when the capture represents a code commit. Use `cxt save` for
+an explicit standalone checkpoint.
+
+### `cxt list` and `cxt log`
+
+```text
+cxt list [--branch <branch>]
+cxt log [--branch <branch>]
+```
+
+Lists local snapshots, optionally restricted to a branch. `log` is an alias for
+`list`.
+
+## Restore and branch commands
+
+### `cxt checkout`
+
+```text
+cxt checkout [<ref>] [-b <new-branch>]
+  [--provider <claude|codex>]
+  [--mode <full|reconstructed|memory>]
+```
+
+Restores a ref. With `-b`, creates and restores a new context branch from that
+ref. Git checkout hooks normally invoke the corresponding behavior
+automatically.
+
+### `cxt switch`
+
+```text
+cxt switch [<branch>] [-c <new-branch>]
+  [--mode <full|reconstructed|memory>]
+```
+
+Git-style alias for checkout. `-c` creates a branch.
+
+### `cxt fork`
+
+```text
+cxt fork <ref> --as <branch>
+  [--provider <claude|codex>]
+  [--mode <full|reconstructed|memory>]
+```
+
+Creates a context branch from a specific ref and restores it.
+
+### `cxt load`
+
+```text
+cxt load [<ref>]
+  [--provider <claude|codex>]
+  [--mode <full|reconstructed|memory>]
+```
+
+Restores a snapshot without creating a branch. Omitting `<ref>` loads the
+current context head. `--provider` enables supported cross-provider
+materialization.
+
+The mode priority is:
+
+1. the command's `--mode`;
+2. local `config load.mode`;
+3. the authenticated account preference from the server; and
+4. `full`.
+
+### `cxt memorize` and `cxt memory`
+
+```text
+cxt memorize [<ref>] [--provider <claude|codex>]
+cxt memory [<ref>] [--provider <claude|codex>]
+```
+
+Distills a snapshot into reusable memory and attaches it for the next push.
+With no ref, uses the current branch head. `memory` is an alias for
+`memorize`; there is no `cxt memory save` subcommand.
+
+## Synchronization
+
+### `cxt push`
+
+```text
+cxt push [--append | --force]
+```
+
+Synchronizes local objects and refs to `origin`.
+
+- The default rejects a non-fast-forward update.
+- `--append` preserves both histories by placing the local segment after the
+  remote head through the graph overlay.
+- `--force` replaces remote ref state and may make remote-only history
+  unreachable from that ref.
+
+Prefer `--append` or pull-and-retry over `--force`.
+
+### `cxt pull`
+
+```text
+cxt pull [--force]
+```
+
+Downloads objects and refs from `origin`.
+
+- The default keeps local state and reports diverged branches.
+- `--force` adopts remote ref state.
+
+Review local work before using `--force`.
+
+## Tags and stashes
+
+### `cxt tag`
+
+```text
+cxt tag
+cxt tag <name> [<ref>]
+```
+
+Lists tags or creates an immutable tag. With no ref, tags the current head.
+Tags are synchronized on the next push.
+
+### `cxt stash`
+
+```text
+cxt stash
+cxt stash push [-m <message>]
+cxt stash list
+cxt stash pop
+```
+
+Stores active context separately and restores the branch-head context. `pop`
+restores and removes the newest context stash. Managed Git hooks mirror
+ordinary `git stash` and `git stash pop` operations.
+
+## Team settings and secret masks
+
+### `cxt settings`
+
+```text
+cxt settings pull
+cxt settings list
+cxt settings restore [index]
+```
+
+- `pull` applies available team `.claude/`, `.agents/`, and `.codex/` settings.
+- `list` shows current setting-object hashes and local replacement backups.
+- `restore` restores a backup; the default index is `0`.
+
+### `cxt secrets`
+
+```text
+cxt secrets push [-p <passphrase>] [--remember] [--rotate]
+cxt secrets pull [-p <passphrase>] [--remember]
+```
+
+Encrypts or decrypts the repository's `.cxtsecrets` list locally. The
+passphrase is not sent to the server.
+
+Passphrase lookup order:
+
+1. `-p`;
+2. `CXT_SECRETS_PASSPHRASE`; and
+3. the per-repository credential saved by `--remember`.
+
+`--rotate` performs a compare-and-swap passphrase rotation and rejects a stale
+update. Share a rotated passphrase with authorized team members through a
+separate secure channel.
+
+The scrubber is defense in depth, not a credential-management system. Revoke
+any secret that may have entered a session.
+
+## Git hook management
+
+### `cxt hooks`
+
+```text
+cxt hooks install
+cxt hooks uninstall
+```
+
+Installs or removes the six managed Git hooks:
+
+```text
+post-commit
+post-checkout
+post-merge
+pre-push
+reference-transaction
+post-rewrite
+```
+
+Existing user hooks are chained and restored on uninstall.
+
+## Configuration
+
+### `cxt config`
+
+```text
+cxt config <key>
+cxt config <key> <value>
+```
+
+Reading a key prints its effective local value. Supported keys are:
+
+| Key | Values | Default | Effect |
+|---|---|---|---|
+| `checkout.mode` | `auto`, `prepare` | `auto` | Restore automatically or only prepare the resume action after Git checkout |
+| `load.mode` | `full`, `reconstructed`, `memory`, `default` | `full` | Default restore fidelity; `default` clears the local override |
+| `boundary.enforce` | `kill`, `none`, `default` | `kill` | Enforce process isolation across context switches |
+| `capture.debounce` | non-negative seconds, `default` | 60 seconds | Minimum interval for repeated Stop-event captures |
+| `secrets.scrub` | `off`, `standard`, `strict`, `default` | `standard` | Pattern-based scrub tier |
+| `secrets.redact` | replacement text, `default` | built-in redaction token | Exact-secret replacement text |
+| `secrets.minlen` | `0` through `64` | `4` | Minimum exact-secret length; `0` restores the default |
+
+Examples:
+
+```bash
+cxt config checkout.mode prepare
+cxt config load.mode reconstructed
+cxt config secrets.scrub strict
+cxt config capture.debounce 120
+```
+
+Configuration is repository-local.
+
+## Maintenance and diagnostics
+
+### `cxt fsck`
+
+```text
+cxt fsck
+```
+
+Runs a read-only server audit for reachability, roots, unreachable snapshots,
+and missing parents. Requires a configured remote.
+
+### `cxt reflog`
+
+```text
+cxt reflog
+```
+
+Lists server ref movements newest first. Requires a configured remote.
+
+### `cxt repack`
+
+```text
+cxt repack
+```
+
+Repackages legacy local documents into chunked content-addressed storage and
+reports reclaimed duplicate-prefix bytes. Snapshot identity remains unchanged.
+Back up important alpha data before storage maintenance.
+
+## Global information
+
+```text
+cxt version
+cxt --version
+cxt help
+cxt -h
+cxt --help
+```
+
+`version` prints the release version. All help aliases print the public command
+catalog and return success.
+
+## Environment variables
+
+| Variable | Purpose |
+|---|---|
+| `CXT_REMOTE` | API base fallback when no repository remote is configured |
+| `CXT_TOKEN` | Non-interactive authentication token |
+| `CXT_NAME`, `CXT_EMAIL`, `CXT_TEAM` | Snapshot author identity overrides |
+| `CXT_NO_BROWSER=1` | Prevent automatic browser launch during login |
+| `CXT_SECRETS_PASSPHRASE` | Passphrase fallback for encrypted secret-mask sharing |
+| `CXT_KEEP_SESSION=1` | Suppress automatic session switching during a Git branch transition |
+| `CXT_CARRY=1` | Carry the active session across a context transition |
+
+Do not expose tokens, passphrases, or private session content in command output,
+shell history, issue reports, or CI logs.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,0 +1,354 @@
+# Installing CXTHub
+
+This guide covers the `cxt` client, source builds, upgrades, removal, and the
+separate `cxtd` server.
+
+> [!WARNING]
+> CXTHub is alpha software. Back up important data and review captured context
+> before sharing it.
+
+## Choose what to install
+
+| Goal | Recommended path |
+|---|---|
+| Use CXTHub in a Git repository | Install the published `cxt` CLI |
+| Contribute to CXTHub | Build the repository from source |
+| Run a local development server | Build `cxtd` from source |
+| Operate an internet-facing server | Review the source deployment templates and the operator requirements in [SECURITY.md](../SECURITY.md) |
+
+The published release installer installs **only the `cxt` client**. It does not
+install `cxtd`, the web application, PostgreSQL, or cloud infrastructure.
+
+## Requirements
+
+Published `cxt` binaries support:
+
+- macOS on arm64 or amd64;
+- Linux on arm64 or amd64;
+- Git 2.28 or newer; and
+- at least one supported coding agent, Claude Code or Codex, for capture and
+  restore workflows.
+
+The installer also requires `curl`, `tar`, and either `sha256sum` or `shasum`.
+Native Windows archives are not currently published.
+
+Source builds additionally require:
+
+- Go 1.26.5 or newer for `cxt` and `cxtd`;
+- Node.js 22 and npm for the web application; and
+- PostgreSQL 16 for PostgreSQL adapter and migration testing.
+
+## Install the latest release
+
+The installer detects the operating system and architecture, downloads the
+matching GitHub Release archive, verifies it against `checksums.txt`, and
+installs `cxt`:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/wnsdy95/cxthub/main/distrib/install | sh
+```
+
+The destination is selected in this order:
+
+1. `CXT_INSTALL_DIR`, when set;
+2. `/usr/local/bin`, when writable; or
+3. `$HOME/.local/bin`.
+
+When the selected directory is not already in `PATH`, the installer adds a
+marked entry to the appropriate shell startup file.
+
+Verify the installation:
+
+```bash
+cxt --version
+cxt --help
+```
+
+The version should match a published
+[CXTHub release](https://github.com/wnsdy95/cxthub/releases).
+
+## Install a specific version
+
+Pass `CXT_VERSION` to the shell that executes the downloaded installer:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/wnsdy95/cxthub/main/distrib/install |
+  CXT_VERSION=v0.1.0 sh
+```
+
+To install into a specific directory:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/wnsdy95/cxthub/main/distrib/install |
+  CXT_VERSION=v0.1.0 CXT_INSTALL_DIR="$HOME/.local/bin" sh
+```
+
+`CXT_VERSION` must include the leading `v`. `CXT_REPO=<owner>/<repository>` may
+be used when testing a compatible fork with the same release asset layout.
+
+## Manual archive installation
+
+If running a remote script is not acceptable, download the archive and
+checksum file from the GitHub Release page. Choose one of:
+
+```text
+cxt_darwin_arm64.tar.gz
+cxt_darwin_amd64.tar.gz
+cxt_linux_arm64.tar.gz
+cxt_linux_amd64.tar.gz
+```
+
+For example:
+
+```bash
+CXT_VERSION=v0.1.0
+CXT_ASSET=cxt_darwin_arm64.tar.gz
+CXT_RELEASE_URL="https://github.com/wnsdy95/cxthub/releases/download/$CXT_VERSION"
+CXT_TEMP_DIR="$(mktemp -d)"
+
+curl -fsSL -o "$CXT_TEMP_DIR/$CXT_ASSET" "$CXT_RELEASE_URL/$CXT_ASSET"
+curl -fsSL -o "$CXT_TEMP_DIR/checksums.txt" "$CXT_RELEASE_URL/checksums.txt"
+```
+
+Verify the archive on macOS:
+
+```bash
+cd "$CXT_TEMP_DIR"
+grep " $CXT_ASSET\$" checksums.txt | shasum -a 256 -c -
+```
+
+Or on Linux:
+
+```bash
+cd "$CXT_TEMP_DIR"
+grep " $CXT_ASSET\$" checksums.txt | sha256sum -c -
+```
+
+Only continue after verification succeeds:
+
+```bash
+tar -xzf "$CXT_ASSET"
+mkdir -p "$HOME/.local/bin"
+install -m 0755 cxt "$HOME/.local/bin/cxt"
+"$HOME/.local/bin/cxt" --version
+```
+
+Add `$HOME/.local/bin` to `PATH` if needed. The checksum protects against
+corruption or an unexpected archive; it is distributed from the same GitHub
+Release as the archive and is not a separate publisher signature.
+
+## Set up a repository
+
+Run `cxt` inside an existing Git repository. For a shared workspace, use its
+two-segment URL:
+
+```bash
+cd /path/to/code-repository
+cxt setup https://<host>/<username>/<workspace>
+```
+
+`cxt setup` is idempotent and performs:
+
+1. local `.cxt` store initialization;
+2. managed Git hook installation;
+3. workspace remote registration;
+4. browser-based login;
+5. Claude Code and Codex hook registration when available; and
+6. team settings pull when authenticated.
+
+It preserves existing provider hooks while adding the CXTHub entries. Claude
+Code settings are written under the repository's `.claude/` directory. Codex
+hooks are merged into `~/.codex/hooks.json`; Codex may require a one-time `/hooks`
+approval.
+
+To initialize local-only storage without a remote:
+
+```bash
+cxt init
+```
+
+To skip browser login during setup:
+
+```bash
+cxt setup https://<host>/<username>/<workspace> --no-login
+```
+
+See the [CLI reference](CLI.md) for manual setup and all commands.
+
+## Update or downgrade
+
+Rerun the installer without `CXT_VERSION` to install the latest stable release:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/wnsdy95/cxthub/main/distrib/install | sh
+```
+
+Rerun it with an explicit `CXT_VERSION` to upgrade, reinstall, or downgrade to
+a published version. The installer replaces only the `cxt` executable at the
+selected destination. It does not delete repository data, authentication
+files, or provider configuration.
+
+After an update:
+
+```bash
+cxt --version
+cxt --help
+```
+
+Review the release notes before moving between versions, especially while the
+project is pre-1.0.
+
+## Remove the client
+
+First locate the executable:
+
+```bash
+command -v cxt
+```
+
+Remove that exact file after inspecting the path. Common installer destinations
+are:
+
+```text
+/usr/local/bin/cxt
+$HOME/.local/bin/cxt
+```
+
+If the installer added a shell startup entry, remove the line ending with:
+
+```text
+# added by cxt install
+```
+
+Client removal does not remove:
+
+- `.cxt/` stores inside repositories;
+- `.cxtsecrets`;
+- `~/.cxt/` credentials;
+- managed Git hooks;
+- `.claude/` or `~/.codex/` provider settings; or
+- remotely synchronized context.
+
+Before uninstalling, run `cxt hooks uninstall` inside each repository where the
+managed Git hooks should be removed. Delete local data only after reviewing it
+and confirming that any required context has been backed up or synchronized.
+
+## Build from source
+
+Clone the public repository:
+
+```bash
+git clone https://github.com/wnsdy95/cxthub.git
+cd cxthub
+make build
+```
+
+This creates:
+
+```text
+bin/cxt
+bin/cxtd
+```
+
+Verify the binaries:
+
+```bash
+./bin/cxt --version
+./bin/cxt --help
+```
+
+Development builds report `cxt dev` unless a version is injected at link time.
+
+To install both Go binaries into `$(go env GOPATH)/bin`:
+
+```bash
+make install
+```
+
+To build the web application:
+
+```bash
+cd frontend/web
+npm ci
+npm run build
+```
+
+Contributor verification commands are documented in
+[CONTRIBUTING.md](../CONTRIBUTING.md).
+
+## Run `cxtd` locally
+
+The release installer does not publish or install `cxtd`. Build it from source,
+then bind development authentication only to loopback:
+
+```bash
+./bin/cxtd serve --addr 127.0.0.1:8907 --data ./cxt-data
+```
+
+Connect a test Git repository with a workspace-shaped URL:
+
+```bash
+cxt setup http://127.0.0.1:8907/<username>/<workspace> --no-login
+```
+
+Development authentication and the filesystem store are for trusted local
+testing. `cxtd` refuses an externally bound development-auth server unless the
+operator explicitly opts in. Internet-facing installations require production
+authentication, TLS, PostgreSQL, backups, rate limits, monitoring, and managed
+secrets. See [SECURITY.md](../SECURITY.md).
+
+## Non-interactive environments
+
+The CLI recognizes these environment variables:
+
+| Variable | Purpose |
+|---|---|
+| `CXT_REMOTE` | API base fallback when no repository `origin` is configured |
+| `CXT_TOKEN` | Non-interactive authentication token; takes precedence over stored credentials |
+| `CXT_NAME`, `CXT_EMAIL`, `CXT_TEAM` | Snapshot author identity overrides |
+| `CXT_NO_BROWSER=1` | Do not attempt to open a browser during device login |
+| `CXT_SECRETS_PASSPHRASE` | Passphrase fallback for `cxt secrets push|pull` |
+
+Do not print tokens or passphrases in CI logs. Prefer a secret manager and the
+smallest repository-scoped permissions available.
+
+## Troubleshooting
+
+### `cxt: command not found`
+
+Open a new shell after installation, source the startup file named by the
+installer, or add the installation directory to `PATH`.
+
+### Workspace URL rejected
+
+Use an HTTP or HTTPS URL with exactly two path segments:
+
+```text
+https://<host>/<username>/<workspace>
+```
+
+Credentials, query strings, fragments, one-segment paths, and three-segment
+paths are rejected.
+
+### No active session to snapshot
+
+Run Claude Code or Codex from the same Git working tree before invoking a
+manual capture. `cxt` isolates sessions by repository path.
+
+### Login cannot open a browser
+
+Run with `CXT_NO_BROWSER=1` to print the approval URL, or use the manual token
+fallback:
+
+```bash
+cxt login <token>
+```
+
+Prefer the browser device flow because a token supplied as a command argument
+may remain in shell history.
+
+### `cxtd` refuses to bind
+
+Development authentication is intentionally restricted to loopback. Use
+`127.0.0.1` for local testing or configure production authentication before
+binding to an external interface.

--- a/scripts/public-preflight.sh
+++ b/scripts/public-preflight.sh
@@ -14,7 +14,8 @@ esac
 required=(
   LICENSE NOTICE THIRD_PARTY_NOTICES.md README.md
   SECURITY.md CONTRIBUTING.md CODE_OF_CONDUCT.md GOVERNANCE.md SUPPORT.md
-  TRADEMARKS.md CHANGELOG.md docs/BRANCHING.md docs/RELEASING.md
+  TRADEMARKS.md CHANGELOG.md docs/BRANCHING.md docs/CLI.md
+  docs/INSTALLATION.md docs/RELEASING.md
   .github/workflows/ci.yml .github/workflows/release.yml
 )
 for file in "${required[@]}"; do
@@ -45,7 +46,8 @@ do
 done
 for path in \
   frontend/web/.env.example deploy/terraform/terraform.tfvars.example \
-  frontend/web/package-lock.json deploy/terraform/.terraform.lock.hcl
+  frontend/web/package-lock.json deploy/terraform/.terraform.lock.hcl \
+  docs/BRANCHING.md docs/CLI.md docs/INSTALLATION.md docs/RELEASING.md
 do
   if git check-ignore -q --no-index "$path"; then
     echo "[public-check] reproducible source file is incorrectly ignored: $path" >&2


### PR DESCRIPTION
## Summary

- add a complete installation guide covering release, pinned, manual, source, update, removal, CI, and local `cxtd` paths
- add a command-by-command `cxt` CLI reference, including restore modes, synchronization safety, MCP tools, configuration, and environment variables
- keep the README concise while linking to the canonical guides and using `cxt setup` for onboarding
- align built-in help with supported flags and the two-segment workspace URL contract
- keep private design documents ignored while explicitly allowlisting and requiring the two public guides
- add a regression test that every public command remains represented in the CLI reference

## Validation

- `make build`
- `make test`
- `make public-check-full`
- local Markdown link validation
- live latest-release installer check with checksum verification
- live pinned `v0.1.0` installer check with checksum verification
- `cxt --version` and `cxt --help` on the installed release

## Compatibility

This changes documentation and help text only. It does not change snapshot identity, persistence, synchronization, provider conversion, authentication, authorization, or migrations.

## AI assistance

Codex assisted with the documentation draft and consistency checks. The resulting commands, release assets, links, tests, and installation paths were reviewed and verified against the repository and published release.
