### PR TITLE
docs: prepare v0.1.1 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and releases follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.1.1] - 2026-07-29
+
+### Changed
+
+- Expanded the installation guide and CLI reference with release, update,
+  removal, CI, restore-mode, synchronization, and configuration workflows.
+
+### Fixed
+
+- Return a normal empty result when optional team settings or shared secrets
+  have not been configured.
+- Capture current Codex rollouts that contain tool-search control records or
+  object-form function arguments.
+- Rebind restored Claude Code and Codex sessions to the destination working
+  tree so relocated clones remain discoverable by live capture.
+- Keep the symbolic context `HEAD` aligned with branch checkouts while leaving
+  tag and direct-snapshot restores detached.
+- Preserve the latest user request and valid tool-call structure when a large
+  restored session must be reduced to the seed context budget.
+
 ## [0.1.0] - 2026-07-26
 
 ### Added
@@ -20,5 +40,6 @@ and releases follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Workspace access control, pending-session review, shared settings, and
   end-to-end encrypted secret-mask distribution.
 
-[Unreleased]: https://github.com/wnsdy95/cxthub/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/wnsdy95/cxthub/compare/v0.1.1...HEAD
+[0.1.1]: https://github.com/wnsdy95/cxthub/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/wnsdy95/cxthub/releases/tag/v0.1.0


### PR DESCRIPTION
## Summary

- document the user-visible fixes and documentation improvements merged since `v0.1.0`
- preserve an empty `Unreleased` section for subsequent work
- advance the comparison links to the immutable `v0.1.1` release boundary

## User impact

The release notes now explain the restored-session, checkout, bounded-seed, Codex rollout, and optional team-asset fixes included in the patch release.

## Verification

- `make build`
- `make test`
- `make typecheck`
- `make lint`
- `npm run build` in `frontend/web`
- `make e2e`
- `make e2e-sync`
- `make public-check-full`

## Compatibility

Documentation only. This does not change snapshot identity, graph reachability, persistence, synchronization, provider conversion, authentication, authorization, or migrations.

## Traceability

No issue: maintainer-requested patch-release preparation, permitted as a focused documentation pull request by `CONTRIBUTING.md`.

## AI assistance

Codex assisted with release-note drafting, commit-to-PR reconciliation, and local gate execution. The changes and verification results were reviewed against PRs #10 through #15 and the repository release policy.
