### PR TITLE
fix(sync): promote context after PR merges

### DIFF
--- a/backend/internal/adapters/delivery/http/server.go
+++ b/backend/internal/adapters/delivery/http/server.go
@@ -858,12 +858,16 @@ func (s *Server) githubWebhook(w http.ResponseWriter, r *http.Request) {
 				Ref string `json:"ref"`
 			} `json:"base"`
 			Head struct {
-				Ref string `json:"ref"`
+				Ref  string `json:"ref"`
+				Repo struct {
+					FullName string `json:"full_name"`
+				} `json:"repo"`
 			} `json:"head"`
 		} `json:"pull_request"`
 		Repository struct {
 			HTMLURL  string `json:"html_url"`
 			CloneURL string `json:"clone_url"`
+			FullName string `json:"full_name"`
 		} `json:"repository"`
 	}
 	if jerr := json.Unmarshal(body, &payload); jerr != nil {
@@ -872,6 +876,13 @@ func (s *Server) githubWebhook(w http.ResponseWriter, r *http.Request) {
 	}
 	if payload.Action != "closed" || !payload.PullRequest.Merged {
 		s.respond(w, map[string]string{"status": "ignored"}, nil)
+		return
+	}
+	// Context branch refs belong to the base cxt repository. A fork PR's
+	// same-named branch could otherwise resolve to unrelated base-repo context.
+	if payload.Repository.FullName == "" || payload.PullRequest.Head.Repo.FullName == "" ||
+		!strings.EqualFold(payload.Repository.FullName, payload.PullRequest.Head.Repo.FullName) {
+		s.respond(w, map[string]string{"status": "ignored", "reason": "fork_head"}, nil)
 		return
 	}
 	gitURL := payload.Repository.CloneURL

--- a/backend/internal/adapters/delivery/http/server_test.go
+++ b/backend/internal/adapters/delivery/http/server_test.go
@@ -3,6 +3,9 @@ package http
 import (
 	"bytes"
 	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -20,6 +23,31 @@ import (
 	"github.com/wnsdy95/cxthub/backend/internal/domain"
 	"github.com/wnsdy95/cxthub/backend/internal/ports/inbound"
 )
+
+type githubWebhookBackend struct {
+	Backend
+	promoted int
+	err      error
+	calls    []githubWebhookPromotion
+}
+
+type githubWebhookPromotion struct {
+	gitURL string
+	base   string
+	head   string
+}
+
+func (b *githubWebhookBackend) PromoteMergedPR(
+	_ context.Context,
+	gitURL, baseBranch, headBranch string,
+) (int, error) {
+	b.calls = append(b.calls, githubWebhookPromotion{
+		gitURL: gitURL,
+		base:   baseBranch,
+		head:   headBranch,
+	})
+	return b.promoted, b.err
+}
 
 type policyDownIdentity struct {
 	*app.IdentityService
@@ -89,6 +117,213 @@ func repoIDForRemoteURLForTest(raw string) domain.ContentHash {
 	normalized = strings.TrimSuffix(normalized, ".git")
 	normalized = strings.TrimRight(normalized, "/")
 	return domain.HashContent([]byte(strings.ToLower(normalized)))
+}
+
+func githubWebhookRequest(t *testing.T, handler http.Handler, secret, event string, body []byte) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/hooks/github", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-GitHub-Event", event)
+	if secret != "" {
+		mac := hmac.New(sha256.New, []byte(secret))
+		_, _ = mac.Write(body)
+		req.Header.Set("X-Hub-Signature-256", "sha256="+hex.EncodeToString(mac.Sum(nil)))
+	}
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestGitHubWebhookSecurityAndPromotion(t *testing.T) {
+	const secret = "test-webhook-secret"
+	merged := []byte(`{
+		"action":"closed",
+		"pull_request":{
+			"merged":true,
+			"base":{"ref":"main"},
+			"head":{"ref":"feature/x","repo":{"full_name":"acme/project"}}
+		},
+		"repository":{
+			"full_name":"acme/project",
+			"html_url":"https://github.com/acme/project",
+			"clone_url":"https://github.com/acme/project.git"
+		}
+	}`)
+
+	t.Run("disabled when secret is unset", func(t *testing.T) {
+		t.Setenv("CXT_GITHUB_WEBHOOK_SECRET", "")
+		backend := &githubWebhookBackend{}
+		rec := githubWebhookRequest(t, NewServer(backend, nil).Handler(), "", "pull_request", merged)
+		if rec.Code != http.StatusNotFound {
+			t.Fatalf("status = %d, want 404", rec.Code)
+		}
+		if len(backend.calls) != 0 {
+			t.Fatalf("promotion calls = %#v, want none", backend.calls)
+		}
+	})
+
+	t.Run("rejects bad signature", func(t *testing.T) {
+		t.Setenv("CXT_GITHUB_WEBHOOK_SECRET", secret)
+		backend := &githubWebhookBackend{}
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/hooks/github", bytes.NewReader(merged))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("X-GitHub-Event", "pull_request")
+		req.Header.Set("X-Hub-Signature-256", "sha256=bad")
+		rec := httptest.NewRecorder()
+		NewServer(backend, nil).Handler().ServeHTTP(rec, req)
+		if rec.Code != http.StatusUnauthorized {
+			t.Fatalf("status = %d, want 401", rec.Code)
+		}
+		if len(backend.calls) != 0 {
+			t.Fatalf("promotion calls = %#v, want none", backend.calls)
+		}
+	})
+
+	t.Run("ignores other events", func(t *testing.T) {
+		t.Setenv("CXT_GITHUB_WEBHOOK_SECRET", secret)
+		backend := &githubWebhookBackend{}
+		rec := githubWebhookRequest(t, NewServer(backend, nil).Handler(), secret, "ping", []byte(`{"zen":"safe"}`))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200", rec.Code)
+		}
+		if len(backend.calls) != 0 {
+			t.Fatalf("promotion calls = %#v, want none", backend.calls)
+		}
+	})
+
+	t.Run("ignores unmerged pull request", func(t *testing.T) {
+		t.Setenv("CXT_GITHUB_WEBHOOK_SECRET", secret)
+		backend := &githubWebhookBackend{}
+		body := bytes.Replace(merged, []byte(`"merged":true`), []byte(`"merged":false`), 1)
+		rec := githubWebhookRequest(t, NewServer(backend, nil).Handler(), secret, "pull_request", body)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200", rec.Code)
+		}
+		if len(backend.calls) != 0 {
+			t.Fatalf("promotion calls = %#v, want none", backend.calls)
+		}
+	})
+
+	t.Run("ignores fork head", func(t *testing.T) {
+		t.Setenv("CXT_GITHUB_WEBHOOK_SECRET", secret)
+		backend := &githubWebhookBackend{}
+		body := bytes.Replace(merged, []byte(`"full_name":"acme/project"}}`), []byte(`"full_name":"fork/project"}}`), 1)
+		rec := githubWebhookRequest(t, NewServer(backend, nil).Handler(), secret, "pull_request", body)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200", rec.Code)
+		}
+		if len(backend.calls) != 0 {
+			t.Fatalf("promotion calls = %#v, want none", backend.calls)
+		}
+	})
+
+	t.Run("promotes same-repository merged head", func(t *testing.T) {
+		t.Setenv("CXT_GITHUB_WEBHOOK_SECRET", secret)
+		backend := &githubWebhookBackend{promoted: 1}
+		rec := githubWebhookRequest(t, NewServer(backend, nil).Handler(), secret, "pull_request", merged)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+		}
+		if len(backend.calls) != 1 {
+			t.Fatalf("promotion calls = %#v, want one", backend.calls)
+		}
+		want := githubWebhookPromotion{
+			gitURL: "https://github.com/acme/project.git",
+			base:   "main",
+			head:   "feature/x",
+		}
+		if backend.calls[0] != want {
+			t.Fatalf("promotion call = %#v, want %#v", backend.calls[0], want)
+		}
+		var response map[string]any
+		if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+			t.Fatalf("decode response: %v", err)
+		}
+		if response["status"] != "ok" || response["promoted"] != float64(1) {
+			t.Fatalf("response = %#v, want status ok and promoted 1", response)
+		}
+	})
+}
+
+func TestGitHubWebhookPromotesDivergedContextEndToEnd(t *testing.T) {
+	const secret = "integration-webhook-secret"
+	t.Setenv("CXT_GITHUB_WEBHOOK_SECRET", secret)
+
+	st := store.NewFSStore(t.TempDir())
+	svc := app.NewService(st, st, auth.NewTeamTokenAuth(), gitengine.NewEngine(st), st)
+	repoID := domain.HashContent([]byte("github.com/acme/project"))
+	if _, err := st.PutRepo(context.Background(), domain.Repo{
+		ID:            repoID,
+		DefaultBranch: "main",
+		GitRemoteURL:  "git@github.com:acme/project.git",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	base, mainTip, featureTip := domain.HashContent([]byte("base")), domain.HashContent([]byte("main")), domain.HashContent([]byte("feature"))
+	for _, snap := range []domain.Snapshot{
+		{ID: base, RepoID: repoID, DocHash: base},
+		{ID: mainTip, RepoID: repoID, DocHash: mainTip, Parents: []domain.ContentHash{base}},
+		{ID: featureTip, RepoID: repoID, DocHash: featureTip, Parents: []domain.ContentHash{base}},
+	} {
+		if err := st.PutSnapshot(context.Background(), snap); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for name, target := range map[string]domain.ContentHash{"main": mainTip, "feature/x": featureTip} {
+		if err := st.CompareAndSwapRef(context.Background(), repoID, domain.Ref{
+			Kind: domain.RefBranch, Name: name, RepoID: repoID, Target: target,
+		}, ""); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	body := []byte(`{
+		"action":"closed",
+		"pull_request":{
+			"merged":true,
+			"base":{"ref":"main"},
+			"head":{"ref":"feature/x","repo":{"full_name":"acme/project"}}
+		},
+		"repository":{
+			"full_name":"acme/project",
+			"clone_url":"https://github.com/acme/project.git"
+		}
+	}`)
+	handler := NewServer(svc, nil).Handler()
+	for attempt := 1; attempt <= 2; attempt++ {
+		rec := githubWebhookRequest(t, handler, secret, "pull_request", body)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("attempt %d status = %d, body=%s", attempt, rec.Code, rec.Body.String())
+		}
+		var response struct {
+			Promoted int `json:"promoted"`
+		}
+		if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+			t.Fatal(err)
+		}
+		want := 1
+		if attempt == 2 {
+			want = 0
+		}
+		if response.Promoted != want {
+			t.Fatalf("attempt %d promoted = %d, want %d", attempt, response.Promoted, want)
+		}
+	}
+
+	mainRef, err := st.GetRef(context.Background(), repoID, domain.RefBranch, "main")
+	if err != nil || mainRef.Target != featureTip {
+		t.Fatalf("main ref = (%s, %v), want feature tip %s", mainRef.Target, err, featureTip)
+	}
+	promoted, err := st.GetSnapshot(context.Background(), repoID, featureTip)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(promoted.Parents) != 1 || promoted.Parents[0] != base {
+		t.Fatalf("natural parents changed: %v, want [%s]", promoted.Parents, base)
+	}
+	if len(promoted.GraftParents) != 1 || promoted.GraftParents[0] != mainTip {
+		t.Fatalf("graft parents = %v, want prior main tip %s", promoted.GraftParents, mainTip)
+	}
 }
 
 func TestHealthIsPublicAndMinimal(t *testing.T) {

--- a/cli/cmd/cxt/main.go
+++ b/cli/cmd/cxt/main.go
@@ -252,6 +252,7 @@ func buildContainer(cfg config) container {
 		Seed:            seedSvc,
 		Tag:             tagSvc,
 		Stash:           stashSvc,
+		PRMerges:        gitctx.NewGitHubPRMergeResolver(),
 		Settings:        remote,
 		SettingsObjects: store,
 		Repack:          store.RepackDocs,

--- a/cli/internal/adapters/delivery/cli/githook.go
+++ b/cli/internal/adapters/delivery/cli/githook.go
@@ -16,6 +16,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -31,6 +32,7 @@ import (
 	"github.com/wnsdy95/cxthub/cli/internal/adapters/remotecfg"
 	"github.com/wnsdy95/cxthub/cli/internal/domain"
 	"github.com/wnsdy95/cxthub/cli/internal/ports/inbound"
+	"github.com/wnsdy95/cxthub/cli/internal/ports/outbound"
 )
 
 // gitOut runs a git subcommand in cwd and returns the trimmed stdout (empty on failure).
@@ -645,30 +647,91 @@ func handleIncomingContexts(ctx context.Context, c *Container, cwd string) {
 			break
 		}
 	}
-	// PR merge context promotion: This merge/pull incorporates git commits and chained snapshots into the cxt branch
-	// (objects already in local cache from previous fetch).
-	appendMergedContexts(ctx, c, cwd, branch)
+	// PR merge context promotion: First resolve host-side squash/rebase/merge
+	// commits back to their source branches. Then retain the generic [git sha]
+	// path for non-GitHub and direct merge histories.
+	shas := incomingCommitSHAs(cwd)
+	appendMergedPRContexts(ctx, c.PRMerges, c.Sync, cwd, branch, gitOut(cwd, "config", "--get", "remote.origin.url"), shas)
+	appendMergedContexts(ctx, c, cwd, branch, shas)
+}
+
+func incomingCommitSHAs(cwd string) []string {
+	if gitOut(cwd, "rev-parse", "--verify", "-q", "ORIG_HEAD") == "" {
+		return nil // not merge/pull path (initial clone, etc.)
+	}
+	raw := gitOut(cwd, "rev-list", "--reverse", "ORIG_HEAD..HEAD")
+	if raw == "" {
+		return nil
+	}
+	shas := strings.Fields(raw) // oldest first
+	if len(shas) > 200 {
+		shas = shas[len(shas)-200:] // large merge defense — last 200 only
+	}
+	return shas
+}
+
+type mergedPRContextSync interface {
+	ResolveRemoteBranch(ctx context.Context, in inbound.SyncInput, branch string) (domain.Ref, error)
+	AppendBranch(ctx context.Context, in inbound.SyncInput, branch string, target domain.ContentHash) error
+}
+
+// appendMergedPRContexts promotes each merged PR source tip to the current base
+// branch in Git commit order. Discovery failure is fail-open because this runs
+// inside a Git hook; the hosted signed webhook remains the primary path.
+func appendMergedPRContexts(
+	ctx context.Context,
+	resolver outbound.PullRequestMergeResolver,
+	syncer mergedPRContextSync,
+	cwd, branch, gitRemoteURL string,
+	shas []string,
+) {
+	if resolver == nil || syncer == nil || branch == "" || branch == "HEAD" || gitRemoteURL == "" || len(shas) == 0 {
+		return
+	}
+	pulls, err := resolver.ResolveMergedPullRequests(ctx, gitRemoteURL, branch, shas)
+	if err != nil {
+		hookWarn("GitHub PR context lookup failed (git continues): %v", err)
+		return
+	}
+
+	appended := 0
+	for _, pull := range pulls {
+		if pull.BaseBranch != branch || pull.HeadBranch == "" || pull.HeadBranch == branch {
+			continue
+		}
+		ref, rerr := syncer.ResolveRemoteBranch(ctx, inbound.SyncInput{Cwd: cwd}, pull.HeadBranch)
+		if rerr != nil {
+			if !errors.Is(rerr, domain.ErrNotFound) {
+				hookWarn("PR #%d context branch %q lookup failed: %v", pull.Number, pull.HeadBranch, rerr)
+			}
+			continue
+		}
+		if ref.Target == "" {
+			continue
+		}
+		if aerr := syncer.AppendBranch(ctx, inbound.SyncInput{Cwd: cwd}, branch, ref.Target); aerr != nil {
+			if strings.Contains(aerr.Error(), "non_fast_forward") {
+				continue // hosted webhook or another client already promoted it
+			}
+			hookWarn("PR #%d context promotion failed (%s → %s): %v", pull.Number, pull.HeadBranch, branch, aerr)
+			continue
+		}
+		appended++
+	}
+	if appended > 0 {
+		fmt.Printf("cxt: promoted %d merged PR context(s) to %q timeline (appended)\n", appended, branch)
+	}
 }
 
 // appendMergedContexts appends git merge/pull commits and chained context snapshots to the same-named cxt branch.
 //
 // In the PR flow, context accumulates on feature branches and merge happens on git host, so cxt main becomes the permanent anchor
 // — this hook fills that gap. Append is a lossless operation (overlay) that is idempotent and conflict-free (server CAS,
-// non-ff targets rejected → skip). Flows like squash/rebase-merge that erase original commit sha are skipped locally (server webhook path to follow).
-func appendMergedContexts(ctx context.Context, c *Container, cwd, branch string) {
-	if branch == "" || branch == "HEAD" {
+// non-ff targets rejected → skip). Provider PR resolution above supplies the
+// squash/rebase path whose original commit links are absent from the base Git history.
+func appendMergedContexts(ctx context.Context, c *Container, cwd, branch string, shas []string) {
+	if branch == "" || branch == "HEAD" || len(shas) == 0 {
 		return
-	}
-	if gitOut(cwd, "rev-parse", "--verify", "-q", "ORIG_HEAD") == "" {
-		return // not merge/pull path (initial clone, etc.)
-	}
-	rawShas := gitOut(cwd, "rev-list", "--reverse", "ORIG_HEAD..HEAD")
-	if rawShas == "" {
-		return
-	}
-	shas := strings.Fields(rawShas) // oldest first
-	if len(shas) > 200 {
-		shas = shas[len(shas)-200:] // large merge defense — last 200 only
 	}
 	list, err := c.List.List(ctx, inbound.ListInput{})
 	if err != nil {

--- a/cli/internal/adapters/delivery/cli/githook_pr_test.go
+++ b/cli/internal/adapters/delivery/cli/githook_pr_test.go
@@ -1,0 +1,179 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/wnsdy95/cxthub/cli/internal/domain"
+	"github.com/wnsdy95/cxthub/cli/internal/ports/inbound"
+	"github.com/wnsdy95/cxthub/cli/internal/ports/outbound"
+)
+
+type fakePRMergeResolver struct {
+	pulls  []outbound.MergedPullRequest
+	err    error
+	remote string
+	base   string
+	shas   []string
+}
+
+func (f *fakePRMergeResolver) ResolveMergedPullRequests(
+	_ context.Context,
+	remote, base string,
+	shas []string,
+) ([]outbound.MergedPullRequest, error) {
+	f.remote = remote
+	f.base = base
+	f.shas = append([]string(nil), shas...)
+	return append([]outbound.MergedPullRequest(nil), f.pulls...), f.err
+}
+
+type appendCall struct {
+	branch string
+	target domain.ContentHash
+}
+
+type fakeMergedPRSync struct {
+	refs        map[string]domain.Ref
+	resolveErrs map[string]error
+	appendErrs  map[domain.ContentHash]error
+	appends     []appendCall
+}
+
+func (f *fakeMergedPRSync) ResolveRemoteBranch(
+	_ context.Context,
+	_ inbound.SyncInput,
+	branch string,
+) (domain.Ref, error) {
+	if err := f.resolveErrs[branch]; err != nil {
+		return domain.Ref{}, err
+	}
+	if ref, ok := f.refs[branch]; ok {
+		return ref, nil
+	}
+	return domain.Ref{}, domain.ErrNotFound
+}
+
+func (f *fakeMergedPRSync) AppendBranch(
+	_ context.Context,
+	_ inbound.SyncInput,
+	branch string,
+	target domain.ContentHash,
+) error {
+	f.appends = append(f.appends, appendCall{branch: branch, target: target})
+	return f.appendErrs[target]
+}
+
+func TestAppendMergedPRContextsPromotesInResolverOrder(t *testing.T) {
+	t.Parallel()
+
+	resolver := &fakePRMergeResolver{pulls: []outbound.MergedPullRequest{
+		{Number: 11, BaseBranch: "main", HeadBranch: "feature/old", MergeCommitSHA: "aaa"},
+		{Number: 12, BaseBranch: "release", HeadBranch: "wrong-base", MergeCommitSHA: "bbb"},
+		{Number: 13, BaseBranch: "main", HeadBranch: "missing", MergeCommitSHA: "ccc"},
+		{Number: 14, BaseBranch: "main", HeadBranch: "feature/already", MergeCommitSHA: "ddd"},
+		{Number: 15, BaseBranch: "main", HeadBranch: "feature/new", MergeCommitSHA: "eee"},
+	}}
+	oldTarget := domain.ContentHash("sha256:old")
+	alreadyTarget := domain.ContentHash("sha256:already")
+	newTarget := domain.ContentHash("sha256:new")
+	syncer := &fakeMergedPRSync{
+		refs: map[string]domain.Ref{
+			"feature/old":     {Target: oldTarget},
+			"feature/already": {Target: alreadyTarget},
+			"feature/new":     {Target: newTarget},
+		},
+		appendErrs: map[domain.ContentHash]error{
+			alreadyTarget: errors.New("non_fast_forward: already reachable"),
+		},
+	}
+
+	shas := []string{"aaa", "bbb", "ccc", "ddd", "eee"}
+	appendMergedPRContexts(
+		context.Background(),
+		resolver,
+		syncer,
+		"/repo",
+		"main",
+		"git@github.com:acme/project.git",
+		shas,
+	)
+
+	if resolver.remote != "git@github.com:acme/project.git" || resolver.base != "main" {
+		t.Fatalf("resolver inputs = (%q, %q), want Git remote and main", resolver.remote, resolver.base)
+	}
+	if strings.Join(resolver.shas, ",") != strings.Join(shas, ",") {
+		t.Fatalf("resolver SHAs = %v, want %v", resolver.shas, shas)
+	}
+	want := []appendCall{
+		{branch: "main", target: oldTarget},
+		{branch: "main", target: alreadyTarget},
+		{branch: "main", target: newTarget},
+	}
+	if len(syncer.appends) != len(want) {
+		t.Fatalf("append calls = %#v, want %#v", syncer.appends, want)
+	}
+	for i := range want {
+		if syncer.appends[i] != want[i] {
+			t.Fatalf("append call %d = %#v, want %#v", i, syncer.appends[i], want[i])
+		}
+	}
+}
+
+func TestAppendMergedPRContextsResolverFailureIsFailOpen(t *testing.T) {
+	t.Parallel()
+
+	resolver := &fakePRMergeResolver{err: errors.New("rate limited")}
+	syncer := &fakeMergedPRSync{}
+	appendMergedPRContexts(
+		context.Background(),
+		resolver,
+		syncer,
+		"/repo",
+		"main",
+		"https://github.com/acme/project",
+		[]string{"aaa"},
+	)
+	if len(syncer.appends) != 0 {
+		t.Fatalf("append calls = %#v, want none after resolver failure", syncer.appends)
+	}
+}
+
+func TestIncomingCommitSHAsOldestFirstAndBounded(t *testing.T) {
+	t.Parallel()
+
+	repo := t.TempDir()
+	runGitForTest(t, repo, "init", "-b", "main")
+	runGitForTest(t, repo, "config", "user.name", "Test")
+	runGitForTest(t, repo, "config", "user.email", "test@example.com")
+	for i := 0; i < 202; i++ {
+		runGitForTest(t, repo, "commit", "--allow-empty", "-m", "commit")
+	}
+	all := strings.Fields(gitOut(repo, "rev-list", "--reverse", "HEAD"))
+	if len(all) != 202 {
+		t.Fatalf("commits = %d, want 202", len(all))
+	}
+	runGitForTest(t, repo, "update-ref", "ORIG_HEAD", all[0])
+
+	got := incomingCommitSHAs(repo)
+	if len(got) != 200 {
+		t.Fatalf("incoming SHAs = %d, want bounded 200", len(got))
+	}
+	// ORIG_HEAD is excluded, leaving 201 commits; the oldest one is dropped by
+	// the 200-entry defense.
+	if got[0] != all[2] || got[len(got)-1] != all[len(all)-1] {
+		t.Fatalf("bounded order = %s…%s, want %s…%s", got[0], got[len(got)-1], all[2], all[len(all)-1])
+	}
+}
+
+func runGitForTest(t *testing.T, cwd string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", filepath.Clean(cwd)}, args...)...)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}

--- a/cli/internal/adapters/delivery/cli/root.go
+++ b/cli/internal/adapters/delivery/cli/root.go
@@ -30,6 +30,7 @@ import (
 	"github.com/wnsdy95/cxthub/cli/internal/adapters/secretscrypto"
 	"github.com/wnsdy95/cxthub/cli/internal/domain"
 	"github.com/wnsdy95/cxthub/cli/internal/ports/inbound"
+	"github.com/wnsdy95/cxthub/cli/internal/ports/outbound"
 )
 
 // Container is a bundle of inbound ports used by the CLI driver + author identifier.
@@ -45,6 +46,9 @@ type Container struct {
 	Seed     inbound.SeedBranch
 	Tag      inbound.TagRef
 	Stash    inbound.StashSession
+	// PRMerges resolves incoming Git commits to merged provider PRs so post-merge
+	// can promote the source branch context into the checked-out base timeline.
+	PRMerges outbound.PullRequestMergeResolver
 	// Settings is a remote client for setting bundles (outbound direct — thin utility path).
 	Settings interface {
 		PullSettings(ctx context.Context, repoID, kind string) (domain.SettingsBundle, error)

--- a/cli/internal/adapters/gitctx/pull_request.go
+++ b/cli/internal/adapters/gitctx/pull_request.go
@@ -1,0 +1,210 @@
+package gitctx
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/wnsdy95/cxthub/cli/internal/ports/outbound"
+)
+
+const (
+	githubAPIBase       = "https://api.github.com"
+	githubAPIVersion    = "2022-11-28"
+	githubPRPageLimit   = 10
+	githubResolveWindow = 5 * time.Second
+)
+
+// GitHubPRMergeResolver discovers merged GitHub pull requests represented by
+// commits newly introduced into the checked-out base branch.
+type GitHubPRMergeResolver struct {
+	client  *http.Client
+	apiBase string
+	token   func() string
+}
+
+// NewGitHubPRMergeResolver creates the production GitHub discovery adapter.
+// Public repositories work without a token; private repositories can use an
+// explicitly supplied CXT_GITHUB_TOKEN, GH_TOKEN, or GITHUB_TOKEN.
+func NewGitHubPRMergeResolver() *GitHubPRMergeResolver {
+	return newGitHubPRMergeResolver(
+		&http.Client{Timeout: githubResolveWindow},
+		githubAPIBase,
+		githubToken,
+	)
+}
+
+func newGitHubPRMergeResolver(client *http.Client, apiBase string, token func() string) *GitHubPRMergeResolver {
+	return &GitHubPRMergeResolver{
+		client:  client,
+		apiBase: strings.TrimRight(apiBase, "/"),
+		token:   token,
+	}
+}
+
+func githubToken() string {
+	for _, name := range []string{"CXT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"} {
+		if token := strings.TrimSpace(os.Getenv(name)); token != "" {
+			return token
+		}
+	}
+	return ""
+}
+
+type githubPullRequest struct {
+	Number         int     `json:"number"`
+	MergedAt       *string `json:"merged_at"`
+	MergeCommitSHA string  `json:"merge_commit_sha"`
+	Base           struct {
+		Ref  string `json:"ref"`
+		Repo *struct {
+			FullName string `json:"full_name"`
+		} `json:"repo"`
+	} `json:"base"`
+	Head struct {
+		Ref  string `json:"ref"`
+		Repo *struct {
+			FullName string `json:"full_name"`
+		} `json:"repo"`
+	} `json:"head"`
+}
+
+// ResolveMergedPullRequests lists recently closed PRs for the base branch and
+// matches GitHub's post-merge merge_commit_sha against incoming Git commits.
+// GitHub defines that field for merge, squash, and rebase merge methods.
+func (r *GitHubPRMergeResolver) ResolveMergedPullRequests(
+	ctx context.Context,
+	gitRemoteURL, baseBranch string,
+	commitSHAs []string,
+) ([]outbound.MergedPullRequest, error) {
+	owner, repo, ok := githubRepository(gitRemoteURL)
+	if !ok || baseBranch == "" || len(commitSHAs) == 0 {
+		return nil, nil
+	}
+
+	positions := make(map[string]int, len(commitSHAs))
+	for i, sha := range commitSHAs {
+		sha = strings.ToLower(strings.TrimSpace(sha))
+		if sha != "" {
+			positions[sha] = i
+		}
+	}
+	if len(positions) == 0 {
+		return nil, nil
+	}
+
+	resolveCtx, cancel := context.WithTimeout(ctx, githubResolveWindow)
+	defer cancel()
+
+	repoFullName := strings.ToLower(owner + "/" + repo)
+	found := make(map[int]outbound.MergedPullRequest)
+	for page := 1; page <= githubPRPageLimit; page++ {
+		endpoint, err := url.Parse(r.apiBase + "/repos/" + url.PathEscape(owner) + "/" + url.PathEscape(repo) + "/pulls")
+		if err != nil {
+			return nil, fmt.Errorf("github PR resolver: build endpoint: %w", err)
+		}
+		query := endpoint.Query()
+		query.Set("state", "closed")
+		query.Set("base", baseBranch)
+		query.Set("sort", "updated")
+		query.Set("direction", "desc")
+		query.Set("per_page", "100")
+		query.Set("page", fmt.Sprintf("%d", page))
+		endpoint.RawQuery = query.Encode()
+
+		var pulls []githubPullRequest
+		if err := r.getJSON(resolveCtx, endpoint.String(), &pulls); err != nil {
+			return nil, err
+		}
+		for _, pull := range pulls {
+			sha := strings.ToLower(strings.TrimSpace(pull.MergeCommitSHA))
+			if pull.MergedAt == nil || pull.Number <= 0 || pull.Base.Ref != baseBranch || pull.Head.Ref == "" {
+				continue
+			}
+			if _, wanted := positions[sha]; !wanted {
+				continue
+			}
+			// A fork PR cannot safely address a branch ref in the base cxt
+			// repository. Skipping also prevents same-name branch confusion.
+			if pull.Base.Repo == nil || pull.Head.Repo == nil ||
+				strings.ToLower(pull.Base.Repo.FullName) != repoFullName ||
+				strings.ToLower(pull.Head.Repo.FullName) != repoFullName {
+				continue
+			}
+			found[pull.Number] = outbound.MergedPullRequest{
+				Number:         pull.Number,
+				BaseBranch:     pull.Base.Ref,
+				HeadBranch:     pull.Head.Ref,
+				MergeCommitSHA: sha,
+			}
+		}
+		if len(pulls) < 100 {
+			break
+		}
+	}
+
+	out := make([]outbound.MergedPullRequest, 0, len(found))
+	for _, pull := range found {
+		out = append(out, pull)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		left, right := positions[out[i].MergeCommitSHA], positions[out[j].MergeCommitSHA]
+		if left != right {
+			return left < right
+		}
+		return out[i].Number < out[j].Number
+	})
+	return out, nil
+}
+
+func (r *GitHubPRMergeResolver) getJSON(ctx context.Context, endpoint string, out any) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return fmt.Errorf("github PR resolver: request: %w", err)
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", githubAPIVersion)
+	req.Header.Set("User-Agent", "cxt")
+	if r.token != nil {
+		if token := strings.TrimSpace(r.token()); token != "" {
+			req.Header.Set("Authorization", "Bearer "+token)
+		}
+	}
+
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("github PR resolver: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4<<10))
+		return fmt.Errorf("github PR resolver: GitHub API returned %s", resp.Status)
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 16<<20)).Decode(out); err != nil {
+		return fmt.Errorf("github PR resolver: decode response: %w", err)
+	}
+	return nil
+}
+
+func githubRepository(rawRemote string) (owner, repo string, ok bool) {
+	normalized := NormalizeRemoteURL(rawRemote)
+	const prefix = "github.com/"
+	if !strings.HasPrefix(normalized, prefix) {
+		return "", "", false
+	}
+	parts := strings.Split(strings.TrimPrefix(normalized, prefix), "/")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" ||
+		parts[0] == "." || parts[0] == ".." || parts[1] == "." || parts[1] == ".." {
+		return "", "", false
+	}
+	return parts[0], parts[1], true
+}
+
+var _ outbound.PullRequestMergeResolver = (*GitHubPRMergeResolver)(nil)

--- a/cli/internal/adapters/gitctx/pull_request_test.go
+++ b/cli/internal/adapters/gitctx/pull_request_test.go
@@ -1,0 +1,182 @@
+package gitctx
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func TestGitHubRepository(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		remote     string
+		owner      string
+		repo       string
+		wantParsed bool
+	}{
+		{name: "scp ssh", remote: "git@github.com:Acme/Project.git", owner: "acme", repo: "project", wantParsed: true},
+		{name: "https", remote: "https://github.com/Acme/Project.git", owner: "acme", repo: "project", wantParsed: true},
+		{name: "ssh url", remote: "ssh://git@github.com/Acme/Project.git", owner: "acme", repo: "project", wantParsed: true},
+		{name: "non github", remote: "git@gitlab.com:acme/project.git"},
+		{name: "nested path", remote: "https://github.com/acme/group/project.git"},
+		{name: "userinfo confusion", remote: "https://github.com@evil.example/acme/project.git"},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			owner, repo, ok := githubRepository(tt.remote)
+			if ok != tt.wantParsed || owner != tt.owner || repo != tt.repo {
+				t.Fatalf("githubRepository(%q) = (%q, %q, %v), want (%q, %q, %v)",
+					tt.remote, owner, repo, ok, tt.owner, tt.repo, tt.wantParsed)
+			}
+		})
+	}
+}
+
+func TestGitHubPRMergeResolver(t *testing.T) {
+	t.Parallel()
+
+	oldSHA := strings.Repeat("a", 40)
+	newSHA := strings.Repeat("b", 40)
+	var requests atomic.Int32
+	var authHeader atomic.Value
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		authHeader.Store(r.Header.Get("Authorization"))
+		if r.URL.Path != "/repos/acme/project/pulls" {
+			http.Error(w, "unexpected path", http.StatusNotFound)
+			return
+		}
+		for key, want := range map[string]string{
+			"state": "closed", "base": "main", "sort": "updated",
+			"direction": "desc", "per_page": "100",
+		} {
+			if got := r.URL.Query().Get(key); got != want {
+				http.Error(w, "bad query "+key, http.StatusBadRequest)
+				return
+			}
+		}
+		page, _ := strconv.Atoi(r.URL.Query().Get("page"))
+		if page == 1 {
+			pulls := make([]map[string]any, 100)
+			for i := range pulls {
+				pulls[i] = mergedPullJSON(1000+i, "main", "noise-"+strconv.Itoa(i), strings.Repeat("c", 39)+strconv.Itoa(i%10), "acme/project")
+			}
+			_ = json.NewEncoder(w).Encode(pulls)
+			return
+		}
+		if page != 2 {
+			http.Error(w, "unexpected page", http.StatusBadRequest)
+			return
+		}
+		_ = json.NewEncoder(w).Encode([]map[string]any{
+			mergedPullJSON(22, "main", "feature/new", newSHA, "acme/project"),
+			mergedPullJSON(21, "main", "feature/old", oldSHA, "acme/project"),
+			mergedPullJSON(23, "other", "wrong-base", oldSHA, "acme/project"),
+			mergedPullJSON(24, "main", "fork-branch", oldSHA, "fork/project"),
+			{
+				"number": 25, "merged_at": nil, "merge_commit_sha": oldSHA,
+				"base": map[string]any{"ref": "main", "repo": map[string]any{"full_name": "acme/project"}},
+				"head": map[string]any{"ref": "open", "repo": map[string]any{"full_name": "acme/project"}},
+			},
+		})
+	}))
+	defer server.Close()
+
+	resolver := newGitHubPRMergeResolver(server.Client(), server.URL, func() string { return "test-token" })
+	got, err := resolver.ResolveMergedPullRequests(
+		context.Background(),
+		"git@github.com:Acme/Project.git",
+		"main",
+		[]string{oldSHA, newSHA},
+	)
+	if err != nil {
+		t.Fatalf("ResolveMergedPullRequests: %v", err)
+	}
+	if requests.Load() != 2 {
+		t.Fatalf("requests = %d, want 2", requests.Load())
+	}
+	if authHeader.Load() != "Bearer test-token" {
+		t.Fatalf("Authorization = %q, want bearer token", authHeader.Load())
+	}
+	if len(got) != 2 {
+		t.Fatalf("resolved = %#v, want 2 PRs", got)
+	}
+	if got[0].Number != 21 || got[0].HeadBranch != "feature/old" || got[0].MergeCommitSHA != oldSHA {
+		t.Fatalf("first resolved PR = %#v, want oldest incoming PR #21", got[0])
+	}
+	if got[1].Number != 22 || got[1].HeadBranch != "feature/new" || got[1].MergeCommitSHA != newSHA {
+		t.Fatalf("second resolved PR = %#v, want newest incoming PR #22", got[1])
+	}
+}
+
+func TestGitHubPRMergeResolverUnsupportedRemoteDoesNotCallAPI(t *testing.T) {
+	t.Parallel()
+
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		requests.Add(1)
+	}))
+	defer server.Close()
+
+	resolver := newGitHubPRMergeResolver(server.Client(), server.URL, nil)
+	got, err := resolver.ResolveMergedPullRequests(
+		context.Background(),
+		"git@gitlab.com:acme/project.git",
+		"main",
+		[]string{strings.Repeat("a", 40)},
+	)
+	if err != nil || len(got) != 0 {
+		t.Fatalf("unsupported remote result = (%#v, %v), want empty success", got, err)
+	}
+	if requests.Load() != 0 {
+		t.Fatalf("API requests = %d, want 0", requests.Load())
+	}
+}
+
+func TestGitHubPRMergeResolverHTTPFailure(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "rate limited with secret details", http.StatusForbidden)
+	}))
+	defer server.Close()
+
+	resolver := newGitHubPRMergeResolver(server.Client(), server.URL, nil)
+	_, err := resolver.ResolveMergedPullRequests(
+		context.Background(),
+		"https://github.com/acme/project",
+		"main",
+		[]string{strings.Repeat("a", 40)},
+	)
+	if err == nil || !strings.Contains(err.Error(), "403 Forbidden") {
+		t.Fatalf("error = %v, want sanitized HTTP status", err)
+	}
+	if strings.Contains(err.Error(), "secret details") {
+		t.Fatalf("error leaked response body: %v", err)
+	}
+}
+
+func mergedPullJSON(number int, base, head, sha, headRepo string) map[string]any {
+	return map[string]any{
+		"number":           number,
+		"merged_at":        "2026-07-30T00:00:00Z",
+		"merge_commit_sha": sha,
+		"base": map[string]any{
+			"ref":  base,
+			"repo": map[string]any{"full_name": "acme/project"},
+		},
+		"head": map[string]any{
+			"ref":  head,
+			"repo": map[string]any{"full_name": headRepo},
+		},
+	}
+}

--- a/cli/internal/ports/outbound/ports.go
+++ b/cli/internal/ports/outbound/ports.go
@@ -138,6 +138,22 @@ type GitContext interface {
 	CurrentBranch(ctx context.Context, cwd string) (string, error)
 }
 
+// MergedPullRequest identifies a Git-host PR whose merge commit entered the
+// currently checked-out base branch.
+type MergedPullRequest struct {
+	Number         int
+	BaseBranch     string
+	HeadBranch     string
+	MergeCommitSHA string
+}
+
+// PullRequestMergeResolver maps incoming Git commits back to merged pull
+// requests. It is provider-specific discovery only; context promotion remains
+// in the SyncRepo use case.
+type PullRequestMergeResolver interface {
+	ResolveMergedPullRequests(ctx context.Context, gitRemoteURL, baseBranch string, commitSHAs []string) ([]MergedPullRequest, error)
+}
+
 // RemoteSync is the sync port to the central server (domain model).
 //
 // Transfers only missing parts (push/pull) based on content-hash. Mimics git push/pull.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,55 @@
+# Deploying CXTHub
+
+The production template runs the web application on Vercel and `cxtd` on
+Cloud Run with PostgreSQL. It is an operator-run template, not an automatic
+deployment performed by the release workflow.
+
+## Runtime secrets
+
+Create these Google Secret Manager secrets before applying Terraform:
+
+| Default secret ID | Runtime environment variable | Value |
+|---|---|---|
+| `cxt-postgres-dsn` | `CXT_POSTGRES_DSN` | PostgreSQL connection string |
+| `cxt-github-webhook-secret` | `CXT_GITHUB_WEBHOOK_SECRET` | Random GitHub webhook HMAC secret |
+
+Secret versions are intentionally managed outside Terraform so their plaintext
+does not enter Terraform state. The Terraform stack looks up only secret
+metadata, grants the Cloud Run service account access, and injects `latest`.
+Use `postgres_secret_id` or `github_webhook_secret_id` to override the default
+IDs.
+
+Run the read-only readiness check before applying:
+
+```bash
+scripts/deploy-preflight.sh ready
+```
+
+It fails closed when either secret is absent or has no enabled version.
+
+## GitHub pull-request webhook
+
+Each GitHub repository whose context is hosted by this deployment needs one
+repository webhook:
+
+- Payload URL: `https://<domain>/api/v1/hooks/github`
+- Content type: `application/json`
+- Secret: the exact value stored in `cxt-github-webhook-secret`
+- Events: select **Pull requests**
+- Active: enabled
+
+On a same-repository PR `closed` event with `merged: true`, `cxtd` appends the
+head context branch tip to the base context branch. This preserves the source
+branch and immutable natural snapshot parents; the append is represented by
+the existing graft overlay and is idempotent.
+
+Fork PR heads are ignored because a fork's Git branch cannot safely identify a
+branch ref in the base CXTHub repository. If webhook delivery is unavailable,
+the installed local `post-merge` hook performs a best-effort GitHub API
+fallback after the merged base branch is pulled. Public repositories need no
+GitHub token; private repositories may explicitly provide
+`CXT_GITHUB_TOKEN`, `GH_TOKEN`, or `GITHUB_TOKEN` with pull-request read access.
+
+The receiver returns `404` when `CXT_GITHUB_WEBHOOK_SECRET` is absent and
+`401` when `X-Hub-Signature-256` does not match. Never configure a webhook
+without the shared secret.

--- a/deploy/terraform/cloudrun.tf
+++ b/deploy/terraform/cloudrun.tf
@@ -65,6 +65,15 @@ resource "google_cloud_run_v2_service" "cxtd" {
         }
       }
       env {
+        name = "CXT_GITHUB_WEBHOOK_SECRET"
+        value_source {
+          secret_key_ref {
+            secret  = data.google_secret_manager_secret.github_webhook.secret_id
+            version = "latest"
+          }
+        }
+      }
+      env {
         name  = "CXT_MIGRATIONS_DIR"
         value = "/app/migrations"
       }
@@ -99,7 +108,10 @@ resource "google_cloud_run_v2_service" "cxtd" {
     }
   }
 
-  depends_on = [google_secret_manager_secret_iam_member.cxtd_postgres]
+  depends_on = [
+    google_secret_manager_secret_iam_member.cxtd_postgres,
+    google_secret_manager_secret_iam_member.cxtd_github_webhook,
+  ]
 }
 
 # Allow unauthenticated public calls (authentication is handled by the app layer — session/token/role gates are responsible).

--- a/deploy/terraform/neon.tf
+++ b/deploy/terraform/neon.tf
@@ -1,14 +1,20 @@
-# Neon credential is not created or read by Terraform. The provider's computed password is not stored in plain text in the tfstate.
-# google_secret_manager_secret_version.secret_data remains in plain text in the tfstate.
+# Runtime credentials are not created or read by Terraform.
+# google_secret_manager_secret_version.secret_data would remain in plain text in the tfstate.
 #
 # Bootstrap sequence:
 #   1. Create project/database/least-privilege role in Neon.
-#   2. Create var.postgres_secret_id in Secret Manager and inject the DSN as a version.
+#   2. Create var.postgres_secret_id and var.github_webhook_secret_id in Secret Manager,
+#      then inject the DSN and webhook HMAC value as enabled versions.
 #   3. Terraform manages only the metadata lookup and IAM binding.
 
 data "google_secret_manager_secret" "postgres_dsn" {
   project   = var.gcp_project
   secret_id = var.postgres_secret_id
+}
+
+data "google_secret_manager_secret" "github_webhook" {
+  project   = var.gcp_project
+  secret_id = var.github_webhook_secret_id
 }
 
 resource "google_service_account" "cxtd" {
@@ -19,6 +25,13 @@ resource "google_service_account" "cxtd" {
 resource "google_secret_manager_secret_iam_member" "cxtd_postgres" {
   project   = var.gcp_project
   secret_id = data.google_secret_manager_secret.postgres_dsn.secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.cxtd.email}"
+}
+
+resource "google_secret_manager_secret_iam_member" "cxtd_github_webhook" {
+  project   = var.gcp_project
+  secret_id = data.google_secret_manager_secret.github_webhook.secret_id
   role      = "roles/secretmanager.secretAccessor"
   member    = "serviceAccount:${google_service_account.cxtd.email}"
 }

--- a/deploy/terraform/outputs.tf
+++ b/deploy/terraform/outputs.tf
@@ -12,6 +12,16 @@ output "postgres_secret" {
   value       = data.google_secret_manager_secret.postgres_dsn.secret_id
 }
 
+output "github_webhook_secret" {
+  description = "GitHub webhook Secret Manager secret ID referenced by Cloud Run (value is not output)."
+  value       = data.google_secret_manager_secret.github_webhook.secret_id
+}
+
+output "github_webhook_url" {
+  description = "Payload URL for the GitHub pull_request webhook."
+  value       = "https://${var.domain}/api/v1/hooks/github"
+}
+
 output "dns_records" {
   description = "Instructions for the record to be entered at the domain registrar. The exact value for the project is determined by `vercel domains inspect`."
   value = {

--- a/deploy/terraform/terraform.tfvars.example
+++ b/deploy/terraform/terraform.tfvars.example
@@ -9,6 +9,11 @@ firebase_project = "replace-with-firebase-project"
 # but it still requires Google Cloud API and web-referrer restrictions.
 firebase_web_api_key = "replace-with-firebase-web-api-key"
 
+# Secret values are created outside Terraform. Override only when using
+# non-default Secret Manager IDs.
+# postgres_secret_id       = "cxt-postgres-dsn"
+# github_webhook_secret_id = "cxt-github-webhook-secret"
+
 # The default value is <firebase_project>.firebaseapp.com.
 # firebase_auth_domain = "replace-with-firebase-project.firebaseapp.com"
 

--- a/deploy/terraform/variables.tf
+++ b/deploy/terraform/variables.tf
@@ -89,6 +89,17 @@ variable "postgres_secret_id" {
   }
 }
 
+variable "github_webhook_secret_id" {
+  description = "GitHub PR webhook HMAC secret ID pre-injected into Secret Manager. The secret version is managed outside Terraform."
+  type        = string
+  default     = "cxt-github-webhook-secret"
+
+  validation {
+    condition     = can(regex("^[A-Za-z0-9_-]{1,255}$", var.github_webhook_secret_id))
+    error_message = "github_webhook_secret_id must be a Secret Manager ID containing only letters, numbers, hyphens, and underscores."
+  }
+}
+
 variable "vercel_team_id" {
   description = "Vercel team ID (team_…). null for individual accounts. Do not include slugs or usernames."
   type        = string

--- a/scripts/deploy-preflight.sh
+++ b/scripts/deploy-preflight.sh
@@ -279,7 +279,7 @@ ready_check() {
   require_env TF_VAR_firebase_web_api_key
   reject_placeholder TF_VAR_firebase_web_api_key
 
-  local head remote required enabled api postgres_secret region image
+  local head remote required enabled api postgres_secret github_webhook_secret region image
   head="$(git -C "$ROOT" rev-parse HEAD)"
   [ "$TF_VAR_image_tag" = "$head" ] || die "TF_VAR_image_tag is not the current HEAD"
   [ -z "$(git -C "$ROOT" status --porcelain)" ] || die "Working tree is not clean"
@@ -297,7 +297,11 @@ ready_check() {
   gcloud secrets describe "$postgres_secret" --project "$TF_VAR_gcp_project" >/dev/null
   [ -n "$(gcloud secrets versions list "$postgres_secret" --project "$TF_VAR_gcp_project" --filter='state=ENABLED' --limit=1 --format='value(name)')" ] \
     || die "No ENABLED version in $postgres_secret"
-  pass "GCP API/state bucket/Postgres secret metadata verified"
+  github_webhook_secret="${TF_VAR_github_webhook_secret_id:-cxt-github-webhook-secret}"
+  gcloud secrets describe "$github_webhook_secret" --project "$TF_VAR_gcp_project" >/dev/null
+  [ -n "$(gcloud secrets versions list "$github_webhook_secret" --project "$TF_VAR_gcp_project" --filter='state=ENABLED' --limit=1 --format='value(name)')" ] \
+    || die "No ENABLED version in $github_webhook_secret"
+  pass "GCP API/state bucket/Postgres and GitHub webhook secret metadata verified"
 
   region="${TF_VAR_gcp_region:-asia-northeast3}"
   image="${region}-docker.pkg.dev/${TF_VAR_gcp_project}/cxthub/cxtd:${TF_VAR_image_tag}"


### PR DESCRIPTION
## Summary

- resolve GitHub merge, squash, and rebase results during the local `post-merge` fallback and append each source cxt branch tip to the checked-out base branch
- harden the signed GitHub webhook against cross-fork branch-name confusion and cover signature, filtering, idempotency, and diverged overlay promotion end to end
- inject the webhook HMAC secret into Cloud Run from Secret Manager, fail deployment preflight when it is missing, and document repository webhook setup

Natural snapshot parents remain immutable. Promotion uses the existing append/graft overlay, preserves source branch refs, and treats duplicate local/webhook delivery as an idempotent no-op.

## Verification

- `go test ./... && go vet ./...` in `backend/`
- `go test -tags postgres ./...` in `backend/`
- `go test ./... && go vet ./...` in `cli/`
- `scripts/deploy-preflight.sh static`
- `make e2e-sync`
- Terraform `fmt`, `validate`, and `test`
- dogfood `cxt`/`cxtd` install + daemon health check
- current PR #12–#17 context tips backfilled as an ordered overlay chain; server/local convergence 6/6, natural parents unchanged, current `main` tip unchanged

Closes #18
