### PR TITLE
fix: treat unset team assets as no content

### DIFF
--- a/backend/internal/adapters/delivery/http/server.go
+++ b/backend/internal/adapters/delivery/http/server.go
@@ -515,11 +515,22 @@ func (s *Server) patchAbout(w http.ResponseWriter, r *http.Request) {
 
 // getSettings returns team default setting bundles.
 func (s *Server) getSettings(w http.ResponseWriter, r *http.Request) {
-	out, err := s.b.GetSettings(r.Context(), s.repoID(r), r.PathValue("kind"))
+	kind := r.PathValue("kind")
+	if !domain.ValidSettingsKind(kind) {
+		s.writeError(w, http.StatusNotFound, "not_found", "settings kind not found")
+		return
+	}
+	out, err := s.b.GetSettings(r.Context(), s.repoID(r), kind)
+	if errors.Is(err, domain.ErrNotFound) {
+		// These optional singleton assets are queried to render their configured/unset
+		// status. Absence is a successful state, not a failed HTTP request.
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
 	s.respond(w, out, err)
 }
 
-// putSettings uploads team default setting bundles (claude|agents folder).
+// putSettings uploads team default setting bundles (claude|agents|codex folder).
 func (s *Server) putSettings(w http.ResponseWriter, r *http.Request) {
 	if !s.requireRepoAction(w, r, "settings") {
 		return
@@ -615,6 +626,13 @@ func fingerprintOf(raw []byte) string {
 // getSecrets returns the encrypted envelope as is (decryption is on the client — E2E).
 func (s *Server) getSecrets(w http.ResponseWriter, r *http.Request) {
 	raw, err := s.b.GetSecrets(r.Context(), s.repoID(r))
+	if errors.Is(err, domain.ErrNotFound) {
+		// The web status rail probes this endpoint before a team envelope exists.
+		// Keep genuine repository/auth failures in middleware, but represent an
+		// unconfigured optional envelope without a noisy 404.
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
 	if err != nil {
 		code, status := mapError(err)
 		s.writeError(w, status, code, err.Error())

--- a/backend/internal/adapters/delivery/http/server_test.go
+++ b/backend/internal/adapters/delivery/http/server_test.go
@@ -563,6 +563,53 @@ func TestSecretsFingerprintConsistency(t *testing.T) {
 	}
 }
 
+func TestOptionalTeamAssetsReturnNoContentWhenUnset(t *testing.T) {
+	ts := newTestServer(t)
+	defer ts.Close()
+
+	var me struct {
+		Username string `json:"username"`
+	}
+	doJSON(t, http.MethodGet, ts.URL+"/api/v1/me", nil, &me)
+	var ws struct {
+		Slug string `json:"slug"`
+	}
+	doJSON(t, http.MethodPost, ts.URL+"/api/v1/workspaces", map[string]any{"name": "Optional"}, &ws)
+	remoteURL := "http://cxthub.test/" + me.Username + "/" + ws.Slug
+	rid := repoIDForRemoteURLForTest(remoteURL)
+	if code := doJSON(t, http.MethodPost, ts.URL+"/api/v1/repos", map[string]any{
+		"id": rid, "remote_url": remoteURL, "default_branch": "main",
+	}, nil); code != http.StatusOK {
+		t.Fatalf("repo create code %d", code)
+	}
+
+	base := ts.URL + "/api/v1/repos/" + url.PathEscape(string(rid))
+	for _, path := range []string{
+		"/settings/claude",
+		"/settings/agents",
+		"/settings/codex",
+		"/secrets",
+	} {
+		if code := doJSON(t, http.MethodGet, base+path, nil, nil); code != http.StatusNoContent {
+			t.Errorf("GET %s = %d, want 204", path, code)
+		}
+	}
+	if code := doJSON(t, http.MethodGet, base+"/settings/unknown", nil, nil); code != http.StatusNotFound {
+		t.Errorf("unknown settings kind = %d, want 404", code)
+	}
+
+	if code := doJSON(t, http.MethodPut, base+"/settings/claude", map[string]any{"files": []any{}}, nil); code != http.StatusOK {
+		t.Fatalf("configure claude settings = %d, want 200", code)
+	}
+	var configured domain.SettingsBundle
+	if code := doJSON(t, http.MethodGet, base+"/settings/claude", nil, &configured); code != http.StatusOK {
+		t.Fatalf("configured claude settings GET = %d, want 200", code)
+	}
+	if configured.Kind != "claude" || configured.Files == nil {
+		t.Errorf("configured bundle = %+v", configured)
+	}
+}
+
 // TestContentTypeGuard: status change body must be application/json — empty/incorrect Content-Type is 415
 // (CSRF 2nd defense regardless of SameSite setting). Correct CT passes.
 func TestContentTypeGuard(t *testing.T) {

--- a/backend/internal/adapters/store/fs_store.go
+++ b/backend/internal/adapters/store/fs_store.go
@@ -316,7 +316,7 @@ func (s *FSStore) UpdateRepoConfig(ctx context.Context, id domain.ContentHash, d
 	return writeAtomic(filepath.Join(s.repoDir(id), "repo.json"), data)
 }
 
-// PutSettingsBundle stores the team default settings bundle (.claude/.agents).
+// PutSettingsBundle stores the team default settings bundle (.claude/.agents/.codex).
 func (s *FSStore) PutSettingsBundle(_ context.Context, repoID domain.ContentHash, bundle domain.SettingsBundle) error {
 	if err := validateHash(repoID); err != nil {
 		return err

--- a/backend/internal/domain/entities.go
+++ b/backend/internal/domain/entities.go
@@ -41,9 +41,11 @@ type SettingsFile struct {
 	ContentB64 string `json:"content_b64"`
 }
 
-// SettingsBundle is the team default agent settings for the repo (.claude/.agents folder).
-// Upload folder (claude|agents) via web, team members receive via cxt and overwrite local .claude/.agents.
-// Kind ∈ {claude, agents}.
+// SettingsBundle is the team default agent settings for the repo
+// (.claude/.agents/.codex folder).
+// Upload folder (claude|agents|codex) via web; team members receive it via cxt
+// and overwrite the matching local directory.
+// Kind ∈ {claude, agents, codex}.
 type SettingsBundle struct {
 	Kind      string         `json:"kind"`
 	Files     []SettingsFile `json:"files"`

--- a/backend/internal/domain/identity.go
+++ b/backend/internal/domain/identity.go
@@ -132,7 +132,8 @@ type Workspace struct {
 	// ""|"members"(role-based = maintainer and above, default) | "owner"(only owner).
 	// User-level segmentation is handled by a 5-tier role ladder (specified lists are removed upon role introduction).
 	SecretsPolicy string `json:"secrets_policy,omitempty"`
-	// SettingsPolicy is the upload permission for team default settings (.claude/.agents): the value meaning is the same as SecretsPolicy.
+	// SettingsPolicy is the upload permission for team default settings
+	// (.claude/.agents/.codex): the value meaning is the same as SecretsPolicy.
 	SettingsPolicy string `json:"settings_policy,omitempty"`
 	// GHVisibilitySync, when enabled, derives the visibility from the GitHub repo status (manual toggle lock).
 	// Rule: Public if the linked GitHub repo has 1 or more and all are public (conservative —

--- a/backend/internal/ports/outbound/outbound.go
+++ b/backend/internal/ports/outbound/outbound.go
@@ -54,7 +54,7 @@ type MetadataStore interface {
 	UpdateRepoAbout(ctx context.Context, id domain.ContentHash, description, website string, topics []string) error
 	// UpdateRepoConfig updates repo structure settings (default branch, protected branch). nil = no change.
 	UpdateRepoConfig(ctx context.Context, id domain.ContentHash, defaultBranch *string, protectDefault *bool) error
-	// Team default settings bundle (.claude/.agents) — kind ∈ {claude, agents}.
+	// Team default settings bundle (.claude/.agents/.codex) — kind ∈ {claude, agents, codex}.
 	PutSettingsBundle(ctx context.Context, repoID domain.ContentHash, bundle domain.SettingsBundle) error
 	GetSettingsBundle(ctx context.Context, repoID domain.ContentHash, kind string) (domain.SettingsBundle, error)
 	// Secret ciphertext envelope (E2E — server cannot decrypt, stored as opaque bytes only).

--- a/cli/internal/adapters/backendclient/backend_client.go
+++ b/cli/internal/adapters/backendclient/backend_client.go
@@ -157,6 +157,16 @@ func (c *BackendClient) doLimited(ctx context.Context, method, path string, body
 		b, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 		return newHTTPError(resp.StatusCode, method, path, b)
 	}
+	if resp.StatusCode == http.StatusNoContent {
+		// Optional singleton assets (team settings and the sealed secrets
+		// envelope) use 204 for "not configured". Preserve the CLI's existing
+		// domain-level absence behavior while keeping browser probes out of the
+		// failed-request path.
+		if out != nil {
+			return domain.ErrNotFound
+		}
+		return nil
+	}
 	if out != nil {
 		if max > 0 {
 			b, err := io.ReadAll(io.LimitReader(resp.Body, max+1))

--- a/cli/internal/adapters/backendclient/backend_client_test.go
+++ b/cli/internal/adapters/backendclient/backend_client_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -12,6 +13,22 @@ import (
 	"github.com/wnsdy95/cxthub/cli/internal/adapters/chunkcas"
 	"github.com/wnsdy95/cxthub/cli/internal/domain"
 )
+
+func TestOptionalAssetNoContentMapsToNotFound(t *testing.T) {
+	repo := string(domain.HashContent([]byte("repo")))
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer ts.Close()
+
+	c := NewBackendClient(func() string { return ts.URL }, func() string { return "" }, domain.TeamIdentity{})
+	if _, err := c.PullSettings(context.Background(), repo, "claude"); !errors.Is(err, domain.ErrNotFound) {
+		t.Fatalf("PullSettings 204 error = %v, want ErrNotFound", err)
+	}
+	if _, err := c.PullSecrets(context.Background(), repo); !errors.Is(err, domain.ErrNotFound) {
+		t.Fatalf("PullSecrets 204 error = %v, want ErrNotFound", err)
+	}
+}
 
 func TestSnapshotForCreateStripsServerOwnedGraftMetadata(t *testing.T) {
 	id := domain.HashContent([]byte("snapshot"))

--- a/cli/internal/adapters/capture/settings_dir.go
+++ b/cli/internal/adapters/capture/settings_dir.go
@@ -11,7 +11,8 @@ import (
 	"github.com/wnsdy95/cxthub/cli/internal/domain"
 )
 
-// ReadSettingsDir reads the SettingsBundle from the repoRoot/.{kind}(claude|agents) folder.
+// ReadSettingsDir reads the SettingsBundle from the
+// repoRoot/.{kind}(claude|agents|codex) folder.
 // It records the agent settings state at the commit point content-addressed.
 // Determinism: path sorting. Safety: hidden subdirectories (.git etc.) and truncation at 2MB (bundle, false).
 func ReadSettingsDir(repoRoot, kind string) (domain.SettingsBundle, bool) {

--- a/cli/internal/adapters/delivery/cli/root.go
+++ b/cli/internal/adapters/delivery/cli/root.go
@@ -1064,7 +1064,7 @@ func shortHash(h domain.ContentHash) string {
 	return hexPart
 }
 
-// applySettings applies server setting bundles (kind ∈ claude|agents) to
+// applySettings applies server setting bundles (kind ∈ claude|agents|codex) to
 // the repo root .claude/ or .agents/ directory (includes path traversal defense).
 func applySettings(ctx context.Context, c *Container, cwd, repoID, kind string) (int, error) {
 	bundle, err := c.Settings.PullSettings(ctx, repoID, kind)

--- a/cli/internal/domain/entities.go
+++ b/cli/internal/domain/entities.go
@@ -288,7 +288,8 @@ type Pending struct {
 	Dismissed bool `json:"dismissed,omitempty"`
 }
 
-// SettingsFile / SettingsBundle — Server team default settings bundle (.claude/.agents) mirror type.
+// SettingsFile / SettingsBundle — server team default settings bundle
+// (.claude/.agents/.codex) mirror type.
 // cxt settings pull updates the local folder with the received settings.
 type SettingsFile struct {
 	Path       string `json:"path"`

--- a/cli/internal/ports/outbound/ports.go
+++ b/cli/internal/ports/outbound/ports.go
@@ -174,7 +174,8 @@ type RemoteSync interface {
 	PushMemory(ctx context.Context, repoID string, digest domain.MemoryDigest) error
 	// PullMemory downloads the MemoryDigest from the snapshot. Returns ErrNotFound if not found.
 	PullMemory(ctx context.Context, repoID string, snapshotID domain.ContentHash) (domain.MemoryDigest, error)
-	// PullSettings downloads the team default settings bundle (claude|agents). Returns ErrNotFound if not found.
+	// PullSettings downloads the team default settings bundle
+	// (claude|agents|codex). Returns ErrNotFound if not found.
 	PullSettings(ctx context.Context, repoID, kind string) (domain.SettingsBundle, error)
 	// Secret ciphertext envelope (E2E — raw bytes, server opaque). rotate=true performs an explicit replacement — protects updates inserted during CAS (conditional assignment) based on the envelope's fingerprint read during replacement.
 	PushSecrets(ctx context.Context, repoID string, raw []byte, rotate bool, expect string) error

--- a/frontend/web/src/api.ts
+++ b/frontend/web/src/api.ts
@@ -118,7 +118,7 @@ export const api = {
   ) =>
     call<Repo>('PATCH', `/repos/${encodeURIComponent(repoId)}/about`, about),
   getSettings: (repoId: string, kind: 'claude' | 'agents' | 'codex') =>
-    call<{ kind: string; files: { path: string; content_b64: string }[]; updated_at: string; updated_by?: string }>(
+    call<{ kind: string; files: { path: string; content_b64: string }[]; updated_at: string; updated_by?: string } | null>(
       'GET',
       `/repos/${encodeURIComponent(repoId)}/settings/${kind}`,
     ),
@@ -131,7 +131,8 @@ export const api = {
       `/repos/${encodeURIComponent(repoId)}/secrets${rotate ? `?rotate=true&expect=${encodeURIComponent(expect)}` : ''}`,
       envelope,
     ),
-  getSecrets: (repoId: string) => call<import('./secretscrypto').SecretsEnvelope>('GET', `/repos/${encodeURIComponent(repoId)}/secrets`),
+  getSecrets: (repoId: string) =>
+    call<import('./secretscrypto').SecretsEnvelope | null>('GET', `/repos/${encodeURIComponent(repoId)}/secrets`),
   getMemory: (repoId: string, snapshotId: string) =>
     call<MemoryDigest>('GET', `/repos/${encodeURIComponent(repoId)}/memories/${encodeURIComponent(snapshotId)}`),
   listPending: (repoId: string) => call<Pending[]>('GET', `/repos/${encodeURIComponent(repoId)}/pending`),

--- a/frontend/web/src/components/About.tsx
+++ b/frontend/web/src/components/About.tsx
@@ -351,6 +351,12 @@ export function SecretsPanel({ repoId, canWrite }: { repoId: string; canWrite: b
   const envelope = useSecretsEnvelope(repoId);
   const qc = useQueryClient();
 
+  async function requireEnvelope() {
+    const env = await api.getSecrets(repoId);
+    if (!env) throw new Error(t('secrets.notConfigured'));
+    return env;
+  }
+
   async function save() {
     if (!pass || !lines.trim()) {
       setOpen(true);
@@ -398,7 +404,7 @@ export function SecretsPanel({ repoId, canWrite }: { repoId: string; canWrite: b
     setBusy(true);
     setMsg(null);
     try {
-      const cur = await api.getSecrets(repoId);
+      const cur = await requireEnvelope();
       const plain = await decryptSecrets(pass, cur, repoId, t); // decrypts with current passphrase (throws if incorrect)
       const env = await encryptSecrets(newPass, plain, repoId); // re-encrypts with new passphrase
       await api.putSecrets(repoId, env, true, cur.fingerprint ?? ''); // rotate CAS — based envelope fingerprint
@@ -423,7 +429,7 @@ export function SecretsPanel({ repoId, canWrite }: { repoId: string; canWrite: b
     setBusy(true);
     setMsg(null);
     try {
-      const env = await api.getSecrets(repoId);
+      const env = await requireEnvelope();
       setLines(await decryptSecrets(pass, env, repoId, t));
       setOpen(true); // decryption result confirmed and editable in modal
       setMsg(t('about.decrypted') + (env.updated_at ? ` (${env.updated_at.slice(0, 10)})` : ''));
@@ -445,7 +451,7 @@ export function SecretsPanel({ repoId, canWrite }: { repoId: string; canWrite: b
     setBusy(true);
     setMsg(null);
     try {
-      const env = await api.getSecrets(repoId);
+      const env = await requireEnvelope();
       const text = await decryptSecrets(pass, env, repoId, t);
       if (window.showDirectoryPicker) {
         const dir = await window.showDirectoryPicker({ mode: 'readwrite' });

--- a/frontend/web/src/hooks.ts
+++ b/frontend/web/src/hooks.ts
@@ -422,7 +422,7 @@ export function useSettingsBundle(repoId: string | null, kind: 'claude' | 'agent
     queryKey: ['settings', repoId, kind],
     queryFn: () => api.getSettings(repoId as string, kind),
     enabled: enabled && Boolean(repoId),
-    retry: false, // 404 = unset (normal)
+    retry: false, // 204/null = unset (normal)
   });
 }
 // Secret envelope metadata (ciphertext — server storage status and update timestamp. Decryption is only by user passphrase).
@@ -431,7 +431,7 @@ export function useSecretsEnvelope(repoId: string | null) {
     queryKey: ['secrets', repoId],
     queryFn: () => api.getSecrets(repoId as string),
     enabled: Boolean(repoId),
-    retry: false, // 404 = unset (normal)
+    retry: false, // 204/null = unset (normal)
   });
 }
 export function usePutSettings() {

--- a/frontend/web/src/i18n/locales/en.ts
+++ b/frontend/web/src/i18n/locales/en.ts
@@ -162,6 +162,7 @@ export const en: Messages = {
   },
   secrets: {
     envUnsupported: 'Unsupported envelope format',
+    notConfigured: 'No team secrets are configured yet',
     kdfLow: 'KDF iteration count is abnormally low',
     decryptFail: 'Decryption failed — wrong passphrase or tampered data',
     passInvalid: 'Team passphrase must be 4+ English words and 12+ chars (e.g. harbor twist ledger cousin)',

--- a/frontend/web/src/i18n/locales/ko.ts
+++ b/frontend/web/src/i18n/locales/ko.ts
@@ -165,6 +165,7 @@ export const ko = {
   },
   secrets: {
     envUnsupported: '지원하지 않는 봉투 형식',
+    notConfigured: '아직 팀 시크릿이 설정되지 않았습니다',
     kdfLow: 'KDF 반복 횟수가 비정상적으로 낮음',
     decryptFail: '복호화 실패 — 패스프레이즈가 다르거나 데이터가 변조됨',
     passInvalid: '팀 패스프레이즈는 영단어 4개 이상·12자 이상이어야 합니다 (예: harbor twist ledger cousin)',

--- a/frontend/web/src/zip.ts
+++ b/frontend/web/src/zip.ts
@@ -1,5 +1,6 @@
 // zip.ts — Minimal ZIP generator (STORE, no compression, dependency-free).
-// Download button for team default settings bundle (.claude/.agents) preserves folder structure.
+// Download button for team default settings bundle
+// (.claude/.agents/.codex) preserves folder structure.
 // Sufficient for small files and text-heavy content (format: PKWARE APPNOTE 4.3).
 
 const CRC_TABLE = (() => {

--- a/schemas/openapi.yaml
+++ b/schemas/openapi.yaml
@@ -1666,7 +1666,7 @@ paths:
       - name: kind
         in: path
         required: true
-        schema: { type: string, enum: [claude, agents] }
+        schema: { type: string, enum: [claude, agents, codex] }
     get:
       operationId: getSettings
       summary: Team basic settings bundle retrieval — puller and above
@@ -1677,6 +1677,7 @@ paths:
           content:
             application/json:
               schema: { $ref: "#/components/schemas/SettingsBundle" }
+        "204": { description: "Team settings of this kind are not configured" }
         "404": { $ref: "#/components/responses/NotFound" }
     put:
       operationId: putSettings
@@ -1935,6 +1936,7 @@ paths:
           content:
             application/json:
               schema: { $ref: "#/components/schemas/SecretsEnvelope" }
+        "204": { description: "Team secrets are not configured" }
         "404": { $ref: "#/components/responses/NotFound" }
     put:
       operationId: putSecrets

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -176,9 +176,9 @@ mrow() { # mrow <jar|-> → "read pull push secretsPUT"
 }
 expect "anonymous 401/401/401/401" "$(mrow -)" "401 401 401 401"
 expect "viewer 200/403/403/403" "$(mrow "$JV")" "200 403 403 403"
-expect "puller 200/404/403/403" "$(mrow "$JP")" "200 404 403 403"
-expect "member 200/404/200/403" "$(mrow "$JM")" "200 404 200 403"
-expect "maint. 200/404/200/200" "$(mrow "$JT")" "200 404 200 200"
+expect "puller 200/204/403/403" "$(mrow "$JP")" "200 204 403 403"
+expect "member 200/204/200/403" "$(mrow "$JM")" "200 204 200 403"
+expect "maint. 200/204/200/200" "$(mrow "$JT")" "200 204 200 200"
 expect "policy owner narrowed → maintainer 403" "$(ccurl -sb "$JA" -o /dev/null -w '' -X PATCH "$B/workspaces/$WS" -H 'Content-Type: application/json' -d '{"secrets_policy":"owner"}')$(ccode -b "$JT" -X PUT "$RB/secrets" -H 'Content-Type: application/json' -d "$ENVL")" 403
 ccurl -sb "$JA" -X PATCH "$B/workspaces/$WS" -H 'Content-Type: application/json' -d '{"secrets_policy":"members"}' >/dev/null
 


### PR DESCRIPTION
## Summary

- return 204 No Content when optional team settings or secrets have not been configured
- preserve 404 for invalid settings kinds and map 204 back to the CLI domain absence result
- make the web API nullable so normal unset state no longer appears as failed browser requests
- include codex in the documented settings-kind contract and align related comments

## Validation

- backend tests, including PostgreSQL-tagged build/tests
- CLI tests
- web i18n check and production build
- real installed cxtd verification: all four unset asset endpoints return 204 with an empty body
- full public tree and Git history secret scan