### PR TITLE
fix(wrapper): preserve Codex boundary resume ID

### DIFF
--- a/cli/internal/adapters/delivery/cli/githook.go
+++ b/cli/internal/adapters/delivery/cli/githook.go
@@ -270,7 +270,7 @@ func contextSwitch(ctx context.Context, c *Container, cwd string) error {
 			// Existing branch: load context of that task (current context is not carried).
 			if out, err := c.Checkout.Checkout(ctx, inbound.CheckoutInput{From: branch, TargetProvider: targetProvider, Mode: hookLoadMode(cwd), Cwd: cwd}); err == nil {
 				b.SeedPath, b.ResumeCmd = out.WrittenPath, out.ResumeCmd
-				b.SeedID = sessionIDFromPath(out.WrittenPath)
+				b.SeedID = restoredSessionID(out.WrittenPath, out.ResumeCmd, "")
 				fmt.Printf("cxt: %q context prepared  [fidelity: %s]\n", branch, out.Fidelity)
 				syncSettingsToSnapshot(ctx, c, cwd, out.Head, "git checkout "+branch)
 			}
@@ -278,7 +278,7 @@ func contextSwitch(ctx context.Context, c *Container, cwd string) error {
 			// New branch: seed genesis — main memory ⊕ ancestry summary + previous commit raw tail.
 			if out, err := c.Seed.Seed(ctx, inbound.SeedInput{Cwd: cwd, FromBranch: prevBranch, NewBranch: branch, Provider: targetProvider, Author: c.Identity}); err == nil {
 				b.SeedPath, b.ResumeCmd = out.WrittenPath, out.ResumeCmd
-				b.SeedID = sessionIDFromPath(out.WrittenPath)
+				b.SeedID = restoredSessionID(out.WrittenPath, out.ResumeCmd, out.SessionID)
 				fmt.Printf("cxt: seed created → branch %q (snapshot %s)\n", branch, shortHash(out.SnapshotID))
 				if _, ok := remotecfg.Origin(cwd); ok {
 					if _, perr := c.Sync.Push(ctx, inbound.SyncInput{Cwd: cwd}); perr != nil && strings.Contains(perr.Error(), domain.ErrSyncConflict.Error()) {
@@ -292,7 +292,14 @@ func contextSwitch(ctx context.Context, c *Container, cwd string) error {
 
 	// 4) Boundary signal + execution.
 	if len(superseded) > 0 || b.SeedPath != "" {
-		_ = boundary.Record(cwd, b)
+		if !boundaryTransitionSafe(b, wrapperManaged) {
+			hookWarn("context boundary has no valid resume target; active agent was not terminated — continue explicitly with cxt checkout %s", branch)
+			return nil
+		}
+		if err := boundary.Record(cwd, b); err != nil {
+			hookWarn("context boundary was not recorded; active agent was not terminated: %v", err)
+			return nil
+		}
 		if b.ResumeCmd != "" {
 			fmt.Printf("cxt: ⚠ Context switch — previous session is isolated (not recorded). Continue: %s\n", b.ResumeCmd)
 		} else if len(superseded) > 0 {
@@ -388,13 +395,35 @@ func codexSessionFiles(ctx context.Context, cwd string) []string {
 	return capture.NewCodexCapture().SessionFilesForCwd(ctx, cwd)
 }
 
-// sessionIDFromPath extracts the session ID (file name UUID) from the session file path.
-func sessionIDFromPath(path string) string {
-	if path == "" {
+// restoredSessionID returns the canonical provider-rewritten resume target.
+// Materialization must have produced both a path and a trusted resume command.
+// For branch seeds, materializedID cross-checks the use-case output against the
+// command so a stale synthetic CIR ID cannot become the wrapper restart target.
+func restoredSessionID(path, resumeCmd, materializedID string) string {
+	if path == "" || resumeCmd == "" {
 		return ""
 	}
-	base := filepath.Base(path)
-	return strings.TrimSuffix(base, filepath.Ext(base))
+	fields := strings.Fields(resumeCmd)
+	if len(fields) == 0 {
+		return ""
+	}
+	resumeID := fields[len(fields)-1]
+	if !providerfs.ValidSessionID(resumeID) {
+		return ""
+	}
+	if materializedID != "" && (!providerfs.ValidSessionID(materializedID) || materializedID != resumeID) {
+		return ""
+	}
+	return resumeID
+}
+
+// boundaryTransitionSafe prevents a live wrapper from observing a boundary
+// that cannot restart its child. An unmanaged superseded-only boundary remains
+// recordable for audit and explicit enforcement.
+func boundaryTransitionSafe(b boundary.Boundary, wrapperManaged bool) bool {
+	restartable := b.SeedPath != "" && b.ResumeCmd != "" && providerfs.ValidSessionID(b.SeedID)
+	preparedResume := b.SeedPath != "" || b.ResumeCmd != "" || b.SeedID != ""
+	return restartable || (!wrapperManaged && !preparedResume)
 }
 
 // runGitHook handles `cxt git-hook <event> [args...]`. Always returns nil (fail-open).

--- a/cli/internal/adapters/delivery/cli/githook_session_id_test.go
+++ b/cli/internal/adapters/delivery/cli/githook_session_id_test.go
@@ -1,0 +1,95 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/wnsdy95/cxthub/cli/internal/adapters/boundary"
+)
+
+func TestRestoredSessionID(t *testing.T) {
+	const sessionID = "12345678-1234-4abc-8def-1234567890ab"
+	tests := []struct {
+		name           string
+		path           string
+		resumeCmd      string
+		materializedID string
+		want           string
+	}{
+		{
+			name:      "claude materialization",
+			path:      "/tmp/.claude/projects/repo/" + sessionID + ".jsonl",
+			resumeCmd: "claude --resume " + sessionID,
+			want:      sessionID,
+		},
+		{
+			name:      "codex rollout filename",
+			path:      "/tmp/.codex/sessions/2026/07/30/rollout-2026-07-30T12-00-00-" + sessionID + ".jsonl",
+			resumeCmd: "codex resume " + sessionID,
+			want:      sessionID,
+		},
+		{
+			name:           "seed output agrees with resume command",
+			path:           "/tmp/materialized.jsonl",
+			resumeCmd:      "codex resume " + sessionID,
+			materializedID: sessionID,
+			want:           sessionID,
+		},
+		{
+			name:           "seed output disagrees with resume command",
+			path:           "/tmp/materialized.jsonl",
+			resumeCmd:      "codex resume " + sessionID,
+			materializedID: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+		},
+		{
+			name:      "missing materialized path",
+			resumeCmd: "codex resume " + sessionID,
+		},
+		{
+			name: "missing resume command",
+			path: "/tmp/materialized.jsonl",
+		},
+		{
+			name:      "invalid resume target",
+			path:      "/tmp/materialized.jsonl",
+			resumeCmd: "codex resume ../../outside",
+		},
+		{
+			name:           "invalid materialized ID",
+			path:           "/tmp/materialized.jsonl",
+			resumeCmd:      "codex resume " + sessionID,
+			materializedID: "../../outside",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := restoredSessionID(tt.path, tt.resumeCmd, tt.materializedID); got != tt.want {
+				t.Fatalf("restoredSessionID() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBoundaryTransitionSafe(t *testing.T) {
+	const sessionID = "12345678-1234-4abc-8def-1234567890ab"
+	restartable := boundary.Boundary{
+		SeedPath:  "/tmp/materialized.jsonl",
+		SeedID:    sessionID,
+		ResumeCmd: "codex resume " + sessionID,
+	}
+	if !boundaryTransitionSafe(restartable, true) {
+		t.Fatal("valid wrapper-managed transition was rejected")
+	}
+	if boundaryTransitionSafe(boundary.Boundary{}, true) {
+		t.Fatal("wrapper-managed transition without a restart target was accepted")
+	}
+	if !boundaryTransitionSafe(boundary.Boundary{}, false) {
+		t.Fatal("unmanaged superseded-only boundary was rejected")
+	}
+	if boundaryTransitionSafe(boundary.Boundary{
+		SeedPath:  restartable.SeedPath,
+		ResumeCmd: restartable.ResumeCmd,
+	}, false) {
+		t.Fatal("prepared transition without a valid seed ID was accepted")
+	}
+}

--- a/scripts/e2e-sync.sh
+++ b/scripts/e2e-sync.sh
@@ -197,8 +197,9 @@ expect "All previous sessions isolated (renamed)" "$(ls "$PROJ"/*.jsonl.supersed
 expect "Boundary record" "$([ -f .cxt/boundary.json ] && echo yes)" yes
 SEED=$(python3 -c "import json;print(json.load(open('.cxt/boundary.json')).get('seed_path',''))")
 SEEDID=$(python3 -c "import json;print(json.load(open('.cxt/boundary.json')).get('seed_id',''))")
+RESUMEID=$(python3 -c "import json;cmd=json.load(open('.cxt/boundary.json')).get('resume_cmd','').split();print(cmd[-1] if cmd else '')")
 expect "seed materialization" "$([ -n "$SEED" ] && [ -f "$SEED" ] && echo yes)" yes
-expect "boundary seed ID matches materialized resume target" "$(basename "$SEED" .jsonl)" "$SEEDID"
+expect "boundary seed ID matches materialized resume target" "$RESUMEID" "$SEEDID"
 SEEDMSG=$(python3 -c "
 import json,glob
 tgt=open('.cxt/refs/heads/feature-x').read().strip()
@@ -212,7 +213,14 @@ expect "seed is first snapshot of feature-x" "$SEEDMSG" "seed:"
 echo x > x.txt; git add x.txt; git commit -qm nocap >"$TMP/nc.out" 2>&1
 expect "unresumed seed is not captured" "$(grep -c 'cxt: snapshot' "$TMP/nc.out")" 0
 # After resuming (file growth), it captures as a formal active session.
-echo '{"type":"user","sessionId":"resumed","gitBranch":"feature-x","message":{"role":"user","content":"resumed work"}}' >> "$SEED"
+case "$SEED" in
+  "$HOME"/.codex/sessions/*)
+    echo '{"timestamp":"2026-07-05T00:00:02Z","type":"event_msg","payload":{"type":"user_message","message":"resumed work"}}' >> "$SEED"
+    ;;
+  *)
+    echo '{"type":"user","sessionId":"resumed","gitBranch":"feature-x","message":{"role":"user","content":"resumed work"}}' >> "$SEED"
+    ;;
+esac
 echo y > y.txt; git add y.txt; git commit -qm cap >"$TMP/cap.out" 2>&1
 expect "resumed seed captures" "$(grep -c 'cxt: snapshot' "$TMP/cap.out")" 1
 


### PR DESCRIPTION
## Summary

- derive branch-transition restart IDs from the provider-generated resume target instead of assuming the materialized filename is a UUID
- cross-check branch-seed output against the resume command and fail closed before recording or enforcing a boundary without a valid restart target
- surface boundary persistence failures instead of silently terminating an agent with no recoverable wrapper state
- make sync E2E assertions and resumed-session growth provider-neutral for both Claude and Codex materializations

## Why

Claude materializes `<uuid>.jsonl`, but Codex materializes `rollout-<timestamp>-<uuid>.jsonl`. Treating the Codex basename as its session ID caused boundary validation to reject the record while the hook continued as if restart state existed.

## Verification

- `go test ./... && go vet ./...` in `cli/`
- focused restart-ID and fail-closed boundary tests
- `make e2e-sync` under a live inherited `cxt codex` wrapper environment
- `make e2e-sync` with wrapper variables removed (Claude default path)
- `bash scripts/public-preflight.sh tree`

Closes #24
