### PR TITLE
fix(memory): preserve encrypted Codex compaction context

### DIFF
--- a/cli/internal/adapters/boundary/boundary.go
+++ b/cli/internal/adapters/boundary/boundary.go
@@ -40,7 +40,10 @@ func boundaryPath(repoRoot string) string { return filepath.Join(repoRoot, ".cxt
 
 // Record logs the boundary (keeps only the last transition — wrapper/enforcement care only about the latest boundary).
 func Record(repoRoot string, b Boundary) error {
-	b.At = time.Now().UTC().Format(time.RFC3339)
+	// Preserve sub-second ordering. The wrapper records its child start time with
+	// nanosecond precision; RFC3339 second truncation can make a newly written
+	// boundary appear older than a child started earlier in the same second.
+	b.At = time.Now().UTC().Format(time.RFC3339Nano)
 	normalized, ok := validateBoundary(b)
 	if !ok || len(normalized.Superseded) != len(b.Superseded) {
 		return fmt.Errorf("invalid context boundary")

--- a/cli/internal/adapters/boundary/boundary_test.go
+++ b/cli/internal/adapters/boundary/boundary_test.go
@@ -1,0 +1,25 @@
+package boundary
+
+import (
+	"testing"
+	"time"
+)
+
+func TestBoundaryTimestampPreservesSubsecondOrdering(t *testing.T) {
+	start := time.Now().UTC()
+	root := t.TempDir()
+	if err := Record(root, Boundary{Branch: "main"}); err != nil {
+		t.Fatal(err)
+	}
+	b, ok := Load(root)
+	if !ok {
+		t.Fatal("recorded boundary did not load")
+	}
+	at, err := time.Parse(time.RFC3339, b.At)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !at.After(start) {
+		t.Fatalf("boundary timestamp %s is not after start %s", at, start)
+	}
+}

--- a/cli/internal/adapters/delivery/cli/agent_wrapper.go
+++ b/cli/internal/adapters/delivery/cli/agent_wrapper.go
@@ -55,7 +55,11 @@ func runAgentWrapper(ctx context.Context, c *Container, cwd, agent string, args 
 		start := time.Now()
 		child := exec.Command(bin, args...)
 		child.Stdin, child.Stdout, child.Stderr = os.Stdin, os.Stdout, os.Stderr
-		child.Env = append(os.Environ(), "CXT_WRAPPED=1")
+		child.Env = append(os.Environ(),
+			"CXT_WRAPPED=1",
+			fmt.Sprintf("CXT_WRAPPER_PID=%d", os.Getpid()),
+			"CXT_WRAPPED_AGENT="+agent,
+		)
 		if err := child.Start(); err != nil {
 			return err
 		}

--- a/cli/internal/adapters/delivery/cli/agent_wrapper_ancestry_test.go
+++ b/cli/internal/adapters/delivery/cli/agent_wrapper_ancestry_test.go
@@ -1,0 +1,61 @@
+package cli
+
+import (
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/wnsdy95/cxthub/cli/internal/domain"
+)
+
+func TestHasProcessAncestor(t *testing.T) {
+	parents := map[int]int{50: 40, 40: 30, 30: 1, 70: 60, 60: 1}
+	parent := func(pid int) (int, bool) {
+		ppid, ok := parents[pid]
+		return ppid, ok
+	}
+	if !hasProcessAncestor(50, 30, parent) {
+		t.Fatal("owning wrapper ancestor was not recognized")
+	}
+	if hasProcessAncestor(50, 60, parent) {
+		t.Fatal("unrelated live wrapper was accepted")
+	}
+	if hasProcessAncestor(50, 99, parent) {
+		t.Fatal("missing/stale wrapper was accepted")
+	}
+	if hasProcessAncestor(1, 1, parent) {
+		t.Fatal("init PID must never be accepted as a wrapper")
+	}
+}
+
+func TestHasProcessAncestorFailsClosedOnCycle(t *testing.T) {
+	parent := func(pid int) (int, bool) {
+		if pid == 10 {
+			return 20, true
+		}
+		return 10, true
+	}
+	if hasProcessAncestor(10, 99, parent) {
+		t.Fatal("cyclic process ancestry accepted an unrelated wrapper")
+	}
+}
+
+func TestSupervisedProviderRequiresOwningWrapperPID(t *testing.T) {
+	t.Setenv("CXT_WRAPPED", "1")
+	t.Setenv("CXT_WRAPPED_AGENT", "codex")
+	t.Setenv("CXT_WRAPPER_PID", strconv.Itoa(os.Getppid()))
+	provider, managed := supervisedProvider()
+	if provider != domain.ProviderCodex || !managed {
+		t.Fatalf("provider=%q managed=%v, want codex/true", provider, managed)
+	}
+
+	t.Setenv("CXT_WRAPPER_PID", "99999999")
+	if _, managed := supervisedProvider(); managed {
+		t.Fatal("stale wrapper PID was accepted")
+	}
+
+	t.Setenv("CXT_WRAPPER_PID", "")
+	if _, managed := supervisedProvider(); managed {
+		t.Fatal("missing wrapper PID was accepted")
+	}
+}

--- a/cli/internal/adapters/delivery/cli/githook.go
+++ b/cli/internal/adapters/delivery/cli/githook.go
@@ -22,6 +22,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -184,6 +185,7 @@ func contextSwitch(ctx context.Context, c *Container, cwd string) error {
 	branch := gitOut(cwd, "rev-parse", "--abbrev-ref", "HEAD")
 	prevBranch := gitOut(cwd, "rev-parse", "--abbrev-ref", "@{-1}")
 	detached := branch == "" || branch == "HEAD"
+	targetProvider, wrapperManaged := supervisedProvider()
 
 	// 1) Checkpoint: snapshot and push (best-effort) the live sessions from the previous branch.
 	//    Ensure isolation target file paths here (direct use of capture adapter — hook-specific paths).
@@ -266,7 +268,7 @@ func contextSwitch(ctx context.Context, c *Container, cwd string) error {
 		}
 		if lerr == nil && (len(existing.Snapshots) > 0 || hasRef) {
 			// Existing branch: load context of that task (current context is not carried).
-			if out, err := c.Checkout.Checkout(ctx, inbound.CheckoutInput{From: branch, Mode: hookLoadMode(cwd), Cwd: cwd}); err == nil {
+			if out, err := c.Checkout.Checkout(ctx, inbound.CheckoutInput{From: branch, TargetProvider: targetProvider, Mode: hookLoadMode(cwd), Cwd: cwd}); err == nil {
 				b.SeedPath, b.ResumeCmd = out.WrittenPath, out.ResumeCmd
 				b.SeedID = sessionIDFromPath(out.WrittenPath)
 				fmt.Printf("cxt: %q context prepared  [fidelity: %s]\n", branch, out.Fidelity)
@@ -274,8 +276,9 @@ func contextSwitch(ctx context.Context, c *Container, cwd string) error {
 			}
 		} else if prevBranch != "" && prevBranch != branch {
 			// New branch: seed genesis — main memory ⊕ ancestry summary + previous commit raw tail.
-			if out, err := c.Seed.Seed(ctx, inbound.SeedInput{Cwd: cwd, FromBranch: prevBranch, NewBranch: branch, Author: c.Identity}); err == nil {
-				b.SeedPath, b.ResumeCmd, b.SeedID = out.WrittenPath, out.ResumeCmd, out.SessionID
+			if out, err := c.Seed.Seed(ctx, inbound.SeedInput{Cwd: cwd, FromBranch: prevBranch, NewBranch: branch, Provider: targetProvider, Author: c.Identity}); err == nil {
+				b.SeedPath, b.ResumeCmd = out.WrittenPath, out.ResumeCmd
+				b.SeedID = sessionIDFromPath(out.WrittenPath)
 				fmt.Printf("cxt: seed created → branch %q (snapshot %s)\n", branch, shortHash(out.SnapshotID))
 				if _, ok := remotecfg.Origin(cwd); ok {
 					if _, perr := c.Sync.Push(ctx, inbound.SyncInput{Cwd: cwd}); perr != nil && strings.Contains(perr.Error(), domain.ErrSyncConflict.Error()) {
@@ -296,7 +299,7 @@ func contextSwitch(ctx context.Context, c *Container, cwd string) error {
 			fmt.Println("cxt: ⚠ Context switch — previous session is isolated (not recorded)")
 		}
 		boundary.Notify("cxt Context switch", fmt.Sprintf("%s → %s — previous session isolated, new context prepared", b.PrevBranch, b.Branch))
-		if len(superseded) > 0 && remotecfg.BoundaryEnforce(cwd) == "kill" {
+		if len(superseded) > 0 && remotecfg.BoundaryEnforce(cwd) == "kill" && wrapperManaged {
 			// Detach session agent delay end — detached helper (hook can be a descendant of the agent, so it cannot be killed immediately). The wrapper (cxt claude) detects child death and automatically restarts the seed.
 			if exe, err := os.Executable(); err == nil {
 				cmd := exec.Command(exe, "git-hook", "boundary-enforce")
@@ -304,9 +307,58 @@ func contextSwitch(ctx context.Context, c *Container, cwd string) error {
 				cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
 				_ = cmd.Start()
 			}
+		} else if len(superseded) > 0 && remotecfg.BoundaryEnforce(cwd) == "kill" {
+			hookWarn("no live owning cxt wrapper — active agent was not terminated; continue explicitly with %s", b.ResumeCmd)
 		}
 	}
 	return nil
+}
+
+// supervisedProvider returns the provider owned by the live cxt wrapper in the
+// current process ancestry. A boolean environment marker alone is insufficient:
+// resumed shells and app integrations can retain CXT_WRAPPED after the original
+// supervisor has exited, which previously caused an unrestartable boundary kill.
+func supervisedProvider() (domain.ProviderKind, bool) {
+	agent := domain.ProviderKind(os.Getenv("CXT_WRAPPED_AGENT"))
+	if agent != domain.ProviderClaude && agent != domain.ProviderCodex {
+		agent = domain.ProviderClaude
+	}
+	if os.Getenv("CXT_WRAPPED") != "1" {
+		return agent, false
+	}
+	wrapperPID, err := strconv.Atoi(os.Getenv("CXT_WRAPPER_PID"))
+	if err != nil || wrapperPID <= 1 {
+		return agent, false
+	}
+	return agent, hasProcessAncestor(os.Getppid(), wrapperPID, processParentPID)
+}
+
+func processParentPID(pid int) (int, bool) {
+	out, err := exec.Command("ps", "-o", "ppid=", "-p", strconv.Itoa(pid)).Output()
+	if err != nil {
+		return 0, false
+	}
+	ppid, err := strconv.Atoi(strings.TrimSpace(string(out)))
+	return ppid, err == nil && ppid > 0
+}
+
+func hasProcessAncestor(start, want int, parent func(int) (int, bool)) bool {
+	if start <= 1 || want <= 1 {
+		return false
+	}
+	seen := map[int]bool{}
+	for pid, depth := start, 0; pid > 1 && depth < 64 && !seen[pid]; depth++ {
+		if pid == want {
+			return true
+		}
+		seen[pid] = true
+		next, ok := parent(pid)
+		if !ok {
+			return false
+		}
+		pid = next
+	}
+	return false
 }
 
 // hookLoadMode is the load fidelity of the hook path (no flag): local load.mode > server personal setting.

--- a/cli/internal/adapters/memory/distiller.go
+++ b/cli/internal/adapters/memory/distiller.go
@@ -81,14 +81,102 @@ func (d *RuleDistiller) Distill(_ context.Context, cir domain.CIRDocument, nativ
 			Provider: prov,
 		}, nil
 	}
-	// Storage artifacts (team sharing, agent injection) are the English data layer — independent of UI language.
-	summary := fmt.Sprintf("session summary: branch %q · %d user / %d assistant messages · tools %v · first request: %q",
-		cir.Envelope.GitBranch, userMsgs, asstMsgs, tools, truncate(firstUser, 120))
+	// Codex compaction bodies can be provider-encrypted while payload.message is
+	// empty. The raw CIR is still losslessly available, so preserve a bounded
+	// extractive digest of meaningful conversation instead of reducing memory to
+	// counters and tool names. This is intentionally deterministic: content hashes
+	// must not depend on an external model or provider-owned decryption.
+	summary := extractiveConversationDigest(cir.Events)
+	if summary == "" {
+		// Empty/non-conversational documents retain the old diagnostic fallback.
+		// Storage artifacts are the English data layer, independent of UI language.
+		summary = fmt.Sprintf("session summary: branch %q · %d user / %d assistant messages · tools %v · first request: %q",
+			cir.Envelope.GitBranch, userMsgs, asstMsgs, tools, truncate(firstUser, 120))
+	}
 	return domain.MemoryDigest{
 		Summary:  summary,
-		KeyFacts: tools,
 		Provider: prov,
 	}, nil
+}
+
+const (
+	extractiveDigestMaxRunes = 16000
+	extractiveItemMaxRunes   = 2000
+	extractiveItemsPerRole   = 6
+)
+
+// extractiveConversationDigest preserves recent user intent and assistant
+// outcomes when the provider's own compaction summary is unavailable. Tool
+// calls/results and compact-summary events are excluded; the latter already
+// have a higher-priority path above and synthetic branch seeds can be very
+// large. Selection is recent-first but rendered chronologically.
+func extractiveConversationDigest(events []domain.Event) string {
+	var users, assistants []string
+	for _, ev := range events {
+		if ev.Kind != domain.EventMessage || ev.CompactSummary {
+			continue
+		}
+		text := messageText(ev.Blocks)
+		if text == "" || isSyntheticSeedText(text) {
+			continue
+		}
+		switch ev.Role {
+		case "user":
+			users = appendRecentDistinct(users, text, extractiveItemsPerRole)
+		case "assistant":
+			assistants = appendRecentDistinct(assistants, text, extractiveItemsPerRole)
+		}
+	}
+	if len(users) == 0 && len(assistants) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("Conversation digest (extractive fallback; provider compaction summary unavailable):\n")
+	writeExtractiveSection(&b, "Recent user intent", users)
+	writeExtractiveSection(&b, "Recent assistant outcomes", assistants)
+	return truncate(strings.TrimSpace(b.String()), extractiveDigestMaxRunes-1)
+}
+
+func messageText(blocks []domain.ContentBlock) string {
+	var parts []string
+	for _, block := range blocks {
+		if block.Type != "text" || strings.TrimSpace(block.Text) == "" {
+			continue
+		}
+		parts = append(parts, strings.TrimSpace(block.Text))
+	}
+	return strings.Join(parts, "\n")
+}
+
+func isSyntheticSeedText(text string) bool {
+	return strings.HasPrefix(strings.TrimSpace(text), "[cxt seed] Branch-switch context:")
+}
+
+func appendRecentDistinct(items []string, text string, limit int) []string {
+	text = strings.Join(strings.Fields(text), " ")
+	text = truncate(text, extractiveItemMaxRunes)
+	if text == "" || (len(items) > 0 && items[len(items)-1] == text) {
+		return items
+	}
+	items = append(items, text)
+	if len(items) > limit {
+		items = items[len(items)-limit:]
+	}
+	return items
+}
+
+func writeExtractiveSection(b *strings.Builder, title string, items []string) {
+	if len(items) == 0 {
+		return
+	}
+	b.WriteString("\n\n")
+	b.WriteString(title)
+	b.WriteString(":\n")
+	for _, item := range items {
+		b.WriteString("- ")
+		b.WriteString(item)
+		b.WriteByte('\n')
+	}
 }
 
 // extractSummarySections extracts the top-level bullets from the KeyFacts ("Key Technical Concepts") and OpenTasks ("Pending Tasks") sections of a compression summary. It accumulates summaries, so it writes the last occurrence of each section. For unstructured text, it returns an empty result (fallback for the caller). Deterministic.

--- a/cli/internal/adapters/memory/distiller_test.go
+++ b/cli/internal/adapters/memory/distiller_test.go
@@ -2,6 +2,7 @@ package memory
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -128,5 +129,76 @@ func TestDistillNoProvenanceMarkerInFacts(t *testing.T) {
 		if strings.HasPrefix(f, "native memory:") {
 			t.Fatalf("source marker mixed with KeyFacts: %q", f)
 		}
+	}
+}
+
+func TestDistillExtractiveFallbackPreservesRecentIntentAndOutcomes(t *testing.T) {
+	cir := domain.CIRDocument{}
+	cir.Envelope.SourceProvider = domain.ProviderCodex
+	cir.Envelope.CompactionCount = 2 // plaintext message unavailable (encrypted provider payload)
+	cir.Events = []domain.Event{
+		{Kind: domain.EventMessage, Role: "user", Blocks: []domain.ContentBlock{{Type: "text", Text: "[cxt seed] Branch-switch context: main → fix/x\n" + strings.Repeat("old seed ", 5000)}}},
+		{Kind: domain.EventToolCall, ToolName: "apply_patch"},
+		{Kind: domain.EventToolResult, Output: "noisy tool output"},
+		{Kind: domain.EventMessage, Role: "user", Blocks: []domain.ContentBlock{{Type: "text", Text: "Find why compacted memory is lost."}}},
+		{Kind: domain.EventMessage, Role: "assistant", Blocks: []domain.ContentBlock{{Type: "text", Text: "Chunk storage is lossless; the plaintext compaction message is empty."}}},
+		{Kind: domain.EventMessage, Role: "user", Blocks: []domain.ContentBlock{{Type: "text", Text: "Fix it without decrypting provider content."}}},
+		{Kind: domain.EventMessage, Role: "assistant", Blocks: []domain.ContentBlock{{Type: "text", Text: "Use a deterministic extractive fallback from preserved CIR."}}},
+	}
+
+	d, err := NewRuleDistiller().Distill(context.Background(), cir, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"Recent user intent",
+		"Find why compacted memory is lost.",
+		"Fix it without decrypting provider content.",
+		"Recent assistant outcomes",
+		"Chunk storage is lossless",
+		"deterministic extractive fallback",
+	} {
+		if !strings.Contains(d.Summary, want) {
+			t.Fatalf("summary missing %q:\n%s", want, d.Summary)
+		}
+	}
+	for _, unwanted := range []string{"[cxt seed]", "apply_patch", "noisy tool output", "tools ["} {
+		if strings.Contains(d.Summary, unwanted) {
+			t.Fatalf("summary contains noise %q:\n%s", unwanted, d.Summary)
+		}
+	}
+	if len([]rune(d.Summary)) > extractiveDigestMaxRunes {
+		t.Fatalf("summary exceeds bound: %d", len([]rune(d.Summary)))
+	}
+	if len(d.KeyFacts) != 0 {
+		t.Fatalf("tool names leaked into key facts: %v", d.KeyFacts)
+	}
+}
+
+func TestDistillExtractiveFallbackIsRecentBoundedAndDeterministic(t *testing.T) {
+	cir := domain.CIRDocument{}
+	cir.Envelope.SourceProvider = domain.ProviderCodex
+	for i := 0; i < 20; i++ {
+		cir.Events = append(cir.Events,
+			domain.Event{Kind: domain.EventMessage, Role: "user", Blocks: []domain.ContentBlock{{Type: "text", Text: fmt.Sprintf("request-%02d %s", i, strings.Repeat("x", 3000))}}},
+			domain.Event{Kind: domain.EventMessage, Role: "assistant", Blocks: []domain.ContentBlock{{Type: "text", Text: fmt.Sprintf("outcome-%02d %s", i, strings.Repeat("y", 3000))}}},
+		)
+	}
+	first, err := NewRuleDistiller().Distill(context.Background(), cir, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := NewRuleDistiller().Distill(context.Background(), cir, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.Summary != second.Summary {
+		t.Fatal("extractive fallback is not deterministic")
+	}
+	if strings.Contains(first.Summary, "request-00") || !strings.Contains(first.Summary, "request-19") {
+		t.Fatalf("fallback did not retain the recent bounded window")
+	}
+	if len([]rune(first.Summary)) > extractiveDigestMaxRunes {
+		t.Fatalf("summary exceeds bound: %d", len([]rune(first.Summary)))
 	}
 }

--- a/cli/internal/app/branch_seed.go
+++ b/cli/internal/app/branch_seed.go
@@ -161,6 +161,12 @@ func (s *BranchSeedService) Seed(ctx context.Context, in inbound.SeedInput) (inb
 				if path, resume, mErr := mat.Materialize(ctx, raw, in.Cwd); mErr == nil {
 					_ = providerfs.RecordMaterialized(in.Cwd, path)
 					out.WrittenPath, out.ResumeCmd = path, resume
+					// Materializers rewrite provider-native session IDs to avoid
+					// colliding with the source session. The restart target is the
+					// rewritten ID, not the synthetic CIR origin ID.
+					if fields := strings.Fields(resume); len(fields) > 0 && providerfs.ValidSessionID(fields[len(fields)-1]) {
+						out.SessionID = fields[len(fields)-1]
+					}
 				}
 			}
 		}

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -412,7 +412,7 @@ Reading a key prints its effective local value. Supported keys are:
 |---|---|---|---|
 | `checkout.mode` | `auto`, `prepare` | `auto` | Restore automatically or only prepare the resume action after Git checkout |
 | `load.mode` | `full`, `reconstructed`, `memory`, `default` | `full` | Default restore fidelity; `default` clears the local override |
-| `boundary.enforce` | `kill`, `none`, `default` | `kill` | Enforce process isolation across context switches |
+| `boundary.enforce` | `kill`, `none`, `default` | `kill` | Enforce process isolation across context switches when a live owning `cxt claude`/`cxt codex` wrapper can restart the prepared seed; unmanaged sessions are not killed and receive an explicit resume command |
 | `capture.debounce` | non-negative seconds, `default` | 60 seconds | Minimum interval for repeated Stop-event captures |
 | `secrets.scrub` | `off`, `standard`, `strict`, `default` | `standard` | Pattern-based scrub tier |
 | `secrets.redact` | replacement text, `default` | built-in redaction token | Exact-secret replacement text |

--- a/scripts/e2e-sync.sh
+++ b/scripts/e2e-sync.sh
@@ -198,6 +198,7 @@ expect "Boundary record" "$([ -f .cxt/boundary.json ] && echo yes)" yes
 SEED=$(python3 -c "import json;print(json.load(open('.cxt/boundary.json')).get('seed_path',''))")
 SEEDID=$(python3 -c "import json;print(json.load(open('.cxt/boundary.json')).get('seed_id',''))")
 expect "seed materialization" "$([ -n "$SEED" ] && [ -f "$SEED" ] && echo yes)" yes
+expect "boundary seed ID matches materialized resume target" "$(basename "$SEED" .jsonl)" "$SEEDID"
 SEEDMSG=$(python3 -c "
 import json,glob
 tgt=open('.cxt/refs/heads/feature-x').read().strip()


### PR DESCRIPTION
## Summary

- replace the count/tool-only memory fallback with a deterministic bounded extractive digest of recent user intent and assistant outcomes when Codex compaction plaintext is unavailable
- keep plaintext compact summaries and native memory at higher priority, while filtering tool noise and synthetic branch-seed boilerplate
- bind branch transition enforcement to a live owning wrapper PID and preserve sub-second boundary ordering
- materialize branch seeds for the supervised agent and restart with the actual provider-rewritten session ID

## Why

Codex currently stores its useful compaction body as provider-encrypted content while `payload.message` is empty. cxt cannot and should not decrypt it. The raw CIR remains lossless, but the former fallback reduced it to message counts and tool names before branch-seed trimming, causing practical context loss.

Separately, stale `CXT_WRAPPED=1` environments and mismatched seed provider/session IDs could terminate Codex without a valid supervisor restart path.

## Validation

- `go build ./... && go vet ./... && go test ./...` (CLI)
- `bash scripts/public-preflight.sh tree`
- `./scripts/e2e-sync.sh` including wrapper restart and materialized seed-ID equality
- updated CLI installed locally for dogfooding

Closes #21
Closes #22
