### PR TITLE
fix(sync): converge local ref after PR append

### DIFF
--- a/cli/internal/adapters/backendclient/backend_client.go
+++ b/cli/internal/adapters/backendclient/backend_client.go
@@ -381,7 +381,8 @@ func (c *BackendClient) GraftSnapshotParents(ctx context.Context, repoID string,
 	return c.do(ctx, http.MethodPost, c.reposPath(repoID)+"/snapshots/"+url.PathEscape(string(id))+"/graft", body, nil)
 }
 
-// GetSnapshotRemote re-reads the (set,seq) source of truth from the server after a graft CAS conflict.
+// GetSnapshotRemote reads authoritative snapshot metadata, including the
+// server-owned graft register.
 func (c *BackendClient) GetSnapshotRemote(ctx context.Context, repoID string, id domain.ContentHash) (domain.Snapshot, error) {
 	if err := domain.ValidateContentHash(domain.ContentHash(repoID)); err != nil {
 		return domain.Snapshot{}, err

--- a/cli/internal/adapters/storage/file_store.go
+++ b/cli/internal/adapters/storage/file_store.go
@@ -415,7 +415,10 @@ func sameHashList(left, right []domain.ContentHash) bool {
 	return true
 }
 
-// ReconcileGraftState forces adoption of server truth graft register after 409 (stale/cycle). Local GraftSeq can be ahead of server due to pending add, so cannot be recovered with general PutSnapshot max-seq merge. Caller passes validated GET response only.
+// ReconcileGraftState forces adoption of a server truth graft register after an
+// authoritative GET. Local GraftSeq can be ahead of server due to a pending add,
+// so this cannot be recovered with general PutSnapshot max-seq merge. Caller
+// passes a validated GET response only.
 func (s *FileStore) ReconcileGraftState(_ context.Context, authoritative domain.Snapshot) error {
 	if err := validateSnapshotRefs(authoritative); err != nil {
 		return err

--- a/cli/internal/app/sync_append_branch_test.go
+++ b/cli/internal/app/sync_append_branch_test.go
@@ -1,0 +1,288 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/wnsdy95/cxthub/cli/internal/adapters/storage"
+	"github.com/wnsdy95/cxthub/cli/internal/domain"
+	"github.com/wnsdy95/cxthub/cli/internal/ports/inbound"
+	"github.com/wnsdy95/cxthub/cli/internal/ports/outbound"
+)
+
+type appendBranchRemote struct {
+	outbound.RemoteSync
+	snapshots map[domain.ContentHash]domain.Snapshot
+	failGets  map[domain.ContentHash]int
+	getCalls  []domain.ContentHash
+	updates   int
+	updateRef domain.Ref
+	append    bool
+	updateErr error
+}
+
+func (r *appendBranchRemote) UpdateRefRemote(
+	_ context.Context,
+	_ string,
+	ref domain.Ref,
+	appendDiverged bool,
+) error {
+	r.updates++
+	r.updateRef = ref
+	r.append = appendDiverged
+	return r.updateErr
+}
+
+func (r *appendBranchRemote) GetSnapshotRemote(
+	_ context.Context,
+	_ string,
+	id domain.ContentHash,
+) (domain.Snapshot, error) {
+	r.getCalls = append(r.getCalls, id)
+	if r.failGets[id] > 0 {
+		r.failGets[id]--
+		return domain.Snapshot{}, errors.New("temporary remote read failure")
+	}
+	snap, ok := r.snapshots[id]
+	if !ok {
+		return domain.Snapshot{}, domain.ErrNotFound
+	}
+	return snap, nil
+}
+
+type appendBranchFixture struct {
+	store    *storage.FileStore
+	remote   *appendBranchRemote
+	service  *SyncRepoService
+	repoID   string
+	oldHead  domain.ContentHash
+	boundary domain.ContentHash
+	target   domain.ContentHash
+}
+
+func newAppendBranchFixture(t *testing.T) appendBranchFixture {
+	t.Helper()
+	ctx := context.Background()
+	st := storage.NewFileStore(t.TempDir())
+	repoID := string(domain.HashContent([]byte("append-branch-repo")))
+	oldHead := domain.HashContent([]byte("append-old-head"))
+	boundary := domain.HashContent([]byte("append-feature-boundary"))
+	target := domain.HashContent([]byte("append-feature-target"))
+
+	put := func(snap domain.Snapshot) {
+		t.Helper()
+		if err := st.PutSnapshot(ctx, snap); err != nil {
+			t.Fatal(err)
+		}
+	}
+	put(domain.Snapshot{
+		ID: oldHead, RepoID: repoID, Branch: "main", DocHash: oldHead,
+	})
+	put(domain.Snapshot{
+		ID: boundary, RepoID: repoID, Branch: "feature", DocHash: boundary,
+	})
+	put(domain.Snapshot{
+		ID: target, RepoID: repoID, Branch: "feature", DocHash: target,
+		Parents: []domain.ContentHash{boundary},
+	})
+	if err := st.PutRef(ctx, domain.Ref{
+		Kind: domain.RefBranch, Name: "main", RepoID: repoID, Target: oldHead,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	remoteBoundary := domain.Snapshot{
+		ID: boundary, RepoID: repoID, Branch: "feature", DocHash: boundary,
+		Grafted: true, GraftParents: []domain.ContentHash{oldHead}, GraftSeq: 1,
+	}
+	remote := &appendBranchRemote{
+		snapshots: map[domain.ContentHash]domain.Snapshot{
+			oldHead: {
+				ID: oldHead, RepoID: repoID, Branch: "main", DocHash: oldHead,
+			},
+			boundary: remoteBoundary,
+			target: {
+				ID: target, RepoID: repoID, Branch: "feature", DocHash: target,
+				Parents: []domain.ContentHash{boundary}, GraftSeq: 9,
+			},
+		},
+		failGets: map[domain.ContentHash]int{},
+	}
+	return appendBranchFixture{
+		store: st, remote: remote, service: NewSyncRepoService(st, remote, nil),
+		repoID: repoID, oldHead: oldHead, boundary: boundary, target: target,
+	}
+}
+
+func TestAppendBranchReconcilesRemoteGraftPathAndAdvancesLocalRef(t *testing.T) {
+	f := newAppendBranchFixture(t)
+	ctx := context.Background()
+
+	if err := f.service.AppendBranch(ctx, inbound.SyncInput{RepoID: f.repoID}, "main", f.target); err != nil {
+		t.Fatal(err)
+	}
+	if f.remote.updates != 1 || !f.remote.append || f.remote.updateRef.Target != f.target {
+		t.Fatalf("remote update = count:%d append:%v ref:%+v", f.remote.updates, f.remote.append, f.remote.updateRef)
+	}
+	wantCalls := []domain.ContentHash{f.target, f.boundary}
+	if fmt.Sprint(f.remote.getCalls) != fmt.Sprint(wantCalls) {
+		t.Fatalf("authoritative reads = %v, want %v", f.remote.getCalls, wantCalls)
+	}
+
+	ref, err := f.store.GetRef(ctx, f.repoID, domain.RefBranch, "main")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ref.Target != f.target {
+		t.Fatalf("local main = %s, want %s", ref.Target, f.target)
+	}
+	boundary, err := f.store.GetSnapshot(ctx, f.boundary)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(boundary.Parents) != 0 {
+		t.Fatalf("natural parents changed: %v", boundary.Parents)
+	}
+	if boundary.GraftSeq != 1 || !boundary.Grafted || len(boundary.GraftParents) != 1 || boundary.GraftParents[0] != f.oldHead {
+		t.Fatalf("authoritative graft not adopted: %+v", boundary)
+	}
+	target, err := f.store.GetSnapshot(ctx, f.target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if target.GraftSeq != 0 {
+		t.Fatalf("unrelated target graft register was overwritten: %+v", target)
+	}
+}
+
+func TestAppendBranchRejectsNaturalParentDisagreementBeforeLocalMutation(t *testing.T) {
+	f := newAppendBranchFixture(t)
+	ctx := context.Background()
+
+	remoteBoundary := f.remote.snapshots[f.boundary]
+	remoteBoundary.Parents = []domain.ContentHash{f.oldHead}
+	remoteBoundary.GraftParents = nil
+	remoteBoundary.Grafted = false
+	f.remote.snapshots[f.boundary] = remoteBoundary
+	remoteTarget := f.remote.snapshots[f.target]
+	remoteTarget.GraftSeq = 7
+	f.remote.snapshots[f.target] = remoteTarget
+
+	err := f.service.AppendBranch(ctx, inbound.SyncInput{RepoID: f.repoID}, "main", f.target)
+	if !errors.Is(err, domain.ErrHashMismatch) {
+		t.Fatalf("AppendBranch error = %v, want ErrHashMismatch", err)
+	}
+	ref, gerr := f.store.GetRef(ctx, f.repoID, domain.RefBranch, "main")
+	if gerr != nil {
+		t.Fatal(gerr)
+	}
+	if ref.Target != f.oldHead {
+		t.Fatalf("local main moved after immutable metadata mismatch: %s", ref.Target)
+	}
+	target, gerr := f.store.GetSnapshot(ctx, f.target)
+	if gerr != nil {
+		t.Fatal(gerr)
+	}
+	if target.GraftSeq != 0 {
+		t.Fatalf("graft register mutated before full preflight: %+v", target)
+	}
+}
+
+func TestAppendBranchRemoteReadFailureLeavesRefAndRetryConverges(t *testing.T) {
+	f := newAppendBranchFixture(t)
+	ctx := context.Background()
+	f.remote.failGets[f.boundary] = 1
+
+	err := f.service.AppendBranch(ctx, inbound.SyncInput{RepoID: f.repoID}, "main", f.target)
+	if err == nil {
+		t.Fatal("AppendBranch succeeded despite authoritative read failure")
+	}
+	ref, gerr := f.store.GetRef(ctx, f.repoID, domain.RefBranch, "main")
+	if gerr != nil {
+		t.Fatal(gerr)
+	}
+	if ref.Target != f.oldHead {
+		t.Fatalf("local main moved after read failure: %s", ref.Target)
+	}
+
+	if err := f.service.AppendBranch(ctx, inbound.SyncInput{RepoID: f.repoID}, "main", f.target); err != nil {
+		t.Fatalf("retry did not converge: %v", err)
+	}
+	ref, gerr = f.store.GetRef(ctx, f.repoID, domain.RefBranch, "main")
+	if gerr != nil {
+		t.Fatal(gerr)
+	}
+	if ref.Target != f.target || f.remote.updates != 2 {
+		t.Fatalf("retry state = ref:%s updates:%d", ref.Target, f.remote.updates)
+	}
+}
+
+func TestAppendBranchPreservesGenuinelyAheadLocalRef(t *testing.T) {
+	f := newAppendBranchFixture(t)
+	ctx := context.Background()
+	localAhead := domain.HashContent([]byte("append-local-ahead"))
+	if err := f.store.PutSnapshot(ctx, domain.Snapshot{
+		ID: localAhead, RepoID: f.repoID, Branch: "main", DocHash: localAhead,
+		Parents: []domain.ContentHash{f.oldHead},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.store.PutRef(ctx, domain.Ref{
+		Kind: domain.RefBranch, Name: "main", RepoID: f.repoID, Target: localAhead,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := f.service.AppendBranch(ctx, inbound.SyncInput{RepoID: f.repoID}, "main", f.target); err != nil {
+		t.Fatal(err)
+	}
+	ref, err := f.store.GetRef(ctx, f.repoID, domain.RefBranch, "main")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ref.Target != localAhead {
+		t.Fatalf("genuinely ahead local history was overwritten: %s", ref.Target)
+	}
+	boundary, err := f.store.GetSnapshot(ctx, f.boundary)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(boundary.GraftParents) != 0 {
+		t.Fatalf("unproven remote path partially reconciled: %+v", boundary.GraftParents)
+	}
+}
+
+func TestReconcileAppendedPathIsBounded(t *testing.T) {
+	repoID := string(domain.HashContent([]byte("bounded-append-repo")))
+	ancestor := domain.HashContent([]byte("bounded-append-ancestor"))
+	remote := &appendBranchRemote{
+		snapshots: map[domain.ContentHash]domain.Snapshot{},
+		failGets:  map[domain.ContentHash]int{},
+	}
+	ids := make([]domain.ContentHash, maxAppendReconcileSnapshots+1)
+	for i := range ids {
+		ids[i] = domain.HashContent([]byte(fmt.Sprintf("bounded-append-%d", i)))
+	}
+	for i, id := range ids {
+		snap := domain.Snapshot{ID: id, RepoID: repoID, Branch: "feature", DocHash: id}
+		if i+1 < len(ids) {
+			snap.Parents = []domain.ContentHash{ids[i+1]}
+		} else {
+			snap.Grafted = true
+			snap.GraftParents = []domain.ContentHash{ancestor}
+			snap.GraftSeq = 1
+		}
+		remote.snapshots[id] = snap
+	}
+
+	svc := NewSyncRepoService(storage.NewFileStore(t.TempDir()), remote, nil)
+	reached, err := svc.reconcileAppendedPath(context.Background(), repoID, ids[0], ancestor)
+	if reached || !errors.Is(err, domain.ErrSyncConflict) {
+		t.Fatalf("bounded traversal = reached:%v err:%v", reached, err)
+	}
+	if len(remote.getCalls) != maxAppendReconcileSnapshots {
+		t.Fatalf("remote reads = %d, want %d", len(remote.getCalls), maxAppendReconcileSnapshots)
+	}
+}

--- a/cli/internal/app/sync_repo.go
+++ b/cli/internal/app/sync_repo.go
@@ -535,6 +535,128 @@ func (s *SyncRepoService) ResolveRemoteBranch(ctx context.Context, in inbound.Sy
 	return domain.Ref{}, domain.ErrNotFound
 }
 
+const maxAppendReconcileSnapshots = 256
+
+// reconcileAppendedPath adopts the authoritative remote graft registers on one
+// path from target to ancestor. appendDiverged can attach its overlay to an
+// ancestor of target rather than target itself, so re-reading only target is
+// insufficient.
+//
+// Remote metadata is collected and checked against immutable local metadata
+// before any graft register is replaced. The traversal is bounded because this
+// path runs from a Git hook; a later full pull remains the recovery path for an
+// unusually large graph.
+func (s *SyncRepoService) reconcileAppendedPath(
+	ctx context.Context,
+	repoID string,
+	target, ancestor domain.ContentHash,
+) (bool, error) {
+	if ancestor == "" || ancestor == target {
+		return true, nil
+	}
+
+	queue := []domain.ContentHash{target}
+	discovered := map[domain.ContentHash]bool{target: true}
+	// towardTarget[parent] is the child from which the parent was discovered.
+	towardTarget := make(map[domain.ContentHash]domain.ContentHash)
+	remoteByID := make(map[domain.ContentHash]domain.Snapshot)
+	found := false
+
+	for len(queue) > 0 {
+		id := queue[0]
+		queue = queue[1:]
+		if id == ancestor {
+			found = true
+			break
+		}
+		if len(remoteByID) >= maxAppendReconcileSnapshots {
+			return false, fmt.Errorf(
+				"%w: authoritative append path exceeded %d snapshots; run cxt pull",
+				domain.ErrSyncConflict,
+				maxAppendReconcileSnapshots,
+			)
+		}
+
+		snap, err := s.remote.GetSnapshotRemote(ctx, repoID, id)
+		if err != nil {
+			return false, fmt.Errorf("read authoritative append snapshot %s: %w", id, err)
+		}
+		if err := validateSnapshotObject(snap); err != nil {
+			return false, err
+		}
+		if snap.ID != id || snap.RepoID != repoID {
+			return false, domain.ErrHashMismatch
+		}
+		remoteByID[id] = snap
+
+		for _, parent := range snap.ReachabilityParents() {
+			if discovered[parent] {
+				continue
+			}
+			discovered[parent] = true
+			towardTarget[parent] = id
+			queue = append(queue, parent)
+		}
+	}
+	if !found {
+		return false, nil
+	}
+
+	// Reconstruct only the proven path. Side branches visited by the bounded
+	// search are not required for this ref movement and are left for normal pull.
+	type pathStep struct {
+		snapshot domain.Snapshot
+		parent   domain.ContentHash
+	}
+	path := make([]pathStep, 0)
+	for id := ancestor; id != target; {
+		child, ok := towardTarget[id]
+		if !ok {
+			return false, domain.ErrHashMismatch
+		}
+		snap, ok := remoteByID[child]
+		if !ok {
+			return false, domain.ErrHashMismatch
+		}
+		path = append(path, pathStep{snapshot: snap, parent: id})
+		id = child
+	}
+
+	// Preflight all immutable metadata before replacing any local graft register.
+	localByID := make(map[domain.ContentHash]domain.Snapshot, len(path))
+	for _, step := range path {
+		remoteSnap := step.snapshot
+		localSnap, err := s.store.GetSnapshot(ctx, remoteSnap.ID)
+		if err != nil {
+			return false, err
+		}
+		if err := validateSnapshotObject(localSnap); err != nil {
+			return false, err
+		}
+		if localSnap.RepoID != repoID || !sameParents(localSnap.Parents, remoteSnap.Parents) {
+			return false, domain.ErrHashMismatch
+		}
+		localByID[localSnap.ID] = localSnap
+	}
+	for _, step := range path {
+		localSnap := localByID[step.snapshot.ID]
+		edgePresent := false
+		for _, parent := range localSnap.ReachabilityParents() {
+			if parent == step.parent {
+				edgePresent = true
+				break
+			}
+		}
+		if edgePresent {
+			continue
+		}
+		if err := s.store.ReconcileGraftState(ctx, step.snapshot); err != nil {
+			return false, fmt.Errorf("reconcile authoritative append snapshot %s: %w", step.snapshot.ID, err)
+		}
+	}
+	return true, nil
+}
+
 // AppendBranch appends the server branch ref to the target (lossless graft) without modifying the commit history.
 // It is idempotent, conflict-free, and does not interfere with branch protection policies (e.g., --force).
 func (s *SyncRepoService) AppendBranch(ctx context.Context, in inbound.SyncInput, branch string, target domain.ContentHash) error {
@@ -546,11 +668,36 @@ func (s *SyncRepoService) AppendBranch(ctx context.Context, in inbound.SyncInput
 	if err := s.remote.UpdateRefRemote(ctx, repoID, ref, true); err != nil {
 		return err
 	}
-	// Local mirror preserves the history when fast-forwarding — it keeps my chain when the local branch is ahead (unpushed segments).
-	if cur, gerr := s.store.GetRef(ctx, repoID, domain.RefBranch, branch); gerr != nil || cur.Target == "" || s.isAncestor(ctx, cur.Target, target) {
-		_ = s.store.PutRef(ctx, ref)
+
+	cur, err := s.store.GetRef(ctx, repoID, domain.RefBranch, branch)
+	switch {
+	case errors.Is(err, domain.ErrNotFound):
+		return s.store.PutRef(ctx, ref)
+	case err != nil:
+		return err
+	case cur.Target == "":
+		return s.store.PutRef(ctx, ref)
+	case cur.Target == target:
+		return nil
+	case s.isAncestor(ctx, cur.Target, target):
+		return s.store.PutRef(ctx, ref)
 	}
-	return nil
+
+	// A diverged server append may have added its graft to an ancestor of target.
+	// Re-read that narrow authoritative path before deciding whether the local
+	// branch can safely fast-forward. If the local branch is genuinely ahead,
+	// the path will not reach it and its ref is preserved.
+	reached, err := s.reconcileAppendedPath(ctx, repoID, target, cur.Target)
+	if err != nil {
+		return err
+	}
+	if !reached {
+		return nil
+	}
+	if !s.isAncestor(ctx, cur.Target, target) {
+		return fmt.Errorf("%w: authoritative append path did not converge", domain.ErrSyncConflict)
+	}
+	return s.store.PutRef(ctx, ref)
 }
 
 // collectObjects gathers push target objects (snapshots+docs) for Push/Shadow Sync.

--- a/cli/internal/ports/inbound/ports.go
+++ b/cli/internal/ports/inbound/ports.go
@@ -57,7 +57,7 @@ type SyncRepo interface {
 	SyncPendings(ctx context.Context, in SyncInput, resolveSessions []string) (int, error)
 	// ResolveRemoteBranch queries the remote (server) branch ref and prepares it for fetch-only if the target snapshot object is not present locally (for web fork connection). Returns ErrNotFound if not found.
 	ResolveRemoteBranch(ctx context.Context, in SyncInput, branch string) (domain.Ref, error)
-	// AppendBranch appends the server branch ref to the target (lossless graft) — path for merging PR merge context into branch. On success, local ref mirrors only if fast-forward (local is ahead). Already reflected (behind) targets are rejected by the server as non_fast_forward — caller treats as idempotent no-op.
+	// AppendBranch appends the server branch ref to the target (lossless graft) — path for merging PR context into a branch. On success, it reconciles the authoritative graft path and mirrors the local ref only if doing so preserves local history. Already reflected (behind) targets are rejected by the server as non_fast_forward — caller treats them as idempotent no-ops.
 	AppendBranch(ctx context.Context, in SyncInput, branch string, target domain.ContentHash) error
 }
 

--- a/cli/internal/ports/outbound/ports.go
+++ b/cli/internal/ports/outbound/ports.go
@@ -32,8 +32,9 @@ type SessionStore interface {
 	// Returns domain.ErrNotFound if not found.
 	GetSnapshot(ctx context.Context, id domain.ContentHash) (domain.Snapshot, error)
 
-	// ReconcileGraftState reverts an optimistic graft event rejected by the server to the server's source of truth.
-	// It replaces only the graft register, leaving immutable metadata (ID/Parents) unchanged.
+	// ReconcileGraftState adopts a snapshot graft register from an authoritative
+	// server read. It replaces only the graft register, leaving immutable
+	// metadata (ID/Parents) unchanged.
 	ReconcileGraftState(ctx context.Context, authoritative domain.Snapshot) error
 
 	// ListSnapshots returns a list of snapshots (history) for a specific repo/branch.
@@ -174,7 +175,8 @@ type RemoteSync interface {
 	// GraftSnapshotParents propagates local graft events using expectedSeq CAS. 409 stale/cycle is terminal, and retrying an already reflected edge is idempotent.
 	GraftSnapshotParents(ctx context.Context, repoID string, id domain.ContentHash, parents []domain.ContentHash, expectedSeq uint64) error
 
-	// GetSnapshotRemote is used to adjust the server truth register after a graft CAS conflict.
+	// GetSnapshotRemote reads authoritative snapshot metadata, including the
+	// server-owned graft register.
 	GetSnapshotRemote(ctx context.Context, repoID string, id domain.ContentHash) (domain.Snapshot, error)
 
 	// Search is the server search (commit messages, conversation bodies) — MCP context_search (read-only).


### PR DESCRIPTION
## Summary

- after a successful appended branch update, traverse the authoritative remote reachability path from the promoted source tip back to the stale local base tip
- preflight every snapshot on the proven path against immutable local repo/natural-parent metadata before adopting any server-owned graft register
- move the local base ref only after the reconciled overlay proves the old local tip remains reachable
- preserve genuinely ahead local refs, bound hook-time traversal to 256 snapshots, and leave refs unchanged on remote fetch or metadata validation failure

## Why

PR context promotion already advances the server ref and adds a lossless graft overlay when the source lineage diverges. The local `AppendBranch` checked ancestry before receiving that authoritative overlay, so its base ref stayed stale until a later full `cxt pull`.

Natural snapshot parents remain immutable; only the existing versioned graft register is reconciled through the validated store boundary.

## Verification

- `go test ./... && go vet ./...` in `cli/`
- focused append reconciliation tests under the race detector
- `make e2e-sync` under a live inherited Codex wrapper environment
- `bash scripts/public-preflight.sh tree`
- updated CLI installed locally for post-merge dogfooding
- current local/server `main` and source branch refs verified equal before merge

Closes #20
