### PR TITLE
fix(memory): budget seed prompt sections and drop digest noise

### DIFF
--- a/cli/internal/adapters/memory/distiller.go
+++ b/cli/internal/adapters/memory/distiller.go
@@ -149,7 +149,14 @@ func messageText(blocks []domain.ContentBlock) string {
 }
 
 func isSyntheticSeedText(text string) bool {
-	return strings.HasPrefix(strings.TrimSpace(text), "[cxt seed] Branch-switch context:")
+	t := strings.TrimSpace(text)
+	// Resume seeds start life as CompactSummary events, but materializing into a
+	// provider rollout and re-capturing them yields plain user messages (measured
+	// in real Codex digests) — match the boilerplate by prefix as well. Harness
+	// environment_context blocks are machine-generated state, not user intent.
+	return strings.HasPrefix(t, "[cxt seed] Branch-switch context:") ||
+		strings.HasPrefix(t, "[cxt] This session was resumed from a branch context seed.") ||
+		strings.HasPrefix(t, "<environment_context>")
 }
 
 func appendRecentDistinct(items []string, text string, limit int) []string {

--- a/cli/internal/adapters/memory/distiller_test.go
+++ b/cli/internal/adapters/memory/distiller_test.go
@@ -202,3 +202,34 @@ func TestDistillExtractiveFallbackIsRecentBoundedAndDeterministic(t *testing.T) 
 		t.Fatalf("summary exceeds bound: %d", len([]rune(first.Summary)))
 	}
 }
+
+// TestExtractiveDigestSkipsResumeSeedAndEnvironmentContext (#32): resume-seed
+// boilerplate loses its CompactSummary marking after materialize→re-capture and
+// harness environment_context blocks are machine state — neither may consume
+// the bounded per-role slots of the extractive fallback.
+func TestExtractiveDigestSkipsResumeSeedAndEnvironmentContext(t *testing.T) {
+	cir := domain.CIRDocument{}
+	cir.Envelope.SourceProvider = domain.ProviderCodex
+	cir.Events = []domain.Event{
+		{Kind: domain.EventMessage, Role: "user", Blocks: []domain.ContentBlock{{Type: "text",
+			Text: "[cxt] This session was resumed from a branch context seed. 601 older events were omitted." + strings.Repeat(" boilerplate", 300)}}},
+		{Kind: domain.EventMessage, Role: "user", Blocks: []domain.ContentBlock{{Type: "text",
+			Text: "<environment_context>\n<cwd>/tmp/x</cwd>\n</environment_context>"}}},
+		{Kind: domain.EventMessage, Role: "user", Blocks: []domain.ContentBlock{{Type: "text", Text: "Fix findings one and two."}}},
+		{Kind: domain.EventMessage, Role: "assistant", Blocks: []domain.ContentBlock{{Type: "text", Text: "Budgeted the seed prompt sections."}}},
+	}
+	d, err := NewRuleDistiller().Distill(context.Background(), cir, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"Fix findings one and two.", "Budgeted the seed prompt sections."} {
+		if !strings.Contains(d.Summary, want) {
+			t.Fatalf("summary missing %q:\n%s", want, d.Summary)
+		}
+	}
+	for _, unwanted := range []string{"This session was resumed from a branch context seed", "<environment_context>"} {
+		if strings.Contains(d.Summary, unwanted) {
+			t.Fatalf("summary contains noise %q:\n%s", unwanted, d.Summary)
+		}
+	}
+}

--- a/cli/internal/app/branch_seed.go
+++ b/cli/internal/app/branch_seed.go
@@ -120,8 +120,7 @@ func (s *BranchSeedService) Seed(ctx context.Context, in inbound.SeedInput) (inb
 	// the recent user-boundary-aligned conversation tail.
 	now := time.Now().UTC().Format(time.RFC3339)
 	seedSession := providerfs.NewSessionID()
-	seedText := renderSeedText(in.FromBranch, in.NewBranch, mainMem, branchMem)
-	seedText = truncateUTF8Prefix(seedText, seedDigestBudgetBytes)
+	seedText := renderSeedText(in.FromBranch, in.NewBranch, mainMem, branchMem, seedDigestBudgetBytes)
 	summaryEvent := domain.Event{
 		Kind: domain.EventMessage, Role: "user", Ts: now, Seq: 0,
 		Blocks: []domain.ContentBlock{{Type: "text", Text: seedText}},
@@ -214,38 +213,92 @@ func (s *BranchSeedService) Seed(ctx context.Context, in inbound.SeedInput) (inb
 
 // renderSeedText renders the seed's summary layer (Layer1⊕Layer2) as labeled markdown.
 // Removes overlapping key facts/tasks from Layer2 (maintains layer distinction + removes duplicates).
-func renderSeedText(from, to string, mainMem *domain.MemoryDigest, branchMem domain.MemoryDigest) string {
-	var b strings.Builder
-	fmt.Fprintf(&b, "[cxt seed] Branch-switch context: %s → %s\n", from, to)
-	b.WriteString("This session is the seed of a new branch — continue from the summaries and the verbatim recent context below.\n")
-	seen := map[string]bool{}
+//
+// Sections are budgeted individually (resume-path parity with renderSeedDigest):
+// MergeDigests puts the oldest summary generations first, so a single whole-text
+// prefix cut would keep only stale summary head and silently drop key facts,
+// open tasks, the entire Layer2 digest, and the trailer once the main summary
+// outgrows the digest budget. Bullets are reserved first and summaries keep
+// their newest tail; exact byte accounting guarantees the result fits maxBytes.
+func renderSeedText(from, to string, mainMem *domain.MemoryDigest, branchMem domain.MemoryDigest, maxBytes int) string {
+	header := fmt.Sprintf("[cxt seed] Branch-switch context: %s → %s\n", from, to) +
+		"This session is the seed of a new branch — continue from the summaries and the verbatim recent context below.\n"
+	trailer := "\n## Recent context (verbatim)\nThe events below are the actual conversation right before the switch.\n"
+	mainHeader := "\n## Project understanding (main)\n"
+	branchHeader := "\n## Work summary of this lineage (" + from + ")\n"
+
+	budget := maxBytes - len(header) - len(trailer) - len(branchHeader)
 	if mainMem != nil {
-		b.WriteString("\n## Project understanding (main)\n")
-		writeDigest(&b, *mainMem, seen)
+		budget -= len(mainHeader)
 	}
-	b.WriteString("\n## Work summary of this lineage (" + from + ")\n")
-	writeDigest(&b, branchMem, seen)
-	b.WriteString("\n## Recent context (verbatim)\nThe events below are the actual conversation right before the switch.\n")
+	if budget <= 0 {
+		return truncateUTF8Prefix(header, maxBytes)
+	}
+
+	// Bullets first — the distilled high-value layer must survive an oversized summary.
+	seen := map[string]bool{}
+	var mainFacts, mainTasks string
+	if mainMem != nil {
+		mainFacts = seedBulletLines(seedWorthyFacts(mainMem.KeyFacts), "- ", seen, budget/6)
+		mainTasks = seedBulletLines(mainMem.OpenTasks, "- ☐ ", seen, budget/8)
+	}
+	branchFacts := seedBulletLines(seedWorthyFacts(branchMem.KeyFacts), "- ", seen, budget/8)
+	branchTasks := seedBulletLines(branchMem.OpenTasks, "- ☐ ", seen, budget/8)
+	remaining := budget - len(mainFacts) - len(mainTasks) - len(branchFacts) - len(branchTasks)
+
+	// Summaries share what is left; each keeps its newest tail. The branch
+	// summary is capped so a large lineage digest cannot starve the main layer
+	// (and vice versa — the main summary takes only the final remainder).
+	mainSummary, branchSummary := "", ""
+	if s := strings.TrimSpace(branchMem.Summary); s != "" && remaining > 1 {
+		limit := remaining
+		if mainMem != nil && strings.TrimSpace(mainMem.Summary) != "" && limit > budget/4 {
+			limit = budget / 4
+		}
+		branchSummary = truncateUTF8Tail(s, limit-1) + "\n"
+		seen[s] = true
+		remaining -= len(branchSummary)
+	}
+	if mainMem != nil {
+		if s := strings.TrimSpace(mainMem.Summary); s != "" && !seen[s] && remaining > 1 {
+			mainSummary = truncateUTF8Tail(s, remaining-1) + "\n"
+		}
+	}
+
+	var b strings.Builder
+	b.WriteString(header)
+	if mainMem != nil {
+		b.WriteString(mainHeader)
+		b.WriteString(mainSummary)
+		b.WriteString(mainFacts)
+		b.WriteString(mainTasks)
+	}
+	b.WriteString(branchHeader)
+	b.WriteString(branchSummary)
+	b.WriteString(branchFacts)
+	b.WriteString(branchTasks)
+	b.WriteString(trailer)
 	return b.String()
 }
 
-func writeDigest(b *strings.Builder, d domain.MemoryDigest, seen map[string]bool) {
-	if d.Summary != "" && !seen[d.Summary] {
-		seen[d.Summary] = true
-		b.WriteString(d.Summary + "\n")
+// seedBulletLines renders "- item" lines within maxBytes, skipping items already
+// emitted by an earlier layer (seen dedup shared across Layer1/Layer2).
+func seedBulletLines(items []string, prefix string, seen map[string]bool, maxBytes int) string {
+	if maxBytes <= 0 {
+		return ""
 	}
-	for _, f := range d.KeyFacts {
-		if f == "" || seen[f] {
+	var b strings.Builder
+	for _, item := range items {
+		item = strings.TrimSpace(item)
+		if item == "" || seen[item] {
 			continue
 		}
-		seen[f] = true
-		b.WriteString("- " + f + "\n")
-	}
-	for _, t := range d.OpenTasks {
-		if t == "" || seen[t] {
-			continue
+		line := prefix + item + "\n"
+		if b.Len()+len(line) > maxBytes {
+			continue // keep scanning — a shorter later item may still fit
 		}
-		seen[t] = true
-		b.WriteString("- ☐ " + t + "\n")
+		seen[item] = true
+		b.WriteString(line)
 	}
+	return b.String()
 }

--- a/cli/internal/app/branch_seed_inheritance_test.go
+++ b/cli/internal/app/branch_seed_inheritance_test.go
@@ -267,7 +267,7 @@ func TestBranchSeedMainMemoryAndConversationStayWithinBudget(t *testing.T) {
 	ctx := context.Background()
 	store := storage.NewFileStore(t.TempDir())
 	repo := domain.Repo{ID: "repo-main-bounded", DefaultBranch: "main", LocalPath: t.TempDir()}
-	fullMainSummary := "MAIN COMPACT MEMORY START\n" + strings.Repeat("project memory ", 12000)
+	fullMainSummary := "MAIN COMPACT MEMORY START\n" + strings.Repeat("project memory ", 12000) + "\nMAIN COMPACT MEMORY NEWEST TAIL"
 
 	events := make([]domain.Event, 0, 122)
 	for i := 0; i < 60; i++ {
@@ -306,7 +306,9 @@ func TestBranchSeedMainMemoryAndConversationStayWithinBudget(t *testing.T) {
 	if got := eventsJSONBytes(seed.CIR.Events); got > seedBudgetBytes {
 		t.Fatalf("seed size = %d, want <= %d", got, seedBudgetBytes)
 	}
-	if !strings.Contains(seed.CIR.Events[0].Blocks[0].Text, "MAIN COMPACT MEMORY START") {
+	// The prompt keeps the newest tail of an oversized summary (#31); the full
+	// digest including the head stays reachable via the seed MemoryHash below.
+	if !strings.Contains(seed.CIR.Events[0].Blocks[0].Text, "MAIN COMPACT MEMORY NEWEST TAIL") {
 		t.Fatal("bounded seed lost main compact memory")
 	}
 	foundLatest := false
@@ -338,5 +340,47 @@ func TestBranchSeedMainMemoryAndConversationStayWithinBudget(t *testing.T) {
 	}
 	if !strings.Contains(seedMemory.Summary, "bounded lineage summary") {
 		t.Fatal("attached seed memory lost the fresh departure-lineage digest")
+	}
+}
+
+// TestRenderSeedTextKeepsBulletsAndNewestSummaryTail fixes the seed-prompt
+// budgeting contract (#31): MergeDigests places the oldest summary generations
+// first, so whole-text prefix truncation used to keep only stale summary head
+// and drop key facts, open tasks, the Layer2 digest, and the trailer whenever
+// the main summary outgrew the digest budget.
+func TestRenderSeedTextKeepsBulletsAndNewestSummaryTail(t *testing.T) {
+	mainMem := &domain.MemoryDigest{
+		Summary:   "OLDEST-GENERATION-HEAD\n" + strings.Repeat("m", 4*seedDigestBudgetBytes) + "\nNEWEST-MAIN-TAIL",
+		KeyFacts:  []string{"main fact alpha beta"},
+		OpenTasks: []string{"main task gamma delta"},
+	}
+	branchMem := domain.MemoryDigest{
+		Summary:   "OLD-BRANCH-HEAD\n" + strings.Repeat("b", 2*seedDigestBudgetBytes) + "\nNEWEST-BRANCH-TAIL",
+		KeyFacts:  []string{"branch fact epsilon zeta"},
+		OpenTasks: []string{"branch task eta theta"},
+	}
+	out := renderSeedText("main", "fix/x", mainMem, branchMem, seedDigestBudgetBytes)
+	if len(out) > seedDigestBudgetBytes {
+		t.Fatalf("seed text = %d bytes, want <= %d", len(out), seedDigestBudgetBytes)
+	}
+	for _, want := range []string{
+		"## Project understanding (main)",
+		"- main fact alpha beta",
+		"- ☐ main task gamma delta",
+		"NEWEST-MAIN-TAIL",
+		"## Work summary of this lineage (main)",
+		"- branch fact epsilon zeta",
+		"- ☐ branch task eta theta",
+		"NEWEST-BRANCH-TAIL",
+		"## Recent context (verbatim)",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("seed text missing %q", want)
+		}
+	}
+	for _, unwanted := range []string{"OLDEST-GENERATION-HEAD", "OLD-BRANCH-HEAD"} {
+		if strings.Contains(out, unwanted) {
+			t.Fatalf("seed text kept stale summary head %q instead of the newest tail", unwanted)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- rewrite `renderSeedText` with per-section budgets (resume-path parity with `renderSeedDigest`): key facts and open tasks are reserved first, summaries keep their newest tail via `truncateUTF8Tail`, and exact byte accounting guarantees the assembled prompt fits `seedDigestBudgetBytes`
- extend the extractive-digest noise filter to skip resume-seed boilerplate (`[cxt] This session was resumed from a branch context seed.` — CompactSummary marking is lost after materialize→re-capture) and harness `<environment_context>` blocks

## Why

`MergeDigests` places the oldest summary generations first. With the previous whole-text `truncateUTF8Prefix` cut, a main memory summary larger than 96KiB (the dogfood repo is at ~735KiB today) left only stale summary head in the seed prompt and silently dropped main key facts, open tasks, the entire departure-lineage digest, and the trailer. Separately, real stored digests show the six per-role extractive slots being consumed by resume-seed boilerplate and environment_context noise (2,000 runes each).

## Validation

- `go vet ./... && go test ./...` (CLI), `go test -race` on the touched packages
- `./scripts/e2e-sync.sh` all passed
- `bash scripts/public-preflight.sh tree`
- new regression tests: `TestRenderSeedTextKeepsBulletsAndNewestSummaryTail`, `TestExtractiveDigestSkipsResumeSeedAndEnvironmentContext`; `TestBranchSeedMainMemoryAndConversationStayWithinBudget` updated to the newest-tail contract (full digest still asserted lossless via seed MemoryHash)

Closes #31
Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)