### PR TITLE
fix(codec): tolerate Codex tool search records

### DIFF
--- a/cli/internal/adapters/codec/codec_test.go
+++ b/cli/internal/adapters/codec/codec_test.go
@@ -109,6 +109,94 @@ func TestCodexMultiModel(t *testing.T) {
 	}
 }
 
+// TestCodexToolSearchItemsAreAuxiliary fixes compatibility with Codex rollouts that include
+// tool_search_call arguments as an object and tool_search_output tool-schema arrays. These are
+// control-plane discovery records, not conversation events, so they must neither fail decoding
+// nor inflate the persisted CIR document.
+func TestCodexToolSearchItemsAreAuxiliary(t *testing.T) {
+	withToolSearch := `{"timestamp":"2026-07-29T00:00:00Z","type":"session_meta","payload":{"id":"roll-tool-search","cwd":"/work/proj","model":"gpt-5.5-codex"}}
+{"timestamp":"2026-07-29T00:00:01Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"review this"}]}}
+{"timestamp":"2026-07-29T00:00:02Z","type":"response_item","payload":{"type":"tool_search_call","call_id":"search-1","status":"completed","arguments":{"query":"code review","limit":3},"execution":"client"}}
+{"timestamp":"2026-07-29T00:00:03Z","type":"response_item","payload":{"type":"tool_search_output","call_id":"search-1","status":"completed","tools":[{"name":"review","description":"Review code","input_schema":{"type":"object"}}],"execution":"client"}}
+{"timestamp":"2026-07-29T00:00:04Z","type":"response_item","payload":{"type":"function_call","name":"shell","arguments":"{\"command\":\"go test ./...\"}","call_id":"call-1"}}
+{"timestamp":"2026-07-29T00:00:05Z","type":"response_item","payload":{"type":"function_call_output","call_id":"call-1","output":"ok"}}
+{"timestamp":"2026-07-29T00:00:06Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"done"}]}}`
+	withoutToolSearch := `{"timestamp":"2026-07-29T00:00:00Z","type":"session_meta","payload":{"id":"roll-tool-search","cwd":"/work/proj","model":"gpt-5.5-codex"}}
+{"timestamp":"2026-07-29T00:00:01Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"review this"}]}}
+{"timestamp":"2026-07-29T00:00:04Z","type":"response_item","payload":{"type":"function_call","name":"shell","arguments":"{\"command\":\"go test ./...\"}","call_id":"call-1"}}
+{"timestamp":"2026-07-29T00:00:05Z","type":"response_item","payload":{"type":"function_call_output","call_id":"call-1","output":"ok"}}
+{"timestamp":"2026-07-29T00:00:06Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"done"}]}}`
+
+	got, err := NewCodexCodec().Decode(context.Background(), []byte(withToolSearch))
+	if err != nil {
+		t.Fatalf("decode rollout with tool search items: %v", err)
+	}
+	want, err := NewCodexCodec().Decode(context.Background(), []byte(withoutToolSearch))
+	if err != nil {
+		t.Fatalf("decode baseline rollout: %v", err)
+	}
+	if mustJSON(t, got) != mustJSON(t, want) {
+		t.Fatalf("tool search control records must not affect CIR\ngot=%s\nwant=%s", mustJSON(t, got), mustJSON(t, want))
+	}
+}
+
+// TestCodexFunctionCallObjectArguments verifies that a future/alternate Codex function_call
+// object form remains readable while materialization emits the conventional JSON string form.
+func TestCodexFunctionCallObjectArguments(t *testing.T) {
+	fixture := `{"timestamp":"2026-07-29T00:00:00Z","type":"session_meta","payload":{"id":"roll-object-args","cwd":"/work/proj","model":"gpt-5.5-codex"}}
+{"timestamp":"2026-07-29T00:00:01Z","type":"response_item","payload":{"type":"function_call","name":"tool_search","arguments":{"query":"code review","limit":3},"call_id":"call-1"}}`
+
+	codec := NewCodexCodec()
+	cir, err := codec.Decode(context.Background(), []byte(fixture))
+	if err != nil {
+		t.Fatalf("decode object arguments: %v", err)
+	}
+	if len(cir.Events) != 1 {
+		t.Fatalf("expected one tool call, got %d", len(cir.Events))
+	}
+	wantInput := map[string]interface{}{"query": "code review", "limit": float64(3)}
+	if mustJSON(t, cir.Events[0].Input) != mustJSON(t, wantInput) {
+		t.Fatalf("unexpected tool input: %#v", cir.Events[0].Input)
+	}
+
+	out, err := codec.Encode(context.Background(), cir, domain.ProviderCodex)
+	if err != nil {
+		t.Fatalf("encode object arguments: %v", err)
+	}
+	found := false
+	for _, rawLine := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		var line struct {
+			Type    string                 `json:"type"`
+			Payload map[string]interface{} `json:"payload"`
+		}
+		if err := json.Unmarshal([]byte(rawLine), &line); err != nil {
+			t.Fatalf("decode encoded line: %v", err)
+		}
+		if line.Type != "response_item" || line.Payload["type"] != "function_call" {
+			continue
+		}
+		found = true
+		args, ok := line.Payload["arguments"].(string)
+		if !ok {
+			t.Fatalf("encoded function_call.arguments must be a JSON string, got %#v", line.Payload["arguments"])
+		}
+		if mustJSON(t, parseToolInput(args)) != mustJSON(t, wantInput) {
+			t.Fatalf("encoded function_call.arguments changed meaning: %q", args)
+		}
+	}
+	if !found {
+		t.Fatal("encoded function_call not found")
+	}
+
+	roundTrip, err := codec.Decode(context.Background(), out)
+	if err != nil {
+		t.Fatalf("decode encoded object arguments: %v", err)
+	}
+	if len(roundTrip.Events) != 1 || mustJSON(t, roundTrip.Events[0].Input) != mustJSON(t, wantInput) {
+		t.Fatalf("object arguments round trip changed meaning: %#v", roundTrip.Events)
+	}
+}
+
 func mustJSON(t *testing.T, v interface{}) string {
 	t.Helper()
 	b, err := json.Marshal(v)

--- a/cli/internal/adapters/codec/codex_codec.go
+++ b/cli/internal/adapters/codec/codex_codec.go
@@ -16,7 +16,7 @@ import (
 //
 // Decode mapping (response_item.payload → CIR event):
 //   - message{role,content:[{input_text|output_text,text}]} → message(role, blocks:[{text}...])
-//   - function_call{name,arguments(JSON string),call_id}     → tool_call(call_id, provider_tool_name:name, input:parse(arguments))
+//   - function_call{name,arguments(JSON string|object),call_id} → tool_call(call_id, provider_tool_name:name, input:parse(arguments))
 //   - function_call_output{call_id,output}                   → tool_result
 //   - custom_tool_call{status,call_id,name,input(string)}    → tool_call(status, input:parse(input))
 //   - custom_tool_call_output{call_id,output}                → tool_result
@@ -117,7 +117,7 @@ type codexResponseItem struct {
 	Role             string          `json:"role,omitempty"`
 	Content          []codexContent  `json:"content,omitempty"`
 	Name             string          `json:"name,omitempty"`
-	Arguments        string          `json:"arguments,omitempty"`
+	Arguments        json.RawMessage `json:"arguments,omitempty"`
 	CallID           string          `json:"call_id,omitempty"`
 	Output           json.RawMessage `json:"output,omitempty"`
 	Input            string          `json:"input,omitempty"`
@@ -125,6 +125,10 @@ type codexResponseItem struct {
 	EncryptedContent string          `json:"encrypted_content,omitempty"`
 	Summary          []interface{}   `json:"summary,omitempty"`
 	Action           *codexAction    `json:"action,omitempty"`
+}
+
+type codexResponseItemHeader struct {
+	Type string `json:"type"`
 }
 
 // Decode converts Codex rollout JSONL bytes to CIRDocument.
@@ -175,6 +179,19 @@ func (c *CodexCodec) Decode(_ context.Context, raw []byte) (domain.CIRDocument, 
 				}
 			}
 		case "response_item":
+			// Codex also emits control-plane response items such as tool_search_call,
+			// tool_search_output, and image_generation_call. Their payloads use schemas
+			// that intentionally differ from conversation tool calls (for example,
+			// tool_search_call.arguments is an object and tool_search_output contains
+			// repeated tool schemas). Discriminate first so auxiliary records cannot
+			// break decoding or bloat persisted CIR documents.
+			var header codexResponseItemHeader
+			if err := json.Unmarshal(ln.Payload, &header); err != nil {
+				return domain.CIRDocument{}, fmt.Errorf("codex decode response_item header: %w", err)
+			}
+			if !isCodexConversationItem(header.Type) {
+				continue
+			}
 			var it codexResponseItem
 			if err := json.Unmarshal(ln.Payload, &it); err != nil {
 				return domain.CIRDocument{}, fmt.Errorf("codex decode response_item: %w", err)
@@ -210,6 +227,21 @@ func (c *CodexCodec) Decode(_ context.Context, raw []byte) (domain.CIRDocument, 
 	return doc, nil
 }
 
+func isCodexConversationItem(itemType string) bool {
+	switch itemType {
+	case "message",
+		"function_call",
+		"custom_tool_call",
+		"function_call_output",
+		"custom_tool_call_output",
+		"web_search_call",
+		"reasoning":
+		return true
+	default:
+		return false
+	}
+}
+
 func codexItemToEvent(it codexResponseItem, ts string) (domain.Event, bool) {
 	ev := domain.Event{Ts: ts}
 	switch it.Type {
@@ -228,17 +260,21 @@ func codexItemToEvent(it codexResponseItem, ts string) (domain.Event, bool) {
 		}
 		ev.Blocks = blocks
 		return ev, true
-	case "function_call", "custom_tool_call":
+	case "function_call":
 		ev.Kind = domain.EventToolCall
 		ev.CallID = it.CallID
 		ev.ProviderToolName = it.Name
 		ev.ToolName = canonicalToolName(it.Name)
 		ev.Status = it.Status
-		args := it.Arguments
-		if args == "" {
-			args = it.Input
-		}
-		ev.Input = parseToolInput(args)
+		ev.Input = parseCodexFunctionArguments(it.Arguments)
+		return ev, true
+	case "custom_tool_call":
+		ev.Kind = domain.EventToolCall
+		ev.CallID = it.CallID
+		ev.ProviderToolName = it.Name
+		ev.ToolName = canonicalToolName(it.Name)
+		ev.Status = it.Status
+		ev.Input = parseToolInput(it.Input)
 		return ev, true
 	case "function_call_output", "custom_tool_call_output":
 		ev.Kind = domain.EventToolResult
@@ -269,6 +305,27 @@ func codexItemToEvent(it codexResponseItem, ts string) (domain.Event, bool) {
 	default:
 		return domain.Event{}, false
 	}
+}
+
+// parseCodexFunctionArguments accepts the conventional JSON-encoded string and
+// the object form observed in newer response item variants. Non-object values
+// remain lossless through CIR's _raw escape hatch.
+func parseCodexFunctionArguments(raw json.RawMessage) map[string]interface{} {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return map[string]interface{}{}
+	}
+
+	var text string
+	if err := json.Unmarshal(trimmed, &text); err == nil {
+		return parseToolInput(text)
+	}
+
+	var object map[string]interface{}
+	if err := json.Unmarshal(trimmed, &object); err == nil && object != nil {
+		return object
+	}
+	return map[string]interface{}{"_raw": string(trimmed)}
 }
 
 // Encode converts CIRDocument to target provider JSONL bytes.
@@ -327,7 +384,7 @@ func (c *CodexCodec) Encode(_ context.Context, doc domain.CIRDocument, _ domain.
 			it.Type = "function_call"
 			it.Name = name
 			it.CallID = ev.CallID
-			it.Arguments = marshalToolInput(ev.Input)
+			it.Arguments, _ = json.Marshal(marshalToolInput(ev.Input))
 			it.Status = ev.Status
 		case domain.EventToolResult:
 			it.Type = "function_call_output"


### PR DESCRIPTION
## Summary

- ignore Codex tool-search control-plane response items before strict conversation decoding
- accept both JSON-string and object forms for real function-call arguments
- keep Codex materialization on the conventional JSON-string wire format
- add regressions for auxiliary tool-search records and object arguments

## Verification

- `go build ./...`
- `go vet ./...`
- `go test ./...`
- `go test -race ./internal/adapters/codec`
- decoded both local rollouts containing `tool_search_call`
- `bash scripts/public-preflight.sh tree`