### PR TITLE
feat(memory): bounded carry for merged digest summaries

### DIFF
--- a/cli/internal/app/branch_seed.go
+++ b/cli/internal/app/branch_seed.go
@@ -156,14 +156,16 @@ func (s *BranchSeedService) Seed(ctx context.Context, in inbound.SeedInput) (inb
 		return inbound.SeedOutput{}, err
 	}
 	// The materialized prompt is intentionally bounded, but the branch must not
-	// lose the complete inherited digest. Attach the untruncated main +
-	// departure-lineage memory to the seed snapshot so the next memorize/seed
-	// operation inherits the full value rather than re-distilling the truncated
-	// summary event.
+	// lose the inherited digest. Attach the merged main + departure-lineage
+	// memory to the seed snapshot so the next memorize/seed operation inherits
+	// it rather than re-distilling the truncated summary event. The carried
+	// copy is bounded (#33 — newest tail); older generations stay reachable
+	// through the parent chain's memory objects.
 	seedMemory := branchMem
 	if mainMem != nil {
 		seedMemory = domain.MergeDigests(*mainMem, branchMem)
 	}
+	seedMemory = boundCarriedDigest(seedMemory)
 	seedMemory.SnapshotID = docHash
 	if seedMemory.Provider == "" {
 		seedMemory.Provider = provider

--- a/cli/internal/app/branch_seed_inheritance_test.go
+++ b/cli/internal/app/branch_seed_inheritance_test.go
@@ -384,3 +384,56 @@ func TestRenderSeedTextKeepsBulletsAndNewestSummaryTail(t *testing.T) {
 		}
 	}
 }
+
+// TestBranchSeedCarriedMemoryIsBounded (#33): a seed born under an oversized
+// main memory stores a bounded carried digest (newest tail), while the
+// ancestor's full memory object stays untouched and reachable via the parent.
+func TestBranchSeedCarriedMemoryIsBounded(t *testing.T) {
+	ctx := context.Background()
+	store := storage.NewFileStore(t.TempDir())
+	repo := domain.Repo{ID: "repo-mem-cap", DefaultBranch: "main", LocalPath: t.TempDir()}
+	oversized := "OLDEST-GENERATION-HEAD\n" + strings.Repeat("project memory ", 2*memoryCarryBudgetBytes/15) + "\nNEWEST-GENERATION-TAIL"
+	head := putBranchSeedSnapshot(t, ctx, store, repo.ID, "main",
+		[]domain.Event{seedMessage("user", "latest main request", 0)}, nil,
+		&domain.MemoryDigest{Summary: oversized, Provider: domain.ProviderCodex})
+	putBranchSeedRef(t, ctx, store, repo.ID, "main", head)
+
+	service := NewBranchSeedService(
+		branchSeedGit{repo: repo},
+		store,
+		stubDistiller{d: domain.MemoryDigest{Summary: "fresh lineage summary"}},
+		nil,
+		nil,
+	)
+	out, err := service.Seed(ctx, inbound.SeedInput{
+		Cwd: repo.LocalPath, FromBranch: "main", NewBranch: "feature/cap", Provider: domain.ProviderCodex,
+	})
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	seedSnap, err := store.GetSnapshot(ctx, out.SnapshotID)
+	if err != nil || seedSnap.MemoryHash == "" {
+		t.Fatalf("seed snapshot missing memory: %+v err=%v", seedSnap, err)
+	}
+	carried, err := store.GetMemory(ctx, seedSnap.MemoryHash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(carried.Summary) > memoryCarryBudgetBytes {
+		t.Fatalf("carried seed memory = %d bytes, want <= %d", len(carried.Summary), memoryCarryBudgetBytes)
+	}
+	if !strings.Contains(carried.Summary, "NEWEST-GENERATION-TAIL") || !strings.Contains(carried.Summary, "fresh lineage summary") {
+		t.Fatal("carried seed memory lost the newest generations")
+	}
+	mainSnap, err := store.GetSnapshot(ctx, head)
+	if err != nil {
+		t.Fatal(err)
+	}
+	full, err := store.GetMemory(ctx, mainSnap.MemoryHash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if full.Summary != oversized {
+		t.Fatal("ancestor full memory object changed — history must stay recoverable")
+	}
+}

--- a/cli/internal/app/load_session.go
+++ b/cli/internal/app/load_session.go
@@ -515,6 +515,9 @@ func (s *LoadSessionService) loadMemory(ctx context.Context, cir domain.CIRDocum
 	if prior, ok := nearestAncestorDigest(ctx, s.store, snap); ok {
 		digest = domain.MergeDigests(prior, digest)
 	}
+	// Injected provider memory files are a forward working copy too — bounded
+	// carry (#33) keeps the newest tail instead of writing an ever-growing file.
+	digest = boundCarriedDigest(digest)
 	digest.SnapshotID = snap.ID
 	if digest.Provider == "" {
 		digest.Provider = target

--- a/cli/internal/app/memorize.go
+++ b/cli/internal/app/memorize.go
@@ -109,6 +109,7 @@ func (s *MemorizeService) Memorize(ctx context.Context, in inbound.MemorizeInput
 		prior.KeyFacts = seedWorthyFacts(prior.KeyFacts)
 		digest = domain.MergeDigests(prior, digest)
 	}
+	digest = boundCarriedDigest(digest)
 	digest.SnapshotID = snap.ID
 
 	memHash, err := s.store.PutMemory(ctx, digest)
@@ -149,4 +150,22 @@ func nearestAncestorDigest(ctx context.Context, store outbound.SessionStore, sna
 		queue = append(queue, ps.ReachabilityParents()...)
 	}
 	return domain.MemoryDigest{}, false
+}
+
+// memoryCarryBudgetBytes bounds the summary carried forward by a merged digest
+// (#33 — bounded carry, user-approved policy). MergeDigests concatenates
+// generations oldest-first, so the forward working set grew without bound
+// (measured 768KB in the dogfood repo). The carried copy keeps the newest
+// tail; every prior generation's full digest object stays attached to its
+// ancestor snapshot (content-addressed, never deleted), so complete history
+// remains recoverable through the parent chain.
+const memoryCarryBudgetBytes = 256 << 10
+
+// boundCarriedDigest caps the summary of a digest that will be carried forward
+// (stored on a new snapshot or injected as a provider memory file).
+func boundCarriedDigest(d domain.MemoryDigest) domain.MemoryDigest {
+	if len(d.Summary) > memoryCarryBudgetBytes {
+		d.Summary = truncateUTF8Tail(d.Summary, memoryCarryBudgetBytes)
+	}
+	return d
 }

--- a/cli/internal/app/memory_lineage_test.go
+++ b/cli/internal/app/memory_lineage_test.go
@@ -79,3 +79,35 @@ func TestNearestAncestorDigest(t *testing.T) {
 		t.Fatalf("overlay graft inheritance failed: ok=%v summary=%q", ok, d.Summary)
 	}
 }
+
+// TestBoundCarriedDigestKeepsNewestTail (#33 — bounded carry): the forward
+// working set is capped at memoryCarryBudgetBytes keeping the newest tail;
+// under-budget digests pass through unchanged.
+func TestBoundCarriedDigestKeepsNewestTail(t *testing.T) {
+	small := domain.MemoryDigest{Summary: "compact history", KeyFacts: []string{"f"}}
+	if got := boundCarriedDigest(small); got.Summary != small.Summary {
+		t.Fatalf("under-budget summary changed: %q", got.Summary)
+	}
+
+	big := domain.MemoryDigest{
+		Summary:   "OLDEST-GENERATION-HEAD\n" + strings.Repeat("m", 2*memoryCarryBudgetBytes) + "\nNEWEST-GENERATION-TAIL",
+		KeyFacts:  []string{"fact stays"},
+		OpenTasks: []string{"task stays"},
+	}
+	got := boundCarriedDigest(big)
+	if len(got.Summary) > memoryCarryBudgetBytes {
+		t.Fatalf("carried summary = %d bytes, want <= %d", len(got.Summary), memoryCarryBudgetBytes)
+	}
+	if !strings.Contains(got.Summary, "NEWEST-GENERATION-TAIL") {
+		t.Fatal("bounded carry lost the newest generation")
+	}
+	if strings.Contains(got.Summary, "OLDEST-GENERATION-HEAD") {
+		t.Fatal("bounded carry kept the oldest head instead of the newest tail")
+	}
+	if !strings.Contains(got.Summary, "[... earlier summary omitted ...]") {
+		t.Fatal("bounded carry missing the omission marker")
+	}
+	if len(got.KeyFacts) != 1 || len(got.OpenTasks) != 1 {
+		t.Fatalf("bullets changed: facts=%v tasks=%v", got.KeyFacts, got.OpenTasks)
+	}
+}


### PR DESCRIPTION
## Summary

Implements the bounded-carry policy approved for #33: digests carried forward — memorize attach, branch-seed attach, and memory-mode provider file injection — cap their summary at 256KiB (`memoryCarryBudgetBytes`), keeping the newest tail with an explicit `[... earlier summary omitted ...]` marker.

**No history is deleted**: every prior generation's full digest object remains attached to its ancestor snapshot (content-addressed) and stays recoverable through the parent chain.

## Why

`MergeDigests` concatenates generations oldest-first, so the forward working set grew without bound — 768KB measured on the dogfood repo, plus a new full-size memory object persisted per branch seed (#33, compounding the known storage-bloat vector).

## Validation

- `go vet ./... && go test ./...` (CLI)
- new regressions: `TestBoundCarriedDigestKeepsNewestTail`, `TestBranchSeedCarriedMemoryIsBounded` (ancestor object asserted byte-identical)
- `./scripts/e2e-sync.sh` all passed, `bash scripts/public-preflight.sh tree` passed

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)