### PR TITLE
fix(cli): keep context HEAD aligned on checkout

### DIFF
--- a/cli/internal/app/checkout_session.go
+++ b/cli/internal/app/checkout_session.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/wnsdy95/cxthub/cli/internal/domain"
 	"github.com/wnsdy95/cxthub/cli/internal/ports/inbound"
 	"github.com/wnsdy95/cxthub/cli/internal/ports/outbound"
 )
@@ -35,10 +36,14 @@ func (s *CheckoutSessionService) Checkout(ctx context.Context, in inbound.Checko
 		return inbound.CheckoutOutput{}, err
 	}
 
-	// Output branch label determination: -b for new branch, otherwise the branch name from From.
+	// Output branch label determination: -b for new branch, otherwise only an
+	// actual branch ref from From. Tags and direct hashes are detached restores
+	// and must not become symbolic HEAD values.
 	branch := in.NewBranch
 	if branch == "" && in.From != "" && in.From != "HEAD" && !strings.HasPrefix(in.From, "sha256:") {
-		branch = in.From
+		if _, branchErr := s.store.GetRef(ctx, in.RepoID, domain.RefBranch, in.From); branchErr == nil {
+			branch = in.From
+		}
 	}
 
 	if in.NewBranch != "" {
@@ -60,6 +65,13 @@ func (s *CheckoutSessionService) Checkout(ctx context.Context, in inbound.Checko
 	})
 	if err != nil {
 		return inbound.CheckoutOutput{}, err
+	}
+	if branch != "" {
+		if err := s.store.PutRef(ctx, domain.Ref{
+			Kind: domain.RefHEAD, Name: "HEAD", RepoID: in.RepoID, Symbolic: branch,
+		}); err != nil {
+			return inbound.CheckoutOutput{}, err
+		}
 	}
 
 	return inbound.CheckoutOutput{

--- a/cli/internal/app/restore_test.go
+++ b/cli/internal/app/restore_test.go
@@ -179,4 +179,78 @@ func TestCheckoutForkAndLoad(t *testing.T) {
 	if err != nil || ref.Target != head {
 		t.Fatalf("forked branch ref: %v %+v", err, ref)
 	}
+	symbolic, err := store.GetRef(ctx, "", domain.RefHEAD, "HEAD")
+	if err != nil || symbolic.Symbolic != "feat/x" {
+		t.Fatalf("HEAD must follow forked branch: %v %+v", err, symbolic)
+	}
+}
+
+func TestCheckoutExistingBranchUpdatesHEAD(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	ctx := context.Background()
+	store := storage.NewFileStore(t.TempDir())
+	head := seedClaudeSnapshot(t, store)
+	cwd := t.TempDir()
+
+	if err := store.PutRef(ctx, domain.Ref{
+		Kind: domain.RefBranch, Name: "other", Target: head,
+	}); err != nil {
+		t.Fatalf("put other branch: %v", err)
+	}
+	if err := store.PutRef(ctx, domain.Ref{
+		Kind: domain.RefHEAD, Name: "HEAD", Symbolic: "other",
+	}); err != nil {
+		t.Fatalf("point HEAD at other: %v", err)
+	}
+
+	checkout := NewCheckoutSessionService(
+		NewForkSessionService(store),
+		newLoadSvc(store),
+		store,
+	)
+	out, err := checkout.Checkout(ctx, inbound.CheckoutInput{
+		From: "main", TargetProvider: domain.ProviderCodex, Mode: domain.FidelityFull, Cwd: cwd,
+	})
+	if err != nil {
+		t.Fatalf("checkout main: %v", err)
+	}
+	if out.Branch != "main" {
+		t.Fatalf("checkout branch = %q, want main", out.Branch)
+	}
+	symbolic, err := store.GetRef(ctx, "", domain.RefHEAD, "HEAD")
+	if err != nil || symbolic.Symbolic != "main" {
+		t.Fatalf("HEAD must follow existing branch: %v %+v", err, symbolic)
+	}
+}
+
+func TestCheckoutTagKeepsCurrentHEAD(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	ctx := context.Background()
+	store := storage.NewFileStore(t.TempDir())
+	head := seedClaudeSnapshot(t, store)
+	cwd := t.TempDir()
+
+	if err := store.PutRef(ctx, domain.Ref{
+		Kind: domain.RefTag, Name: "v1", Target: head,
+	}); err != nil {
+		t.Fatalf("put tag: %v", err)
+	}
+	checkout := NewCheckoutSessionService(
+		NewForkSessionService(store),
+		newLoadSvc(store),
+		store,
+	)
+	out, err := checkout.Checkout(ctx, inbound.CheckoutInput{
+		From: "v1", TargetProvider: domain.ProviderCodex, Mode: domain.FidelityFull, Cwd: cwd,
+	})
+	if err != nil {
+		t.Fatalf("checkout tag: %v", err)
+	}
+	if out.Branch != "" {
+		t.Fatalf("tag restore must be detached, got branch %q", out.Branch)
+	}
+	symbolic, err := store.GetRef(ctx, "", domain.RefHEAD, "HEAD")
+	if err != nil || symbolic.Symbolic != "main" {
+		t.Fatalf("tag restore must not move HEAD: %v %+v", err, symbolic)
+	}
 }


### PR DESCRIPTION
## Summary

- update the symbolic cxt HEAD after a successful existing-branch checkout
- update HEAD after fork-and-checkout as well
- keep tag and direct-hash restores detached instead of treating tag names as branches
- add regressions for existing branches, new branches, and tags

## Verification

- `go build ./...`
- `go vet ./...`
- `go test ./...`
- `go test -race ./internal/app`
- `bash scripts/public-preflight.sh tree`