### PR TITLE
fix(cli): preserve active request in bounded seeds

### DIFF
--- a/cli/internal/app/load_session.go
+++ b/cli/internal/app/load_session.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/wnsdy95/cxthub/cli/internal/adapters/providerfs"
 	"github.com/wnsdy95/cxthub/cli/internal/domain"
@@ -105,11 +106,18 @@ func (s *LoadSessionService) Load(ctx context.Context, in inbound.LoadInput) (in
 	// full / reconstructed: codec.Encode → materializer.Materialize
 	// Seed budget: Session doc can exceed target model context (empirically: weekly session summary → codex "ran out of room" like empty session).
 	// Recent event tail remains within budget — truncation point is user prompt boundary.
-	seedCIR, dropped := trimEventsForSeed(cir, seedBudgetBytes)
+	seedCIR := cir
+	var omitted []domain.Event
+	if eventsJSONBytes(cir.Events) > seedBudgetBytes {
+		seedCIR, omitted = trimEventsForSeed(cir, seedTailBudgetBytes)
+	}
+	dropped := len(omitted)
 	if dropped > 0 {
 		// Omit memory digest of skipped segment at seed start with "CompactSummary" event — context compression equivalent (summary + recent raw). Viewer collapses, distiller 1st priority last-wins (memory ↔ context cycle accumulation block).
 		// Failure is fail-open (tail only).
-		seedCIR = s.prependTrimDigest(ctx, cir, seedCIR, snap, target, in.Cwd, dropped)
+		omittedCIR := cir
+		omittedCIR.Events = omitted
+		seedCIR = s.prependTrimDigest(ctx, omittedCIR, seedCIR, snap, target, in.Cwd)
 	}
 	// A restored session belongs to the working tree it is being restored into,
 	// not the machine/path where the source snapshot was captured. Codex active
@@ -205,31 +213,210 @@ func (s *LoadSessionService) reachesFrom(ctx context.Context, from, anc domain.C
 // Claude(200k)/Codex(258k) windows leave room for default instructions and buffer.
 const seedBudgetBytes = 400 << 10
 
-// Trims old events exceeding the budget, leaving only the recent tail. Returns: (trimmed CIR, number of omitted events). The cut point advances to the user message boundary to ensure the seed starts from the user prompt and that tool call/response pairs are not split.
-func trimEventsForSeed(cir domain.CIRDocument, budget int) (domain.CIRDocument, int) {
+// A bounded digest gets a fixed share of the total event budget. Without this
+// reservation, a large inherited digest can dwarf the raw-tail limit and push
+// the materialized session over the target model's context window.
+const seedDigestBudgetBytes = 96 << 10
+const seedTailBudgetBytes = seedBudgetBytes - seedDigestBudgetBytes
+
+func eventsJSONBytes(evs []domain.Event) int {
+	total := 0
+	for _, ev := range evs {
+		b, _ := json.Marshal(ev)
+		total += len(b)
+	}
+	return total
+}
+
+func isSeedSummaryEvent(ev domain.Event) bool {
+	return ev.Kind == domain.EventMessage && ev.Role == "user" && len(ev.Blocks) > 0 &&
+		strings.HasPrefix(ev.Blocks[0].Text, seedSummaryPrefix)
+}
+
+func isSeedUserBoundary(ev domain.Event) bool {
+	return ev.Kind == domain.EventMessage && ev.Role == "user" && !isSeedSummaryEvent(ev)
+}
+
+// trimEventsForSeed keeps a bounded recent tail and returns the exact omitted
+// events. Normally the cut advances to the next user message, preserving whole
+// turns. If the newest in-progress turn alone exceeds the budget, there is no
+// next user boundary; in that case the latest user request is anchored in
+// front of the bounded suffix. Unmatched tool results at that synthetic gap are
+// removed so the provider never receives an output without its call.
+func trimEventsForSeed(cir domain.CIRDocument, budget int) (domain.CIRDocument, []domain.Event) {
 	evs := cir.Events
+	if eventsJSONBytes(evs) <= budget {
+		return cir, nil
+	}
 	sum := 0
-	cut := 0 // Start index of the maintained segment
+	cut := len(evs)
 	for i := len(evs) - 1; i >= 0; i-- {
 		b, _ := json.Marshal(evs[i])
 		if sum+len(b) > budget {
-			cut = i + 1
 			break
 		}
 		sum += len(b)
+		cut = i
 	}
-	if cut == 0 {
-		return cir, 0
-	}
+
+	selected := make([]bool, len(evs))
+	nextUser := -1
 	for i := cut; i < len(evs); i++ {
-		if evs[i].Kind == domain.EventMessage && evs[i].Role == "user" {
-			cut = i
+		if isSeedUserBoundary(evs[i]) {
+			nextUser = i
 			break
 		}
 	}
+
+	if nextUser >= 0 {
+		for i := nextUser; i < len(evs); i++ {
+			selected[i] = true
+		}
+	} else {
+		latestUser := -1
+		for i := cut - 1; i >= 0; i-- {
+			if isSeedUserBoundary(evs[i]) {
+				latestUser = i
+				break
+			}
+		}
+		if latestUser < 0 {
+			for i := cut; i < len(evs); i++ {
+				selected[i] = true
+			}
+		} else {
+			selected[latestUser] = true
+			userBytes, _ := json.Marshal(evs[latestUser])
+			remaining := budget - len(userBytes)
+			suffixCut := len(evs)
+			suffixBytes := 0
+			if remaining > 0 {
+				for i := len(evs) - 1; i > latestUser; i-- {
+					b, _ := json.Marshal(evs[i])
+					if suffixBytes+len(b) > remaining {
+						break
+					}
+					suffixBytes += len(b)
+					suffixCut = i
+				}
+			}
+			for i := suffixCut; i < len(evs); i++ {
+				selected[i] = true
+			}
+		}
+	}
+
+	// Any bounded suffix can begin after a tool call but before its result.
+	// Keep only results whose call is also present in the selected stream.
+	calls := map[string]bool{}
+	for i, keep := range selected {
+		if keep && evs[i].Kind == domain.EventToolCall && evs[i].CallID != "" {
+			calls[evs[i].CallID] = true
+		}
+	}
+	for i, keep := range selected {
+		if keep && evs[i].Kind == domain.EventToolResult && evs[i].CallID != "" && !calls[evs[i].CallID] {
+			selected[i] = false
+		}
+	}
+
 	out := cir
-	out.Events = append([]domain.Event{}, evs[cut:]...)
-	return out, cut
+	out.Events = make([]domain.Event, 0, len(evs))
+	omitted := make([]domain.Event, 0, len(evs))
+	for i, ev := range evs {
+		if selected[i] {
+			out.Events = append(out.Events, ev)
+		} else {
+			omitted = append(omitted, ev)
+		}
+	}
+	if len(omitted) == 0 {
+		return cir, nil
+	}
+	return out, omitted
+}
+
+func truncateUTF8Prefix(s string, maxBytes int) string {
+	if maxBytes <= 0 {
+		return ""
+	}
+	if len(s) <= maxBytes {
+		return s
+	}
+	end := maxBytes
+	for end > 0 && !utf8.ValidString(s[:end]) {
+		end--
+	}
+	return s[:end]
+}
+
+func truncateUTF8Tail(s string, maxBytes int) string {
+	if maxBytes <= 0 {
+		return ""
+	}
+	if len(s) <= maxBytes {
+		return s
+	}
+	const marker = "[... earlier summary omitted ...]\n"
+	if maxBytes <= len(marker) {
+		return truncateUTF8Prefix(marker, maxBytes)
+	}
+	start := len(s) - (maxBytes - len(marker))
+	for start < len(s) && !utf8.RuneStart(s[start]) {
+		start++
+	}
+	return marker + s[start:]
+}
+
+func renderSeedBulletSection(title string, items []string, maxBytes int) string {
+	header := "\n" + title + "\n"
+	if len(items) == 0 || maxBytes <= len(header)+2 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString(header)
+	for _, item := range items {
+		item = strings.TrimSpace(item)
+		if item == "" {
+			continue
+		}
+		line := "- " + item + "\n"
+		remaining := maxBytes - b.Len()
+		if remaining <= 2 {
+			break
+		}
+		if len(line) > remaining {
+			b.WriteString("- " + truncateUTF8Prefix(item, remaining-2))
+			break
+		}
+		b.WriteString(line)
+	}
+	if b.Len() == len(header) {
+		return ""
+	}
+	return b.String()
+}
+
+func renderSeedDigest(digest domain.MemoryDigest, dropped, budget int) string {
+	header := fmt.Sprintf("%s %d events were omitted to fit the context window; below is a bounded memory summary of the omitted span. The recent history follows verbatim.\n", seedSummaryPrefix, dropped)
+	if len(header) >= budget {
+		return truncateUTF8Prefix(header, budget)
+	}
+
+	facts := renderSeedBulletSection("Key facts:", seedWorthyFacts(digest.KeyFacts), budget/6)
+	tasks := renderSeedBulletSection("Open tasks:", digest.OpenTasks, budget/4)
+	remaining := budget - len(header) - len(facts) - len(tasks)
+
+	summaryBlock := ""
+	if summary := strings.TrimSpace(digest.Summary); summary != "" && remaining > 2 {
+		summary = truncateUTF8Tail(summary, remaining-2)
+		summaryBlock = "\n" + summary + "\n"
+	}
+	out := header + summaryBlock + facts + tasks
+	if len(out) > budget {
+		return truncateUTF8Prefix(out, budget)
+	}
+	return out
 }
 
 // `seedSummaryPrefix` is the identifier prefix for seed compression summary events — a marker to find and replace (remove) the previous generation summary in the tail when the next seed is generated. It is removed from materialized copies, while the saved doc remains unchanged.
@@ -245,10 +432,8 @@ const seedSummaryPrefix = "[cxt] This session was resumed from a branch context 
 //   - Previous generation seed summary (prefix CompactSummary) in the tail is removed — the new summary takes precedence.
 //   - If the digest summary matches the original native memory (e.g., MEMORY.md) of the target provider, it is omitted — the agent loads context itself at session start, so context re-injection is redundant.
 //   - KeyFacts noise such as whitespace-free tool tokens and legacy ingestion markers ("native memory:"/"absorbed from") is excluded from seed content.
-func (s *LoadSessionService) prependTrimDigest(ctx context.Context, full, seed domain.CIRDocument, snap domain.Snapshot, target domain.ProviderKind, cwd string, dropped int) domain.CIRDocument {
-	head := full
-	head.Events = full.Events[:dropped]
-	digest, derr := s.distiller.Distill(ctx, head, nil)
+func (s *LoadSessionService) prependTrimDigest(ctx context.Context, omitted, seed domain.CIRDocument, snap domain.Snapshot, target domain.ProviderKind, cwd string) domain.CIRDocument {
+	digest, derr := s.distiller.Distill(ctx, omitted, nil)
 	if derr != nil {
 		digest = domain.MemoryDigest{} // Send the stored digest even if empty
 	}
@@ -277,30 +462,13 @@ func (s *LoadSessionService) prependTrimDigest(ctx context.Context, full, seed d
 			digest.Summary = ""
 		}
 	}
-	var b strings.Builder
-	fmt.Fprintf(&b, "%s %d older events were omitted to fit the context window; below is the memory summary of the omitted span. The recent history follows verbatim.\n", seedSummaryPrefix, dropped)
-	if digest.Summary != "" {
-		b.WriteString("\n" + digest.Summary + "\n")
-	}
-	if facts := seedWorthyFacts(digest.KeyFacts); len(facts) > 0 {
-		b.WriteString("\nKey facts:\n")
-		for _, f := range facts {
-			b.WriteString("- " + f + "\n")
-		}
-	}
-	if len(digest.OpenTasks) > 0 {
-		b.WriteString("\nOpen tasks:\n")
-		for _, t := range digest.OpenTasks {
-			b.WriteString("- " + t + "\n")
-		}
-	}
-	ev := domain.Event{Kind: domain.EventMessage, Role: "user", CompactSummary: true, Blocks: []domain.ContentBlock{{Type: "text", Text: b.String()}}}
+	text := renderSeedDigest(digest, len(omitted.Events), seedDigestBudgetBytes)
+	ev := domain.Event{Kind: domain.EventMessage, Role: "user", CompactSummary: true, Blocks: []domain.ContentBlock{{Type: "text", Text: text}}}
 	// Remove previous generation seed summary (materialized copy limit): Since the new summary inherits its content,
 	// leaving it would cause ◈ blocks to accumulate per generation. Determination is based on prefix text — legacy seed messages (unmarked user) must also be removed.
 	tail := make([]domain.Event, 0, len(seed.Events))
 	for _, e := range seed.Events {
-		if e.Kind == domain.EventMessage && e.Role == "user" && len(e.Blocks) > 0 &&
-			strings.HasPrefix(e.Blocks[0].Text, seedSummaryPrefix) {
+		if isSeedSummaryEvent(e) {
 			continue
 		}
 		tail = append(tail, e)

--- a/cli/internal/app/seed_digest_test.go
+++ b/cli/internal/app/seed_digest_test.go
@@ -53,7 +53,7 @@ func TestPrependTrimDigestCompactSummary(t *testing.T) {
 		Summary:  "did X, decided Y",
 		KeyFacts: []string{"apply_patch", "unknown:Agent", "native memory: claude:MEMORY.md", "absorbed from claude:MEMORY.md", "budget is 400KB per seed"},
 	}, "")
-	out := svc.prependTrimDigest(ctx, full, seed, domain.Snapshot{}, domain.ProviderClaude, t.TempDir(), 2)
+	out := svc.prependTrimDigest(ctx, full, seed, domain.Snapshot{}, domain.ProviderClaude, t.TempDir())
 
 	if len(out.Events) != 2 {
 		t.Fatalf("Event count: got %d want 2 (new summary 1 + recent 1 — old [cxt] removed)", len(out.Events))
@@ -79,7 +79,7 @@ func TestPrependTrimDigestCompactSummary(t *testing.T) {
 
 	// (4) Omit summary of native memory text as-is.
 	svc = mk(domain.MemoryDigest{Summary: "MEMROOT\nfacts"}, "MEMROOT\nfacts")
-	out = svc.prependTrimDigest(ctx, full, seed, domain.Snapshot{}, domain.ProviderClaude, t.TempDir(), 2)
+	out = svc.prependTrimDigest(ctx, full, seed, domain.Snapshot{}, domain.ProviderClaude, t.TempDir())
 	if strings.Contains(out.Events[0].Blocks[0].Text, "MEMROOT") {
 		t.Fatalf("Native memory text re-injected into seed: %q", out.Events[0].Blocks[0].Text)
 	}

--- a/cli/internal/app/seed_trim_test.go
+++ b/cli/internal/app/seed_trim_test.go
@@ -1,0 +1,119 @@
+package app
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/wnsdy95/cxthub/cli/internal/domain"
+)
+
+func seedMessage(role, text string, seq int) domain.Event {
+	return domain.Event{
+		Kind: domain.EventMessage,
+		Role: role,
+		Seq:  seq,
+		Blocks: []domain.ContentBlock{{
+			Type: "text",
+			Text: text,
+		}},
+	}
+}
+
+func TestTrimEventsForSeedStartsAtNextUserBoundary(t *testing.T) {
+	cir := domain.CIRDocument{Events: []domain.Event{
+		seedMessage("user", "old prompt", 0),
+		seedMessage("assistant", strings.Repeat("old answer ", 80), 1),
+		seedMessage("user", "recent prompt", 2),
+		seedMessage("assistant", "recent answer", 3),
+	}}
+	budget := eventsJSONBytes(cir.Events[2:])
+
+	got, omitted := trimEventsForSeed(cir, budget)
+	if len(got.Events) != 2 || got.Events[0].Blocks[0].Text != "recent prompt" {
+		t.Fatalf("trim did not start at the next user boundary: %+v", got.Events)
+	}
+	if len(omitted) != 2 {
+		t.Fatalf("omitted count: got %d want 2", len(omitted))
+	}
+}
+
+func TestTrimEventsForSeedAnchorsLatestUserInOversizedTurn(t *testing.T) {
+	cir := domain.CIRDocument{Events: []domain.Event{
+		seedMessage("user", "old prompt", 0),
+		seedMessage("assistant", strings.Repeat("old answer ", 80), 1),
+		seedMessage("user", "current sync request", 2),
+		{
+			Kind: domain.EventToolCall, Seq: 3, CallID: "omitted-call", ToolName: "exec",
+			Input: map[string]interface{}{"payload": strings.Repeat("large input ", 80)},
+		},
+		{Kind: domain.EventToolResult, Seq: 4, CallID: "omitted-call", Output: "orphaned result"},
+		{Kind: domain.EventReasoning, Seq: 5, RedactedSummary: "continue diagnosis"},
+		{Kind: domain.EventToolCall, Seq: 6, CallID: "kept-call", ToolName: "exec"},
+		{Kind: domain.EventToolResult, Seq: 7, CallID: "kept-call", Output: "verified"},
+		seedMessage("assistant", "latest progress", 8),
+	}}
+	budget := eventsJSONBytes([]domain.Event{cir.Events[2], cir.Events[4], cir.Events[5], cir.Events[6], cir.Events[7], cir.Events[8]})
+
+	got, omitted := trimEventsForSeed(cir, budget)
+	if len(got.Events) == 0 || got.Events[0].Blocks[0].Text != "current sync request" {
+		t.Fatalf("latest user request was not anchored: %+v", got.Events)
+	}
+	if eventsJSONBytes(got.Events) > budget {
+		t.Fatalf("trimmed events exceed budget: got %d want <= %d", eventsJSONBytes(got.Events), budget)
+	}
+
+	calls := map[string]bool{}
+	for _, ev := range got.Events {
+		if ev.Kind == domain.EventToolCall {
+			calls[ev.CallID] = true
+		}
+	}
+	for _, ev := range got.Events {
+		if ev.Kind == domain.EventToolResult && !calls[ev.CallID] {
+			t.Fatalf("unmatched tool result retained: %s", ev.CallID)
+		}
+	}
+	if calls["omitted-call"] {
+		t.Fatal("oversized old tool call unexpectedly retained")
+	}
+	if !calls["kept-call"] {
+		t.Fatal("recent complete tool pair was not retained")
+	}
+	if len(got.Events)+len(omitted) != len(cir.Events) {
+		t.Fatalf("selected/omitted partition lost events: selected=%d omitted=%d total=%d", len(got.Events), len(omitted), len(cir.Events))
+	}
+}
+
+func TestRenderSeedDigestIsBoundedAndKeepsRecentState(t *testing.T) {
+	const budget = 8 << 10
+	digest := domain.MemoryDigest{
+		Summary: strings.Repeat("résumé history ", 5000) + "\nLATEST DECISION: continue from the public repository.",
+		KeyFacts: []string{
+			"the restored session must use the target working directory",
+		},
+		OpenTasks: []string{
+			"verify the newest pending snapshot before ending migration",
+		},
+	}
+
+	got := renderSeedDigest(digest, 1234, budget)
+	if len(got) > budget {
+		t.Fatalf("digest exceeds budget: got %d want <= %d", len(got), budget)
+	}
+	if !utf8.ValidString(got) {
+		t.Fatal("digest truncation produced invalid UTF-8")
+	}
+	for _, want := range []string{
+		"LATEST DECISION",
+		"target working directory",
+		"verify the newest pending snapshot",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("bounded digest lost %q", want)
+		}
+	}
+	if !strings.Contains(got, "earlier summary omitted") {
+		t.Fatal("large summary was not visibly truncated")
+	}
+}


### PR DESCRIPTION
## Summary
- reserve a bounded share of the seed budget for inherited memory summaries
- preserve the latest user request when one in-progress turn exceeds the raw-tail budget
- remove unmatched tool results introduced by a bounded mid-turn suffix
- cap digest sections without breaking UTF-8

## Verification
- `go test ./...`
- `go test -race ./internal/app ./internal/adapters/codec`
- `go vet ./...`
- `bash scripts/public-preflight.sh`
- live materialization of `7c90978665`: target cwd restored, current prompt retained, output reduced from 2.1 MB to 521 KB, zero unmatched tool results