### PR TITLE
docs: define solo-maintainer review exception

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -49,6 +49,13 @@ owner has an explicit ruleset bypass for emergency security work, release
 recovery, and authorized history maintenance. It is not the normal contribution
 path and should retain a public audit trail whenever confidentiality permits.
 
+While the project has only one eligible maintainer, an owner-authored pull
+request cannot receive an independent code-owner approval. The owner may use
+the documented solo-maintainer exception only after required checks pass and
+the bypass rationale is recorded in the pull request. Contributor-authored
+changes still require owner review, and the exception expires when another
+eligible maintainer or code owner is available.
+
 The branching and review policy is documented in
 [docs/BRANCHING.md](docs/BRANCHING.md).
 

--- a/docs/BRANCHING.md
+++ b/docs/BRANCHING.md
@@ -79,10 +79,21 @@ Repository rules require:
 - linear history;
 - no branch deletion or force-push.
 
-The repository owner has an explicit ruleset bypass for emergency security
-work, release recovery, and authorized history maintenance. Bypass is not the
-normal merge path. When confidentiality does not prevent it, bypassed changes
-must retain an issue, pull request, release note, or other public audit trail.
+When the project has only one eligible maintainer and that maintainer authors a
+pull request, GitHub cannot accept the author's own approval. In that
+solo-maintainer state, the owner may use the ruleset bypass after every required
+status check passes and must record the reason in the pull request. The bypass
+replaces only the unavailable independent approval: the change must still use a
+short-lived branch, signed commits, a pull request targeting `main`, resolved
+review conversations, and linear history.
+
+The solo-maintainer exception never permits direct pushes to `main`, merging
+failed checks, force-pushing protected refs, or moving release tags. It ends
+when another eligible maintainer or code owner is available. Outside this
+narrow exception, the owner bypass remains reserved for emergency security
+work, release recovery, and authorized history maintenance. When
+confidentiality does not prevent it, every bypassed change must retain a public
+audit trail.
 
 ## Releases and fixes
 


### PR DESCRIPTION
## Summary

- document why an owner-authored pull request cannot satisfy its own CODEOWNER approval in a single-maintainer repository
- allow the owner bypass only after every required status check passes and the reason is recorded publicly
- preserve short-lived branches, signed commits, pull requests, resolved conversations, and linear history
- end the exception when another eligible maintainer or code owner becomes available

## Policy impact

This makes the written policy match the repository's current solo-maintainer operating model. The exception replaces only the impossible independent approval. It does not permit direct pushes to `main`, failed-check merges, protected-ref force pushes, or release-tag movement. Contributor-authored changes continue to require owner review.

## Verification

- `git diff --check`
- `make public-check-full`

## Compatibility

Documentation and governance policy only. No product behavior, snapshot identity, persistence, synchronization, provider conversion, authentication, authorization, or migration changes.

## Decision record

The project owner explicitly authorized continued owner-bypass use while CXTHub has one maintainer. PR #16 recorded the first release-preparation use of this solo-maintainer rationale.

## AI assistance

Codex assisted with policy drafting and consistency checks. The exception scope was reviewed against `docs/BRANCHING.md`, `GOVERNANCE.md`, the active GitHub ruleset, and the repository's current collaborator/CODEOWNER configuration.
