### PR TITLE
fix(hook): real seed-ID cross-check + provider recency + single ps snapshot

### DIFF
--- a/cli/internal/adapters/delivery/cli/agent_wrapper_ancestry_test.go
+++ b/cli/internal/adapters/delivery/cli/agent_wrapper_ancestry_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"os"
 	"strconv"
 	"testing"
@@ -44,18 +45,40 @@ func TestSupervisedProviderRequiresOwningWrapperPID(t *testing.T) {
 	t.Setenv("CXT_WRAPPED", "1")
 	t.Setenv("CXT_WRAPPED_AGENT", "codex")
 	t.Setenv("CXT_WRAPPER_PID", strconv.Itoa(os.Getppid()))
-	provider, managed := supervisedProvider()
+	provider, managed := supervisedProvider(context.Background(), t.TempDir())
 	if provider != domain.ProviderCodex || !managed {
 		t.Fatalf("provider=%q managed=%v, want codex/true", provider, managed)
 	}
 
 	t.Setenv("CXT_WRAPPER_PID", "99999999")
-	if _, managed := supervisedProvider(); managed {
+	if _, managed := supervisedProvider(context.Background(), t.TempDir()); managed {
 		t.Fatal("stale wrapper PID was accepted")
 	}
 
 	t.Setenv("CXT_WRAPPER_PID", "")
-	if _, managed := supervisedProvider(); managed {
+	if _, managed := supervisedProvider(context.Background(), t.TempDir()); managed {
 		t.Fatal("missing wrapper PID was accepted")
+	}
+}
+
+func TestProviderByRecency(t *testing.T) {
+	if providerByRecency(0, 0) != domain.ProviderClaude {
+		t.Fatal("no sessions must default to claude")
+	}
+	if providerByRecency(100, 200) != domain.ProviderCodex {
+		t.Fatal("newer codex session was not selected")
+	}
+	if providerByRecency(200, 100) != domain.ProviderClaude {
+		t.Fatal("newer claude session was not selected")
+	}
+	if providerByRecency(100, 100) != domain.ProviderClaude {
+		t.Fatal("tie must stay claude")
+	}
+}
+
+func TestParsePIDTable(t *testing.T) {
+	table := parsePIDTable([]byte("  50   40\n40 30\ngarbage line here\n 30    1\n\n"))
+	if len(table) != 3 || table[50] != 40 || table[40] != 30 || table[30] != 1 {
+		t.Fatalf("parsed table = %v", table)
 	}
 }

--- a/cli/internal/adapters/delivery/cli/githook.go
+++ b/cli/internal/adapters/delivery/cli/githook.go
@@ -185,7 +185,7 @@ func contextSwitch(ctx context.Context, c *Container, cwd string) error {
 	branch := gitOut(cwd, "rev-parse", "--abbrev-ref", "HEAD")
 	prevBranch := gitOut(cwd, "rev-parse", "--abbrev-ref", "@{-1}")
 	detached := branch == "" || branch == "HEAD"
-	targetProvider, wrapperManaged := supervisedProvider()
+	targetProvider, wrapperManaged := supervisedProvider(ctx, cwd)
 
 	// 1) Checkpoint: snapshot and push (best-effort) the live sessions from the previous branch.
 	//    Ensure isolation target file paths here (direct use of capture adapter — hook-specific paths).
@@ -270,7 +270,7 @@ func contextSwitch(ctx context.Context, c *Container, cwd string) error {
 			// Existing branch: load context of that task (current context is not carried).
 			if out, err := c.Checkout.Checkout(ctx, inbound.CheckoutInput{From: branch, TargetProvider: targetProvider, Mode: hookLoadMode(cwd), Cwd: cwd}); err == nil {
 				b.SeedPath, b.ResumeCmd = out.WrittenPath, out.ResumeCmd
-				b.SeedID = restoredSessionID(out.WrittenPath, out.ResumeCmd, "")
+				b.SeedID = restoredSessionID(out.WrittenPath, out.ResumeCmd)
 				fmt.Printf("cxt: %q context prepared  [fidelity: %s]\n", branch, out.Fidelity)
 				syncSettingsToSnapshot(ctx, c, cwd, out.Head, "git checkout "+branch)
 			}
@@ -278,7 +278,7 @@ func contextSwitch(ctx context.Context, c *Container, cwd string) error {
 			// New branch: seed genesis — main memory ⊕ ancestry summary + previous commit raw tail.
 			if out, err := c.Seed.Seed(ctx, inbound.SeedInput{Cwd: cwd, FromBranch: prevBranch, NewBranch: branch, Provider: targetProvider, Author: c.Identity}); err == nil {
 				b.SeedPath, b.ResumeCmd = out.WrittenPath, out.ResumeCmd
-				b.SeedID = restoredSessionID(out.WrittenPath, out.ResumeCmd, out.SessionID)
+				b.SeedID = restoredSessionID(out.WrittenPath, out.ResumeCmd)
 				fmt.Printf("cxt: seed created → branch %q (snapshot %s)\n", branch, shortHash(out.SnapshotID))
 				if _, ok := remotecfg.Origin(cwd); ok {
 					if _, perr := c.Sync.Push(ctx, inbound.SyncInput{Cwd: cwd}); perr != nil && strings.Contains(perr.Error(), domain.ErrSyncConflict.Error()) {
@@ -325,10 +325,13 @@ func contextSwitch(ctx context.Context, c *Container, cwd string) error {
 // current process ancestry. A boolean environment marker alone is insufficient:
 // resumed shells and app integrations can retain CXT_WRAPPED after the original
 // supervisor has exited, which previously caused an unrestartable boundary kill.
-func supervisedProvider() (domain.ProviderKind, bool) {
+func supervisedProvider(ctx context.Context, cwd string) (domain.ProviderKind, bool) {
 	agent := domain.ProviderKind(os.Getenv("CXT_WRAPPED_AGENT"))
 	if agent != domain.ProviderClaude && agent != domain.ProviderCodex {
-		agent = domain.ProviderClaude
+		// Pre-wrapper-env sessions and plain terminals carry no agent marker.
+		// A fixed claude default materialized claude seeds for live codex
+		// sessions (#35) — follow the provider that is actually active here.
+		agent = activeProviderForCwd(ctx, cwd)
 	}
 	if os.Getenv("CXT_WRAPPED") != "1" {
 		return agent, false
@@ -337,7 +340,62 @@ func supervisedProvider() (domain.ProviderKind, bool) {
 	if err != nil || wrapperPID <= 1 {
 		return agent, false
 	}
-	return agent, hasProcessAncestor(os.Getppid(), wrapperPID, processParentPID)
+	return agent, hasProcessAncestor(os.Getppid(), wrapperPID, snapshotParentPID())
+}
+
+// activeProviderForCwd picks the provider whose session file for this cwd was
+// modified most recently (claude on ties and when neither has sessions).
+func activeProviderForCwd(ctx context.Context, cwd string) domain.ProviderKind {
+	newest := func(paths []string) int64 {
+		var best int64
+		for _, p := range paths {
+			if info, err := os.Stat(p); err == nil {
+				if ns := info.ModTime().UnixNano(); ns > best {
+					best = ns
+				}
+			}
+		}
+		return best
+	}
+	return providerByRecency(newest(claudeSessionFiles(cwd)), newest(codexSessionFiles(ctx, cwd)))
+}
+
+func providerByRecency(claudeNewest, codexNewest int64) domain.ProviderKind {
+	if codexNewest > claudeNewest {
+		return domain.ProviderCodex
+	}
+	return domain.ProviderClaude
+}
+
+// snapshotParentPID reads the process table once and answers ancestry lookups
+// from memory — the previous per-ancestor `ps -p` spawned a process for every
+// step of the walk on the git-hook hot path (#35).
+func snapshotParentPID() func(int) (int, bool) {
+	out, err := exec.Command("ps", "-axo", "pid=,ppid=").Output()
+	if err != nil {
+		return processParentPID // degraded fallback: per-pid query
+	}
+	table := parsePIDTable(out)
+	return func(pid int) (int, bool) {
+		ppid, ok := table[pid]
+		return ppid, ok && ppid > 0
+	}
+}
+
+func parsePIDTable(out []byte) map[int]int {
+	table := map[int]int{}
+	for _, line := range strings.Split(string(out), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) != 2 {
+			continue
+		}
+		pid, perr := strconv.Atoi(fields[0])
+		ppid, qerr := strconv.Atoi(fields[1])
+		if perr == nil && qerr == nil && pid > 0 {
+			table[pid] = ppid
+		}
+	}
+	return table
 }
 
 func processParentPID(pid int) (int, bool) {
@@ -397,9 +455,12 @@ func codexSessionFiles(ctx context.Context, cwd string) []string {
 
 // restoredSessionID returns the canonical provider-rewritten resume target.
 // Materialization must have produced both a path and a trusted resume command.
-// For branch seeds, materializedID cross-checks the use-case output against the
-// command so a stale synthetic CIR ID cannot become the wrapper restart target.
-func restoredSessionID(path, resumeCmd, materializedID string) string {
+// The resume ID is cross-checked against the materialized file name — an
+// independent source (both materializers embed the rewritten ID in it) — so a
+// stale or mismatched resume command cannot become the wrapper restart target.
+// The previous cross-check compared two values parsed from the same command
+// string and could never disagree (#34).
+func restoredSessionID(path, resumeCmd string) string {
 	if path == "" || resumeCmd == "" {
 		return ""
 	}
@@ -411,7 +472,7 @@ func restoredSessionID(path, resumeCmd, materializedID string) string {
 	if !providerfs.ValidSessionID(resumeID) {
 		return ""
 	}
-	if materializedID != "" && (!providerfs.ValidSessionID(materializedID) || materializedID != resumeID) {
+	if !strings.Contains(filepath.Base(path), resumeID) {
 		return ""
 	}
 	return resumeID

--- a/cli/internal/adapters/delivery/cli/githook_session_id_test.go
+++ b/cli/internal/adapters/delivery/cli/githook_session_id_test.go
@@ -9,11 +9,10 @@ import (
 func TestRestoredSessionID(t *testing.T) {
 	const sessionID = "12345678-1234-4abc-8def-1234567890ab"
 	tests := []struct {
-		name           string
-		path           string
-		resumeCmd      string
-		materializedID string
-		want           string
+		name      string
+		path      string
+		resumeCmd string
+		want      string
 	}{
 		{
 			name:      "claude materialization",
@@ -28,17 +27,17 @@ func TestRestoredSessionID(t *testing.T) {
 			want:      sessionID,
 		},
 		{
-			name:           "seed output agrees with resume command",
-			path:           "/tmp/materialized.jsonl",
-			resumeCmd:      "codex resume " + sessionID,
-			materializedID: sessionID,
-			want:           sessionID,
+			// The materialized file name is the independent cross-check (#34):
+			// a resume command pointing at a session the materializer did not
+			// write must never become the wrapper restart target.
+			name:      "resume target absent from materialized file name",
+			path:      "/tmp/materialized.jsonl",
+			resumeCmd: "codex resume " + sessionID,
 		},
 		{
-			name:           "seed output disagrees with resume command",
-			path:           "/tmp/materialized.jsonl",
-			resumeCmd:      "codex resume " + sessionID,
-			materializedID: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+			name:      "materialized file name carries a different session",
+			path:      "/tmp/.claude/projects/repo/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa.jsonl",
+			resumeCmd: "claude --resume " + sessionID,
 		},
 		{
 			name:      "missing materialized path",
@@ -46,24 +45,18 @@ func TestRestoredSessionID(t *testing.T) {
 		},
 		{
 			name: "missing resume command",
-			path: "/tmp/materialized.jsonl",
+			path: "/tmp/" + sessionID + ".jsonl",
 		},
 		{
 			name:      "invalid resume target",
-			path:      "/tmp/materialized.jsonl",
+			path:      "/tmp/" + sessionID + ".jsonl",
 			resumeCmd: "codex resume ../../outside",
-		},
-		{
-			name:           "invalid materialized ID",
-			path:           "/tmp/materialized.jsonl",
-			resumeCmd:      "codex resume " + sessionID,
-			materializedID: "../../outside",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := restoredSessionID(tt.path, tt.resumeCmd, tt.materializedID); got != tt.want {
+			if got := restoredSessionID(tt.path, tt.resumeCmd); got != tt.want {
 				t.Fatalf("restoredSessionID() = %q, want %q", got, tt.want)
 			}
 		})


### PR DESCRIPTION
## Summary

- `restoredSessionID` cross-checks the resume target against the **materialized file name** — an independent source (both materializers embed the rewritten session ID in it). The previous `materializedID` parameter compared two values parsed from the same resume-command string and could never disagree.
- `supervisedProvider` no longer hard-defaults to claude when `CXT_WRAPPED_AGENT` is absent (pre-wrapper-env sessions, plain terminals): it picks the provider whose session file for this cwd was modified most recently, so live codex sessions stop getting claude-materialized checkout/seed targets. Kill/restart gating is unchanged (still requires a live owning wrapper PID in the ancestry).
- Ancestry walks read the process table once (`ps -axo pid=,ppid=`) instead of spawning `ps -p` per ancestor on the git-hook hot path; per-pid query remains as a degraded fallback.

## Validation

- `go vet ./... && go test ./...` (CLI) + `-race` on the touched package
- new/updated regressions: `TestRestoredSessionID` (file-name cross-check contract), `TestProviderByRecency`, `TestParsePIDTable`
- `./scripts/e2e-sync.sh` all passed, `bash scripts/public-preflight.sh tree` passed

Closes #34
Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)