### PR TITLE
fix(seed): retain full inherited memory digest

### DIFF
--- a/cli/internal/app/branch_seed.go
+++ b/cli/internal/app/branch_seed.go
@@ -156,10 +156,27 @@ func (s *BranchSeedService) Seed(ctx context.Context, in inbound.SeedInput) (inb
 	if err != nil {
 		return inbound.SeedOutput{}, err
 	}
+	// The materialized prompt is intentionally bounded, but the branch must not
+	// lose the complete inherited digest. Attach the untruncated main +
+	// departure-lineage memory to the seed snapshot so the next memorize/seed
+	// operation inherits the full value rather than re-distilling the truncated
+	// summary event.
+	seedMemory := branchMem
+	if mainMem != nil {
+		seedMemory = domain.MergeDigests(*mainMem, branchMem)
+	}
+	seedMemory.SnapshotID = docHash
+	if seedMemory.Provider == "" {
+		seedMemory.Provider = provider
+	}
+	memoryHash, err := s.store.PutMemory(ctx, seedMemory)
+	if err != nil {
+		return inbound.SeedOutput{}, err
+	}
 	snap := domain.Snapshot{
 		ID: docHash, RepoID: repo.ID, Branch: in.NewBranch,
 		Parents: []domain.ContentHash{fromRef.Target}, DocHash: docHash,
-		Provider: provider, Fidelity: domain.FidelityReconstructed,
+		MemoryHash: memoryHash, Provider: provider, Fidelity: domain.FidelityReconstructed,
 		Message:   fmt.Sprintf("seed: %s → %s", in.FromBranch, in.NewBranch),
 		Author:    in.Author,
 		CreatedAt: time.Now().UTC(),

--- a/cli/internal/app/branch_seed_inheritance_test.go
+++ b/cli/internal/app/branch_seed_inheritance_test.go
@@ -267,6 +267,7 @@ func TestBranchSeedMainMemoryAndConversationStayWithinBudget(t *testing.T) {
 	ctx := context.Background()
 	store := storage.NewFileStore(t.TempDir())
 	repo := domain.Repo{ID: "repo-main-bounded", DefaultBranch: "main", LocalPath: t.TempDir()}
+	fullMainSummary := "MAIN COMPACT MEMORY START\n" + strings.Repeat("project memory ", 12000)
 
 	events := make([]domain.Event, 0, 122)
 	for i := 0; i < 60; i++ {
@@ -280,7 +281,7 @@ func TestBranchSeedMainMemoryAndConversationStayWithinBudget(t *testing.T) {
 		seedMessage("assistant", "latest main answer", len(events)+1),
 	)
 	head := putBranchSeedSnapshot(t, ctx, store, repo.ID, "main", events, nil, &domain.MemoryDigest{
-		Summary:  "MAIN COMPACT MEMORY START\n" + strings.Repeat("project memory ", 12000),
+		Summary:  fullMainSummary,
 		Provider: domain.ProviderCodex,
 	})
 	putBranchSeedRef(t, ctx, store, repo.ID, "main", head)
@@ -317,5 +318,25 @@ func TestBranchSeedMainMemoryAndConversationStayWithinBudget(t *testing.T) {
 	}
 	if !foundLatest {
 		t.Fatal("bounded seed lost latest main user request")
+	}
+	seedSnapshot, err := store.GetSnapshot(ctx, out.SnapshotID)
+	if err != nil {
+		t.Fatalf("get seed snapshot: %v", err)
+	}
+	if seedSnapshot.MemoryHash == "" {
+		t.Fatal("seed snapshot lost the full inherited memory digest")
+	}
+	seedMemory, err := store.GetMemory(ctx, seedSnapshot.MemoryHash)
+	if err != nil {
+		t.Fatalf("get seed memory: %v", err)
+	}
+	if seedMemory.SnapshotID != out.SnapshotID {
+		t.Fatalf("seed memory snapshot = %s, want %s", seedMemory.SnapshotID, out.SnapshotID)
+	}
+	if !strings.Contains(seedMemory.Summary, fullMainSummary) {
+		t.Fatalf("attached seed memory lost full main digest: got %d bytes, want at least %d", len(seedMemory.Summary), len(fullMainSummary))
+	}
+	if !strings.Contains(seedMemory.Summary, "bounded lineage summary") {
+		t.Fatal("attached seed memory lost the fresh departure-lineage digest")
 	}
 }

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -234,7 +234,9 @@ ref. Git checkout hooks normally invoke the corresponding behavior
 automatically. A new branch seed carries the main head's compact memory plus
 the departure branch head's session conversation. Conversations that fit are
 preserved in full; larger sessions keep a bounded recent tail starting at a
-user-turn boundary.
+user-turn boundary. The prompt copy is bounded independently; the complete
+untruncated merged memory remains attached to the seed snapshot for future
+memorize and branch operations.
 
 ### `cxt switch`
 

--- a/scripts/e2e-sync.sh
+++ b/scripts/e2e-sync.sh
@@ -202,6 +202,14 @@ expect "seed materialization" "$([ -n "$SEED" ] && [ -f "$SEED" ] && echo yes)" 
 expect "boundary seed ID matches materialized resume target" "$RESUMEID" "$SEEDID"
 expect "seed inherits main compact memory" "$(grep -q 'Project understanding (main)' "$SEED" && echo yes)" yes
 expect "seed inherits main session conversation" "$(grep -q 'task E' "$SEED" && echo yes)" yes
+SEEDMEM=$(python3 -c "
+import json,glob
+tgt=open('.cxt/refs/heads/feature-x').read().strip()
+for p in glob.glob('.cxt/objects/snapshots/*'):
+    s=json.load(open(p))
+    if s['id']==tgt: print(s.get('memory_hash','')); break
+")
+expect "seed snapshot retains full inherited memory object" "$([ -n "$SEEDMEM" ] && [ -f ".cxt/objects/memories/${SEEDMEM#sha256:}" ] && echo yes)" yes
 SEEDMSG=$(python3 -c "
 import json,glob
 tgt=open('.cxt/refs/heads/feature-x').read().strip()


### PR DESCRIPTION
## Summary

- attach the complete untruncated main + departure-lineage digest to every branch seed snapshot
- keep the materialized agent prompt independently bounded
- prove that a digest larger than the prompt budget survives through `MemoryHash`
- assert the retained memory object in the real checkout/switch sync E2E

## Recovery context

The affected dogfood repository was recovered separately before this change: local/server `main` now points to a snapshot containing the original 725KB memory, all later memory generations, the current Codex conversation, and the missing PR #21 session lineage.

## Validation

- `go test ./...`
- `go vet ./...`
- `go test -race ./internal/app -run TestBranchSeed -count=1`
- `make e2e-sync`
- `bash scripts/public-preflight.sh tree`

Closes #29