### PR TITLE
fix(cli): rebind restored sessions to target cwd

### DIFF
--- a/cli/internal/app/branch_seed.go
+++ b/cli/internal/app/branch_seed.go
@@ -117,6 +117,13 @@ func (s *BranchSeedService) Seed(ctx context.Context, in inbound.SeedInput) (inb
 	}
 	cir := domain.CIRDocument{Events: events}
 	cir.Envelope = fromDoc.CIR.Envelope // Inherit model, cwd, etc.
+	targetCwd := in.Cwd
+	if targetCwd == "" {
+		targetCwd = repo.LocalPath
+	}
+	if targetCwd = materializationCwd(targetCwd); targetCwd != "" {
+		cir.Envelope.Cwd = targetCwd
+	}
 	cir.Envelope.GitBranch = in.NewBranch
 	cir.Envelope.SessionOriginID = seedSession
 	cir.Envelope.CapturedAt = now

--- a/cli/internal/app/branch_seed_cwd_test.go
+++ b/cli/internal/app/branch_seed_cwd_test.go
@@ -1,0 +1,95 @@
+package app
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/wnsdy95/cxthub/cli/internal/adapters/memory"
+	"github.com/wnsdy95/cxthub/cli/internal/adapters/storage"
+	"github.com/wnsdy95/cxthub/cli/internal/domain"
+	"github.com/wnsdy95/cxthub/cli/internal/ports/inbound"
+)
+
+type branchSeedGit struct {
+	repo domain.Repo
+}
+
+func (g branchSeedGit) CurrentRepo(context.Context, string) (domain.Repo, error) {
+	return g.repo, nil
+}
+
+func (g branchSeedGit) CurrentBranch(context.Context, string) (string, error) {
+	return "main", nil
+}
+
+func TestBranchSeedUsesTargetWorkingDirectory(t *testing.T) {
+	ctx := context.Background()
+	store := storage.NewFileStore(t.TempDir())
+	targetCwd := t.TempDir()
+	repo := domain.Repo{
+		ID:            "repo-1",
+		LocalPath:     targetCwd,
+		DefaultBranch: "main",
+	}
+	source := domain.CIRDocument{
+		Envelope: domain.Envelope{
+			CIRVersion:      "1",
+			SourceProvider:  domain.ProviderCodex,
+			SessionOriginID: "source-session",
+			Cwd:             "/old/repository/path",
+			GitBranch:       "main",
+			Fidelity:        domain.FidelityFull,
+		},
+		Events: []domain.Event{{
+			Seq:    0,
+			Kind:   domain.EventMessage,
+			Role:   "user",
+			Ts:     time.Now().UTC().Format(time.RFC3339),
+			Blocks: []domain.ContentBlock{{Type: "text", Text: "continue"}},
+		}},
+	}
+	head, err := store.PutDoc(ctx, domain.SessionDoc{CIR: source})
+	if err != nil {
+		t.Fatalf("put source doc: %v", err)
+	}
+	if err := store.PutSnapshot(ctx, domain.Snapshot{
+		ID:       head,
+		RepoID:   repo.ID,
+		Branch:   "main",
+		DocHash:  head,
+		Provider: domain.ProviderCodex,
+		Fidelity: domain.FidelityFull,
+	}); err != nil {
+		t.Fatalf("put source snapshot: %v", err)
+	}
+	if err := store.PutRef(ctx, domain.Ref{
+		Kind: domain.RefBranch, Name: "main", RepoID: repo.ID, Target: head,
+	}); err != nil {
+		t.Fatalf("put source ref: %v", err)
+	}
+
+	service := NewBranchSeedService(
+		branchSeedGit{repo: repo},
+		store,
+		memory.NewRuleDistiller(),
+		nil,
+		nil,
+	)
+	out, err := service.Seed(ctx, inbound.SeedInput{
+		Cwd:        targetCwd,
+		FromBranch: "main",
+		NewBranch:  "feature",
+		Provider:   domain.ProviderCodex,
+	})
+	if err != nil {
+		t.Fatalf("seed branch: %v", err)
+	}
+	seed, err := store.GetDoc(ctx, out.SnapshotID)
+	if err != nil {
+		t.Fatalf("get seed doc: %v", err)
+	}
+	if seed.CIR.Envelope.Cwd != targetCwd {
+		t.Fatalf("seed cwd = %q, want target %q", seed.CIR.Envelope.Cwd, targetCwd)
+	}
+}

--- a/cli/internal/app/load_session.go
+++ b/cli/internal/app/load_session.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -110,6 +111,13 @@ func (s *LoadSessionService) Load(ctx context.Context, in inbound.LoadInput) (in
 		// Failure is fail-open (tail only).
 		seedCIR = s.prependTrimDigest(ctx, cir, seedCIR, snap, target, in.Cwd, dropped)
 	}
+	// A restored session belongs to the working tree it is being restored into,
+	// not the machine/path where the source snapshot was captured. Codex active
+	// session discovery reads payload.cwd, so retaining the source path makes a
+	// relocated clone impossible to capture after resume.
+	if targetCwd := materializationCwd(in.Cwd); targetCwd != "" {
+		seedCIR.Envelope.Cwd = targetCwd
+	}
 	cdc, okCodec := s.codecs[target]
 	mat, okMat := s.materializers[target]
 	if okCodec && okMat {
@@ -127,6 +135,17 @@ func (s *LoadSessionService) Load(ctx context.Context, in inbound.LoadInput) (in
 	}
 	// Fallback (compatibility rules): full restoration failure → memory mode downgrade.
 	return s.loadMemory(ctx, cir, snap, target, in.Cwd)
+}
+
+func materializationCwd(cwd string) string {
+	if cwd == "" {
+		return ""
+	}
+	abs, err := filepath.Abs(cwd)
+	if err != nil {
+		return cwd
+	}
+	return abs
 }
 
 // pendingTailOf returns the latest pending (uncommitted hook capture) snapshot connecting to head.

--- a/cli/internal/app/restore_test.go
+++ b/cli/internal/app/restore_test.go
@@ -83,6 +83,13 @@ func TestLoadFullSameProvider(t *testing.T) {
 	if !strings.Contains(string(data), "SIG1") {
 		t.Fatalf("full same-provider must preserve signature")
 	}
+	restored, err := codec.NewClaudeCodec().Decode(ctx, data)
+	if err != nil {
+		t.Fatalf("decode restored Claude session: %v", err)
+	}
+	if restored.Envelope.Cwd != cwd {
+		t.Fatalf("restored Claude session cwd = %q, want target %q", restored.Envelope.Cwd, cwd)
+	}
 }
 
 // Cross-provider full request: claude → codex, reconstructed fallback + claude signature masked.
@@ -112,6 +119,13 @@ func TestLoadCrossProvider(t *testing.T) {
 	}
 	if !strings.Contains(string(data), "session_meta") {
 		t.Fatalf("codex output should be a rollout (session_meta)")
+	}
+	restored, err := codec.NewCodexCodec().Decode(ctx, data)
+	if err != nil {
+		t.Fatalf("decode restored Codex session: %v", err)
+	}
+	if restored.Envelope.Cwd != cwd {
+		t.Fatalf("restored Codex session cwd = %q, want target %q", restored.Envelope.Cwd, cwd)
 	}
 }
 


### PR DESCRIPTION
## Summary

- rebind restored Claude and Codex session metadata to the target working directory
- persist branch seeds with the target checkout path instead of the source snapshot path
- prevent relocated clones from becoming invisible to active-session capture
- add same-provider, cross-provider, and branch-seed regressions

## Verification

- `go build ./...`
- `go vet ./...`
- `go test ./...`
- `go test -race ./internal/app`
- `bash scripts/public-preflight.sh tree`
- migrated and loaded the latest pending snapshot with zero missing objects
- confirmed the materialized Codex `session_meta.cwd` points to `cxthub-public`