### PR TITLE
fix(seed): inherit main memory and full session

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ CXTHub follows Git actions developers already use:
 |---|---|
 | `git commit` | Capture staged active agent sessions and link them to the commit |
 | `git switch` / `git checkout` | Restore the destination branch context |
-| `git branch` | Create the corresponding context branch |
+| `git switch -c` / `git checkout -b` | Seed a new context branch with main memory and the current session |
+| `git branch` | Create the corresponding context branch from the current context |
 | `git rebase` / `git commit --amend` | Track rewritten commit links |
 | `git stash` / `git stash pop` | Preserve or restore unfinished agent work |
 | `git push` / `git pull` | Synchronize context with the configured remote |

--- a/cli/internal/app/branch_seed.go
+++ b/cli/internal/app/branch_seed.go
@@ -18,7 +18,7 @@ import (
 //
 //	[Project Understanding] main head's MemoryDigest        (long-term memory)
 //	[Changelog Summary] departure branch head's on-the-fly distillation      (mid-term summary — including ancestor inheritance, items overlapping with main layer removed)
-//	[Previous Context] departure head's last commit raw tail   (original reason for the context switch)
+//	[Previous Context] departure head's bounded full session   (conversation at the switch point)
 //
 // The seed is committed as the first snapshot of the new branch (branch birth — cut meaning), and serialized to a session file (ledger record — capture excluded for resumption).
 type BranchSeedService struct {
@@ -65,18 +65,42 @@ func (s *BranchSeedService) Seed(ctx context.Context, in inbound.SeedInput) (inb
 		return inbound.SeedOutput{}, err
 	}
 
-	// Layer 1: main head memory (if present — explicit layer of project shared understanding).
-	var mainMem *domain.MemoryDigest
+	// Layer 1: main head memory (explicit project understanding), including
+	// when the departure branch itself is main. The post-checkout hook
+	// checkpoints and memorizes main immediately before this service runs; the
+	// old equality guard discarded exactly that freshly attached digest.
 	mainBranch := repo.DefaultBranch
 	if mainBranch == "" {
 		mainBranch = "main"
 	}
-	if mainBranch != in.FromBranch {
-		if mref, merr := s.store.GetRef(ctx, repo.ID, domain.RefBranch, mainBranch); merr == nil && mref.Target != "" {
-			if msnap, serr := s.store.GetSnapshot(ctx, mref.Target); serr == nil && msnap.MemoryHash != "" {
-				if d, derr := s.store.GetMemory(ctx, msnap.MemoryHash); derr == nil {
-					mainMem = &d
+	var mainMem *domain.MemoryDigest
+	var mainSnap domain.Snapshot
+	var mainDoc domain.SessionDoc
+	mainDocAvailable := false
+	if mainBranch == in.FromBranch {
+		mainSnap, mainDoc = fromSnap, fromDoc
+		mainDocAvailable = true
+	} else if mref, merr := s.store.GetRef(ctx, repo.ID, domain.RefBranch, mainBranch); merr == nil && mref.Target != "" {
+		if msnap, serr := s.store.GetSnapshot(ctx, mref.Target); serr == nil {
+			mainSnap = msnap
+			if mdoc, derr := s.store.GetDoc(ctx, msnap.DocHash); derr == nil {
+				mainDoc = mdoc
+				mainDocAvailable = true
+			}
+		}
+	}
+	if mainSnap.ID != "" {
+		if mainSnap.MemoryHash != "" {
+			if d, derr := s.store.GetMemory(ctx, mainSnap.MemoryHash); derr == nil {
+				mainMem = &d
+			}
+		}
+		if mainMem == nil && mainDocAvailable {
+			if d, derr := s.distiller.Distill(ctx, mainDoc.CIR, nil); derr == nil {
+				if prior, ok := nearestAncestorDigest(ctx, s.store, mainSnap); ok {
+					d = domain.MergeDigests(prior, d)
 				}
+				mainMem = &d
 			}
 		}
 	}
@@ -90,28 +114,25 @@ func (s *BranchSeedService) Seed(ctx context.Context, in inbound.SeedInput) (inb
 		branchMem = domain.MergeDigests(prior, branchMem)
 	}
 
-	// Layer 3: last commit's raw tail — suffix (complement of inheritance prefix) excluding parent doc.
-	tail := fromDoc.CIR.Events
-	if len(fromSnap.Parents) > 0 {
-		if psnap, perr := s.store.GetSnapshot(ctx, fromSnap.Parents[0]); perr == nil {
-			if pdoc, derr := s.store.GetDoc(ctx, psnap.DocHash); derr == nil && len(pdoc.CIR.Events) < len(tail) {
-				tail = tail[len(pdoc.CIR.Events):]
-			}
-		}
-	}
-	// Budget trimming — same rules as existing branch switch (Load path) — byte budget + user boundary truncation.
-	// Audit #6: fixed event count limit (formerly 120) split across paths.
-	trimmedTail, _ := trimEventsForSeed(domain.CIRDocument{Events: tail}, seedBudgetBytes)
-	tail = trimmedTail.Events
-
-	// Seed CIR synthesis: [Layer1⊕Layer2 summary message] + [Layer3 raw tail]. Seq is reset to 0.
+	// Seed CIR synthesis: [Layer1⊕Layer2 summary message] + [Layer3 bounded
+	// full session]. The summary has a fixed maximum, and the exact encoded
+	// summary size is subtracted from the shared seed budget before selecting
+	// the recent user-boundary-aligned conversation tail.
 	now := time.Now().UTC().Format(time.RFC3339)
 	seedSession := providerfs.NewSessionID()
-	events := []domain.Event{{
+	seedText := renderSeedText(in.FromBranch, in.NewBranch, mainMem, branchMem)
+	seedText = truncateUTF8Prefix(seedText, seedDigestBudgetBytes)
+	summaryEvent := domain.Event{
 		Kind: domain.EventMessage, Role: "user", Ts: now, Seq: 0,
-		Blocks: []domain.ContentBlock{{Type: "text", Text: renderSeedText(in.FromBranch, in.NewBranch, mainMem, branchMem)}},
-	}}
-	for i, ev := range tail {
+		Blocks: []domain.ContentBlock{{Type: "text", Text: seedText}},
+	}
+	conversationBudget := seedBudgetBytes - eventsJSONBytes([]domain.Event{summaryEvent})
+	if conversationBudget < 0 {
+		conversationBudget = 0
+	}
+	trimmedConversation, _ := trimEventsForSeed(fromDoc.CIR, conversationBudget)
+	events := []domain.Event{summaryEvent}
+	for i, ev := range trimmedConversation.Events {
 		ev.Seq = i + 1
 		events = append(events, ev)
 	}

--- a/cli/internal/app/branch_seed_inheritance_test.go
+++ b/cli/internal/app/branch_seed_inheritance_test.go
@@ -1,0 +1,321 @@
+package app
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/wnsdy95/cxthub/cli/internal/adapters/storage"
+	"github.com/wnsdy95/cxthub/cli/internal/domain"
+	"github.com/wnsdy95/cxthub/cli/internal/ports/inbound"
+)
+
+func putBranchSeedSnapshot(
+	t *testing.T,
+	ctx context.Context,
+	store *storage.FileStore,
+	repoID, branch string,
+	events []domain.Event,
+	parents []domain.ContentHash,
+	memory *domain.MemoryDigest,
+) domain.ContentHash {
+	t.Helper()
+	docHash, err := store.PutDoc(ctx, domain.SessionDoc{CIR: domain.CIRDocument{
+		Envelope: domain.Envelope{
+			CIRVersion:     "1",
+			SourceProvider: domain.ProviderCodex,
+			GitBranch:      branch,
+			Fidelity:       domain.FidelityFull,
+		},
+		Events: events,
+	}})
+	if err != nil {
+		t.Fatalf("put doc: %v", err)
+	}
+	var memoryHash domain.ContentHash
+	if memory != nil {
+		digest := *memory
+		digest.SnapshotID = docHash
+		memoryHash, err = store.PutMemory(ctx, digest)
+		if err != nil {
+			t.Fatalf("put memory: %v", err)
+		}
+	}
+	if err := store.PutSnapshot(ctx, domain.Snapshot{
+		ID:         docHash,
+		RepoID:     repoID,
+		Branch:     branch,
+		Parents:    parents,
+		DocHash:    docHash,
+		MemoryHash: memoryHash,
+		Provider:   domain.ProviderCodex,
+		Fidelity:   domain.FidelityFull,
+	}); err != nil {
+		t.Fatalf("put snapshot: %v", err)
+	}
+	return docHash
+}
+
+func putBranchSeedRef(
+	t *testing.T,
+	ctx context.Context,
+	store *storage.FileStore,
+	repoID, branch string,
+	target domain.ContentHash,
+) {
+	t.Helper()
+	if err := store.PutRef(ctx, domain.Ref{
+		Kind: domain.RefBranch, Name: branch, RepoID: repoID, Target: target,
+	}); err != nil {
+		t.Fatalf("put ref: %v", err)
+	}
+}
+
+func TestBranchSeedFromMainIncludesStoredMemoryAndFullSession(t *testing.T) {
+	ctx := context.Background()
+	store := storage.NewFileStore(t.TempDir())
+	repo := domain.Repo{ID: "repo-main-seed", DefaultBranch: "main", LocalPath: t.TempDir()}
+
+	parentEvents := []domain.Event{
+		seedMessage("user", "main session opening request", 0),
+		seedMessage("assistant", "main session opening answer", 1),
+	}
+	parent := putBranchSeedSnapshot(t, ctx, store, repo.ID, "main", parentEvents, nil, nil)
+	headEvents := append(append([]domain.Event{}, parentEvents...),
+		seedMessage("user", "main session latest request", 2),
+		seedMessage("assistant", "main session latest answer", 3),
+	)
+	head := putBranchSeedSnapshot(t, ctx, store, repo.ID, "main", headEvents, []domain.ContentHash{parent}, &domain.MemoryDigest{
+		Summary:   "MAIN COMPACT MEMORY: preserve architecture and current decisions.",
+		KeyFacts:  []string{"main compact fact"},
+		OpenTasks: []string{"main compact task"},
+		Provider:  domain.ProviderCodex,
+	})
+	putBranchSeedRef(t, ctx, store, repo.ID, "main", head)
+
+	service := NewBranchSeedService(
+		branchSeedGit{repo: repo},
+		store,
+		stubDistiller{d: domain.MemoryDigest{Summary: "fresh main lineage summary"}},
+		nil,
+		nil,
+	)
+	out, err := service.Seed(ctx, inbound.SeedInput{
+		Cwd: repo.LocalPath, FromBranch: "main", NewBranch: "feature/main-inheritance", Provider: domain.ProviderCodex,
+	})
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	seed, err := store.GetDoc(ctx, out.SnapshotID)
+	if err != nil {
+		t.Fatalf("get seed: %v", err)
+	}
+	if len(seed.CIR.Events) != len(headEvents)+1 {
+		t.Fatalf("seed events = %d, want summary + full main session = %d", len(seed.CIR.Events), len(headEvents)+1)
+	}
+	summary := seed.CIR.Events[0].Blocks[0].Text
+	for _, want := range []string{
+		"## Project understanding (main)",
+		"MAIN COMPACT MEMORY",
+		"main compact fact",
+		"main compact task",
+	} {
+		if !strings.Contains(summary, want) {
+			t.Fatalf("seed summary missing %q: %s", want, summary)
+		}
+	}
+	for i, want := range headEvents {
+		got := seed.CIR.Events[i+1]
+		if len(got.Blocks) == 0 || got.Blocks[0].Text != want.Blocks[0].Text {
+			t.Fatalf("main conversation event %d = %+v, want %+v", i, got, want)
+		}
+	}
+}
+
+func TestBranchSeedFromMainDistillsMemoryWhenHeadHasNoStoredDigest(t *testing.T) {
+	ctx := context.Background()
+	store := storage.NewFileStore(t.TempDir())
+	repo := domain.Repo{ID: "repo-main-fallback", DefaultBranch: "main", LocalPath: t.TempDir()}
+	head := putBranchSeedSnapshot(t, ctx, store, repo.ID, "main", []domain.Event{
+		seedMessage("user", "fallback main conversation", 0),
+	}, nil, nil)
+	putBranchSeedRef(t, ctx, store, repo.ID, "main", head)
+
+	service := NewBranchSeedService(
+		branchSeedGit{repo: repo},
+		store,
+		stubDistiller{d: domain.MemoryDigest{Summary: "DISTILLED MAIN COMPACT MEMORY"}},
+		nil,
+		nil,
+	)
+	out, err := service.Seed(ctx, inbound.SeedInput{
+		Cwd: repo.LocalPath, FromBranch: "main", NewBranch: "feature/fallback", Provider: domain.ProviderCodex,
+	})
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	seed, err := store.GetDoc(ctx, out.SnapshotID)
+	if err != nil {
+		t.Fatalf("get seed: %v", err)
+	}
+	summary := seed.CIR.Events[0].Blocks[0].Text
+	if !strings.Contains(summary, "## Project understanding (main)") ||
+		!strings.Contains(summary, "DISTILLED MAIN COMPACT MEMORY") {
+		t.Fatalf("distilled main memory was not inherited explicitly: %s", summary)
+	}
+}
+
+func TestBranchSeedFromOtherLineageIncludesMainMemoryAndLineageSession(t *testing.T) {
+	ctx := context.Background()
+	store := storage.NewFileStore(t.TempDir())
+	repo := domain.Repo{ID: "repo-other-lineage", DefaultBranch: "main", LocalPath: t.TempDir()}
+
+	mainHead := putBranchSeedSnapshot(t, ctx, store, repo.ID, "main", []domain.Event{
+		seedMessage("user", "main conversation should not replace feature conversation", 0),
+	}, nil, &domain.MemoryDigest{
+		Summary:  "MAIN PROJECT MEMORY FOR EVERY NEW BRANCH",
+		Provider: domain.ProviderCodex,
+	})
+	putBranchSeedRef(t, ctx, store, repo.ID, "main", mainHead)
+
+	featureEvents := []domain.Event{
+		seedMessage("user", "feature lineage opening request", 0),
+		seedMessage("assistant", "feature lineage current answer", 1),
+	}
+	featureHead := putBranchSeedSnapshot(t, ctx, store, repo.ID, "feature/source", featureEvents, nil, nil)
+	putBranchSeedRef(t, ctx, store, repo.ID, "feature/source", featureHead)
+
+	service := NewBranchSeedService(
+		branchSeedGit{repo: repo},
+		store,
+		stubDistiller{d: domain.MemoryDigest{Summary: "feature lineage digest"}},
+		nil,
+		nil,
+	)
+	out, err := service.Seed(ctx, inbound.SeedInput{
+		Cwd: repo.LocalPath, FromBranch: "feature/source", NewBranch: "feature/child", Provider: domain.ProviderCodex,
+	})
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	seed, err := store.GetDoc(ctx, out.SnapshotID)
+	if err != nil {
+		t.Fatalf("get seed: %v", err)
+	}
+	if !strings.Contains(seed.CIR.Events[0].Blocks[0].Text, "MAIN PROJECT MEMORY FOR EVERY NEW BRANCH") {
+		t.Fatal("non-main branch seed lost main project memory")
+	}
+	if len(seed.CIR.Events) != len(featureEvents)+1 {
+		t.Fatalf("seed events = %d, want summary + feature session = %d", len(seed.CIR.Events), len(featureEvents)+1)
+	}
+	for i, want := range featureEvents {
+		if got := seed.CIR.Events[i+1].Blocks[0].Text; got != want.Blocks[0].Text {
+			t.Fatalf("feature conversation event %d = %q, want %q", i, got, want.Blocks[0].Text)
+		}
+	}
+}
+
+func TestBranchSeedUsesStoredMainMemoryWhenMainDocIsNotLocal(t *testing.T) {
+	ctx := context.Background()
+	store := storage.NewFileStore(t.TempDir())
+	repo := domain.Repo{ID: "repo-partial-main", DefaultBranch: "main", LocalPath: t.TempDir()}
+
+	mainID := domain.HashContent([]byte("partial-main-snapshot"))
+	mainMemoryHash, err := store.PutMemory(ctx, domain.MemoryDigest{
+		SnapshotID: mainID,
+		Summary:    "STORED MAIN MEMORY SURVIVES PARTIAL LOCAL DOCS",
+		Provider:   domain.ProviderCodex,
+	})
+	if err != nil {
+		t.Fatalf("put main memory: %v", err)
+	}
+	if err := store.PutSnapshot(ctx, domain.Snapshot{
+		ID: mainID, RepoID: repo.ID, Branch: "main", DocHash: mainID, MemoryHash: mainMemoryHash,
+	}); err != nil {
+		t.Fatalf("put main snapshot: %v", err)
+	}
+	putBranchSeedRef(t, ctx, store, repo.ID, "main", mainID)
+
+	featureHead := putBranchSeedSnapshot(t, ctx, store, repo.ID, "feature/source", []domain.Event{
+		seedMessage("user", "feature conversation remains available", 0),
+	}, nil, nil)
+	putBranchSeedRef(t, ctx, store, repo.ID, "feature/source", featureHead)
+
+	service := NewBranchSeedService(
+		branchSeedGit{repo: repo},
+		store,
+		stubDistiller{d: domain.MemoryDigest{Summary: "feature digest"}},
+		nil,
+		nil,
+	)
+	out, err := service.Seed(ctx, inbound.SeedInput{
+		Cwd: repo.LocalPath, FromBranch: "feature/source", NewBranch: "feature/partial-main", Provider: domain.ProviderCodex,
+	})
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	seed, err := store.GetDoc(ctx, out.SnapshotID)
+	if err != nil {
+		t.Fatalf("get seed: %v", err)
+	}
+	if !strings.Contains(seed.CIR.Events[0].Blocks[0].Text, "STORED MAIN MEMORY SURVIVES PARTIAL LOCAL DOCS") {
+		t.Fatal("stored main memory was discarded because the main doc was unavailable")
+	}
+}
+
+func TestBranchSeedMainMemoryAndConversationStayWithinBudget(t *testing.T) {
+	ctx := context.Background()
+	store := storage.NewFileStore(t.TempDir())
+	repo := domain.Repo{ID: "repo-main-bounded", DefaultBranch: "main", LocalPath: t.TempDir()}
+
+	events := make([]domain.Event, 0, 122)
+	for i := 0; i < 60; i++ {
+		events = append(events,
+			seedMessage("user", strings.Repeat("older main request ", 300), i*2),
+			seedMessage("assistant", strings.Repeat("older main answer ", 300), i*2+1),
+		)
+	}
+	events = append(events,
+		seedMessage("user", "LATEST MAIN USER REQUEST MUST SURVIVE", len(events)),
+		seedMessage("assistant", "latest main answer", len(events)+1),
+	)
+	head := putBranchSeedSnapshot(t, ctx, store, repo.ID, "main", events, nil, &domain.MemoryDigest{
+		Summary:  "MAIN COMPACT MEMORY START\n" + strings.Repeat("project memory ", 12000),
+		Provider: domain.ProviderCodex,
+	})
+	putBranchSeedRef(t, ctx, store, repo.ID, "main", head)
+
+	service := NewBranchSeedService(
+		branchSeedGit{repo: repo},
+		store,
+		stubDistiller{d: domain.MemoryDigest{Summary: "bounded lineage summary"}},
+		nil,
+		nil,
+	)
+	out, err := service.Seed(ctx, inbound.SeedInput{
+		Cwd: repo.LocalPath, FromBranch: "main", NewBranch: "feature/bounded", Provider: domain.ProviderCodex,
+	})
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	seed, err := store.GetDoc(ctx, out.SnapshotID)
+	if err != nil {
+		t.Fatalf("get seed: %v", err)
+	}
+	if got := eventsJSONBytes(seed.CIR.Events); got > seedBudgetBytes {
+		t.Fatalf("seed size = %d, want <= %d", got, seedBudgetBytes)
+	}
+	if !strings.Contains(seed.CIR.Events[0].Blocks[0].Text, "MAIN COMPACT MEMORY START") {
+		t.Fatal("bounded seed lost main compact memory")
+	}
+	foundLatest := false
+	for _, event := range seed.CIR.Events {
+		if len(event.Blocks) > 0 && event.Blocks[0].Text == "LATEST MAIN USER REQUEST MUST SURVIVE" {
+			foundLatest = true
+			break
+		}
+	}
+	if !foundLatest {
+		t.Fatal("bounded seed lost latest main user request")
+	}
+}

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -231,7 +231,10 @@ cxt checkout [<ref>] [-b <new-branch>]
 
 Restores a ref. With `-b`, creates and restores a new context branch from that
 ref. Git checkout hooks normally invoke the corresponding behavior
-automatically.
+automatically. A new branch seed carries the main head's compact memory plus
+the departure branch head's session conversation. Conversations that fit are
+preserved in full; larger sessions keep a bounded recent tail starting at a
+user-turn boundary.
 
 ### `cxt switch`
 

--- a/scripts/e2e-sync.sh
+++ b/scripts/e2e-sync.sh
@@ -200,6 +200,8 @@ SEEDID=$(python3 -c "import json;print(json.load(open('.cxt/boundary.json')).get
 RESUMEID=$(python3 -c "import json;cmd=json.load(open('.cxt/boundary.json')).get('resume_cmd','').split();print(cmd[-1] if cmd else '')")
 expect "seed materialization" "$([ -n "$SEED" ] && [ -f "$SEED" ] && echo yes)" yes
 expect "boundary seed ID matches materialized resume target" "$RESUMEID" "$SEEDID"
+expect "seed inherits main compact memory" "$(grep -q 'Project understanding (main)' "$SEED" && echo yes)" yes
+expect "seed inherits main session conversation" "$(grep -q 'task E' "$SEED" && echo yes)" yes
 SEEDMSG=$(python3 -c "
 import json,glob
 tgt=open('.cxt/refs/heads/feature-x').read().strip()


### PR DESCRIPTION
## Summary

- always include the main head compact memory when creating a branch seed, including branches created directly from main
- preserve the full departure session when it fits, or a bounded recent user-turn-aligned tail when it does not
- fall back to distilling main when no stored digest exists and retain stored memory with partial local objects
- document the branch-creation behavior and assert it in the sync E2E

## Validation

- `go test ./...`
- `go vet ./...`
- `go test -race ./internal/app -run TestBranchSeed -count=1`
- `make e2e-sync`
- `bash scripts/public-preflight.sh tree`

Closes #27