### PR TITLE
fix: harden branch transitions and preserve fresh memory

### DIFF
--- a/cli/internal/adapters/boundary/boundary.go
+++ b/cli/internal/adapters/boundary/boundary.go
@@ -117,6 +117,28 @@ func Supersede(repoRoot, path string) string {
 	return renamed
 }
 
+// RestoreSuperseded rolls back Supersede when the transition boundary could
+// not be recorded. The bytes remain recoverable even if rename-back fails; in
+// that case the ledger marker is intentionally retained.
+func RestoreSuperseded(repoRoot, renamed string) bool {
+	if !providerfs.IsProviderSessionPath(renamed) {
+		return false
+	}
+	original := strings.TrimSuffix(renamed, ".superseded")
+	if original == renamed {
+		return providerfs.UnmarkSuperseded(repoRoot, original) == nil
+	}
+	if _, err := os.Stat(original); err == nil {
+		// A provider recreated the path while its old descriptor pointed at the
+		// renamed file. Never replace those newly written bytes.
+		return false
+	}
+	if err := os.Rename(renamed, original); err != nil {
+		return false
+	}
+	return providerfs.UnmarkSuperseded(repoRoot, original) == nil
+}
+
 // Notify sends an OS alert (best-effort — macOS osascript / Linux notify-send).
 func Notify(title, msg string) {
 	switch runtime.GOOS {

--- a/cli/internal/adapters/boundary/boundary_security_test.go
+++ b/cli/internal/adapters/boundary/boundary_security_test.go
@@ -80,6 +80,33 @@ func TestSupersedeRejectsOutsidePath(t *testing.T) {
 	}
 }
 
+func TestRestoreSupersededRollsBackFileAndLedger(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	repo := t.TempDir()
+	sessionDir := filepath.Join(home, ".claude", "projects", "repo")
+	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	original := filepath.Join(sessionDir, providerfs.NewSessionID()+".jsonl")
+	if err := os.WriteFile(original, []byte("session\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	renamed := Supersede(repo, original)
+	if renamed == "" || !providerfs.CaptureExcluded(repo, original, 999) {
+		t.Fatal("session was not superseded")
+	}
+	if !RestoreSuperseded(repo, renamed) {
+		t.Fatal("superseded session was not restored")
+	}
+	if data, err := os.ReadFile(original); err != nil || string(data) != "session\n" {
+		t.Fatalf("restored file = %q, err=%v", data, err)
+	}
+	if providerfs.CaptureExcluded(repo, original, 999) {
+		t.Fatal("rollback left the session excluded in the ledger")
+	}
+}
+
 func writeBoundaryFixture(t *testing.T, repo string, b Boundary) {
 	t.Helper()
 	data, err := json.Marshal(b)

--- a/cli/internal/adapters/delivery/cli/githook.go
+++ b/cli/internal/adapters/delivery/cli/githook.go
@@ -238,43 +238,46 @@ func contextSwitch(ctx context.Context, c *Container, cwd string) error {
 		fmt.Printf("cxt: prepare mode — no recovery. Context switch: cxt checkout %s\n", branch)
 		return nil
 	}
-
-	// 2) Isolation: old session ended at switch point — subsequent utterances are not recorded.
-	// Isolates all session files in this cwd, not just the latest session: branch switch changes disk state (all session prerequisites), so must prevent remaining sessions from being erroneously active in next commit (multi-terminal cases included). Applies to claude/codex as well.
-	var superseded []string
-	for _, p := range append(claudeSessionFiles(cwd), codexSessionFiles(ctx, cwd)...) {
-		if renamed := boundary.Supersede(cwd, p); renamed != "" {
-			superseded = append(superseded, renamed)
-		}
+	if detached {
+		// Detached HEAD has no target branch context to prepare. Keep every live
+		// provider session captureable; isolating first would strand the running
+		// agent without a restart target.
+		fmt.Println("cxt: detached HEAD — time travel mode (current session maintained). Recovery: cxt checkout <ref>")
+		return nil
 	}
 
-	// 3) Recovery/seed.
-	b := boundary.Boundary{PrevBranch: prevBranch, Branch: branch, Superseded: superseded}
-	switch {
-	case detached:
-		fmt.Println("cxt: detached HEAD — time travel mode (no context capture). Recovery: cxt checkout <ref>")
-	default:
-		existing, lerr := c.List.List(ctx, inbound.ListInput{Branch: branch})
+	// 2) Prepare recovery/seed before mutating any provider session file. A
+	// failed or memory-only materialization must leave the current session
+	// captureable; isolation is the commit step of this transition.
+	b := boundary.Boundary{PrevBranch: prevBranch, Branch: branch}
+	prepareExpected := false
+	var prepareErr error
+	existing, lerr := c.List.List(ctx, inbound.ListInput{Branch: branch})
+	if lerr != nil {
+		prepareErr = lerr
+	} else {
 		// fork-only ref (web fork connection·git branch fork) exists without label snapshot —
 		// this is also an "existing branch" (seed override invalidates fork connection).
 		hasRef := false
-		if lerr == nil {
-			for _, r := range existing.Refs {
-				if r.Kind == domain.RefBranch && r.Name == branch && r.Target != "" {
-					hasRef = true
-					break
-				}
+		for _, r := range existing.Refs {
+			if r.Kind == domain.RefBranch && r.Name == branch && r.Target != "" {
+				hasRef = true
+				break
 			}
 		}
-		if lerr == nil && (len(existing.Snapshots) > 0 || hasRef) {
+		if len(existing.Snapshots) > 0 || hasRef {
+			prepareExpected = true
 			// Existing branch: load context of that task (current context is not carried).
 			if out, err := c.Checkout.Checkout(ctx, inbound.CheckoutInput{From: branch, TargetProvider: targetProvider, Mode: hookLoadMode(cwd), Cwd: cwd}); err == nil {
 				b.SeedPath, b.ResumeCmd = out.WrittenPath, out.ResumeCmd
 				b.SeedID = restoredSessionID(out.WrittenPath, out.ResumeCmd)
 				fmt.Printf("cxt: %q context prepared  [fidelity: %s]\n", branch, out.Fidelity)
 				syncSettingsToSnapshot(ctx, c, cwd, out.Head, "git checkout "+branch)
+			} else {
+				prepareErr = err
 			}
 		} else if prevBranch != "" && prevBranch != branch {
+			prepareExpected = true
 			// New branch: seed genesis — main memory ⊕ ancestry summary + previous commit raw tail.
 			if out, err := c.Seed.Seed(ctx, inbound.SeedInput{Cwd: cwd, FromBranch: prevBranch, NewBranch: branch, Provider: targetProvider, Author: c.Identity}); err == nil {
 				b.SeedPath, b.ResumeCmd = out.WrittenPath, out.ResumeCmd
@@ -286,27 +289,47 @@ func contextSwitch(ctx context.Context, c *Container, cwd string) error {
 						hookWarn("remote context branch %q exists with same name (web fork?) — push reordering will occur", branch)
 					}
 				}
+			} else {
+				prepareErr = err
 			}
 		}
 	}
 
-	// 4) Boundary signal + execution.
-	if len(superseded) > 0 || b.SeedPath != "" {
-		if !boundaryTransitionSafe(b, wrapperManaged) {
-			hookWarn("context boundary has no valid resume target; active agent was not terminated — continue explicitly with cxt checkout %s", branch)
-			return nil
+	// 3) Preflight the complete restart target before isolation. In particular,
+	// memory-mode fallback has a path but no resume command and cannot restart a
+	// wrapper child automatically.
+	if !transitionPreflightSafe(prepareErr, prepareExpected, b, wrapperManaged) {
+		hookWarn("context recovery was not restartable; current session was preserved — continue explicitly with cxt checkout %s", branch)
+		return nil
+	}
+
+	// 4) Commit isolation only after recovery preflight succeeds. Isolate all
+	// sessions in this cwd (multi-terminal invariant), then atomically record the
+	// boundary consumed by the wrapper. The newly materialized restart target is
+	// deliberately excluded from the old-session inventory.
+	for _, p := range append(claudeSessionFiles(cwd), codexSessionFiles(ctx, cwd)...) {
+		if !shouldSupersedeSession(p, b.SeedPath) {
+			continue
 		}
+		if renamed := boundary.Supersede(cwd, p); renamed != "" {
+			b.Superseded = append(b.Superseded, renamed)
+		}
+	}
+	if len(b.Superseded) > 0 || b.SeedPath != "" {
 		if err := boundary.Record(cwd, b); err != nil {
+			for i := len(b.Superseded) - 1; i >= 0; i-- {
+				_ = boundary.RestoreSuperseded(cwd, b.Superseded[i])
+			}
 			hookWarn("context boundary was not recorded; active agent was not terminated: %v", err)
 			return nil
 		}
 		if b.ResumeCmd != "" {
 			fmt.Printf("cxt: ⚠ Context switch — previous session is isolated (not recorded). Continue: %s\n", b.ResumeCmd)
-		} else if len(superseded) > 0 {
+		} else if len(b.Superseded) > 0 {
 			fmt.Println("cxt: ⚠ Context switch — previous session is isolated (not recorded)")
 		}
 		boundary.Notify("cxt Context switch", fmt.Sprintf("%s → %s — previous session isolated, new context prepared", b.PrevBranch, b.Branch))
-		if len(superseded) > 0 && remotecfg.BoundaryEnforce(cwd) == "kill" && wrapperManaged {
+		if len(b.Superseded) > 0 && remotecfg.BoundaryEnforce(cwd) == "kill" && wrapperManaged {
 			// Detach session agent delay end — detached helper (hook can be a descendant of the agent, so it cannot be killed immediately). The wrapper (cxt claude) detects child death and automatically restarts the seed.
 			if exe, err := os.Executable(); err == nil {
 				cmd := exec.Command(exe, "git-hook", "boundary-enforce")
@@ -314,7 +337,7 @@ func contextSwitch(ctx context.Context, c *Container, cwd string) error {
 				cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
 				_ = cmd.Start()
 			}
-		} else if len(superseded) > 0 && remotecfg.BoundaryEnforce(cwd) == "kill" {
+		} else if len(b.Superseded) > 0 && remotecfg.BoundaryEnforce(cwd) == "kill" {
 			hookWarn("no live owning cxt wrapper — active agent was not terminated; continue explicitly with %s", b.ResumeCmd)
 		}
 	}
@@ -343,21 +366,23 @@ func supervisedProvider(ctx context.Context, cwd string) (domain.ProviderKind, b
 	return agent, hasProcessAncestor(os.Getppid(), wrapperPID, snapshotParentPID())
 }
 
-// activeProviderForCwd picks the provider whose session file for this cwd was
-// modified most recently (claude on ties and when neither has sessions).
+// activeProviderForCwd picks the provider whose capture-eligible active session
+// for this cwd was modified most recently (claude on ties and when neither has
+// sessions). Use LocateActiveSession rather than the isolation inventory: the
+// latter intentionally includes ledger-excluded materialized recovery files.
 func activeProviderForCwd(ctx context.Context, cwd string) domain.ProviderKind {
-	newest := func(paths []string) int64 {
-		var best int64
-		for _, p := range paths {
-			if info, err := os.Stat(p); err == nil {
-				if ns := info.ModTime().UnixNano(); ns > best {
-					best = ns
-				}
-			}
+	mtime := func(path string, err error) int64 {
+		if err != nil || path == "" {
+			return 0
 		}
-		return best
+		if info, statErr := os.Stat(path); statErr == nil {
+			return info.ModTime().UnixNano()
+		}
+		return 0
 	}
-	return providerByRecency(newest(claudeSessionFiles(cwd)), newest(codexSessionFiles(ctx, cwd)))
+	claudePath, claudeErr := capture.NewClaudeCapture().LocateActiveSession(ctx, cwd)
+	codexPath, codexErr := capture.NewCodexCapture().LocateActiveSession(ctx, cwd)
+	return providerByRecency(mtime(claudePath, claudeErr), mtime(codexPath, codexErr))
 }
 
 func providerByRecency(claudeNewest, codexNewest int64) domain.ProviderKind {
@@ -485,6 +510,20 @@ func boundaryTransitionSafe(b boundary.Boundary, wrapperManaged bool) bool {
 	restartable := b.SeedPath != "" && b.ResumeCmd != "" && providerfs.ValidSessionID(b.SeedID)
 	preparedResume := b.SeedPath != "" || b.ResumeCmd != "" || b.SeedID != ""
 	return restartable || (!wrapperManaged && !preparedResume)
+}
+
+func transitionPreflightSafe(prepareErr error, prepareExpected bool, b boundary.Boundary, wrapperManaged bool) bool {
+	if prepareErr != nil {
+		return false
+	}
+	if prepareExpected || wrapperManaged {
+		return boundaryTransitionSafe(b, wrapperManaged)
+	}
+	return true
+}
+
+func shouldSupersedeSession(path, preparedSeedPath string) bool {
+	return path != "" && (preparedSeedPath == "" || filepath.Clean(path) != filepath.Clean(preparedSeedPath))
 }
 
 // runGitHook handles `cxt git-hook <event> [args...]`. Always returns nil (fail-open).

--- a/cli/internal/adapters/delivery/cli/githook_pr_test.go
+++ b/cli/internal/adapters/delivery/cli/githook_pr_test.go
@@ -148,6 +148,10 @@ func TestIncomingCommitSHAsOldestFirstAndBounded(t *testing.T) {
 
 	repo := t.TempDir()
 	runGitForTest(t, repo, "init", "-b", "main")
+	// Keep this repository hermetic. Developer/CI machines can have a global
+	// cxt hooksPath; running 202 commits through those hooks performs real
+	// checkpoint/network work and made this pure rev-list test flaky (#42).
+	runGitForTest(t, repo, "config", "core.hooksPath", t.TempDir())
 	runGitForTest(t, repo, "config", "user.name", "Test")
 	runGitForTest(t, repo, "config", "user.email", "test@example.com")
 	for i := 0; i < 202; i++ {

--- a/cli/internal/adapters/delivery/cli/githook_session_id_test.go
+++ b/cli/internal/adapters/delivery/cli/githook_session_id_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/wnsdy95/cxthub/cli/internal/adapters/boundary"
@@ -60,6 +61,40 @@ func TestRestoredSessionID(t *testing.T) {
 				t.Fatalf("restoredSessionID() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestTransitionPreflightRejectsBeforeIsolation(t *testing.T) {
+	const sessionID = "12345678-1234-4abc-8def-1234567890ab"
+	restartable := boundary.Boundary{
+		SeedPath:  "/tmp/" + sessionID + ".jsonl",
+		SeedID:    sessionID,
+		ResumeCmd: "codex resume " + sessionID,
+	}
+	if !transitionPreflightSafe(nil, true, restartable, true) {
+		t.Fatal("restartable managed transition was rejected")
+	}
+	if transitionPreflightSafe(errors.New("materialization failed"), true, boundary.Boundary{}, true) {
+		t.Fatal("failed materialization was accepted")
+	}
+	if transitionPreflightSafe(nil, true, boundary.Boundary{SeedPath: "/tmp/AGENTS.md"}, true) {
+		t.Fatal("memory-only fallback was accepted for a managed wrapper")
+	}
+	if transitionPreflightSafe(nil, false, boundary.Boundary{}, true) {
+		t.Fatal("managed transition without a restart target was accepted")
+	}
+	if !transitionPreflightSafe(nil, false, boundary.Boundary{}, false) {
+		t.Fatal("unmanaged transition without prepared recovery was rejected")
+	}
+}
+
+func TestPreparedSeedIsExcludedFromIsolation(t *testing.T) {
+	seed := "/tmp/provider/new-session.jsonl"
+	if shouldSupersedeSession(seed, seed) {
+		t.Fatal("prepared restart target would be superseded as an old session")
+	}
+	if !shouldSupersedeSession("/tmp/provider/old-session.jsonl", seed) {
+		t.Fatal("old session was excluded from isolation")
 	}
 }
 

--- a/cli/internal/adapters/providerfs/ledger.go
+++ b/cli/internal/adapters/providerfs/ledger.go
@@ -103,6 +103,27 @@ func MarkSuperseded(repoRoot, path string) error {
 	return saveLedger(repoRoot, lf)
 }
 
+// UnmarkSuperseded rolls back a transition that failed before its boundary was
+// durably recorded. It removes only a superseded marker; materialization
+// entries retain their size gate.
+func UnmarkSuperseded(repoRoot, path string) error {
+	unlock, _ := lockLedger(repoRoot)
+	defer unlock()
+	lf := loadLedger(repoRoot)
+	e, ok := lf.Sessions[path]
+	if !ok || !e.Superseded {
+		return nil
+	}
+	if e.Size > 0 {
+		e.Superseded = false
+		e.At = time.Now().UTC().Format(time.RFC3339)
+		lf.Sessions[path] = e
+	} else {
+		delete(lf.Sessions, path)
+	}
+	return saveLedger(repoRoot, lf)
+}
+
 // CaptureExcluded returns whether the path should be excluded from active session determination.
 // If the materialized entry "grows" (size increases), the entry is deleted and false is returned — the resumed session starts from the moment it becomes officially active.
 func CaptureExcluded(repoRoot, path string, size int64) bool {

--- a/cli/internal/adapters/providerfs/ledger_test.go
+++ b/cli/internal/adapters/providerfs/ledger_test.go
@@ -42,4 +42,30 @@ func TestLedger(t *testing.T) {
 	if !CaptureExcluded(root, sess, info.Size()+9999) {
 		t.Fatal("Isolation session captured as paused (isolation breakdown)")
 	}
+	if err := UnmarkSuperseded(root, sess); err != nil {
+		t.Fatalf("unmark superseded: %v", err)
+	}
+	if CaptureExcluded(root, sess, info.Size()+9999) {
+		t.Fatal("rolled-back isolation remains excluded")
+	}
+}
+
+func TestUnmarkSupersededRestoresMaterializationGate(t *testing.T) {
+	root := t.TempDir()
+	sess := filepath.Join(root, "seed.jsonl")
+	if err := os.WriteFile(sess, []byte("seed"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := RecordMaterialized(root, sess); err != nil {
+		t.Fatal(err)
+	}
+	if err := MarkSuperseded(root, sess); err != nil {
+		t.Fatal(err)
+	}
+	if err := UnmarkSuperseded(root, sess); err != nil {
+		t.Fatal(err)
+	}
+	if !CaptureExcluded(root, sess, int64(len("seed"))) {
+		t.Fatal("rollback discarded the pre-existing materialization gate")
+	}
 }

--- a/cli/internal/app/branch_seed.go
+++ b/cli/internal/app/branch_seed.go
@@ -98,6 +98,7 @@ func (s *BranchSeedService) Seed(ctx context.Context, in inbound.SeedInput) (inb
 		if mainMem == nil && mainDocAvailable {
 			if d, derr := s.distiller.Distill(ctx, mainDoc.CIR, nil); derr == nil {
 				if prior, ok := nearestAncestorDigest(ctx, s.store, mainSnap); ok {
+					prior = boundCarriedDigest(prior)
 					d = domain.MergeDigests(prior, d)
 				}
 				mainMem = &d
@@ -111,6 +112,7 @@ func (s *BranchSeedService) Seed(ctx context.Context, in inbound.SeedInput) (inb
 		return inbound.SeedOutput{}, err
 	}
 	if prior, ok := nearestAncestorDigest(ctx, s.store, fromSnap); ok {
+		prior = boundCarriedDigest(prior)
 		branchMem = domain.MergeDigests(prior, branchMem)
 	}
 
@@ -163,9 +165,8 @@ func (s *BranchSeedService) Seed(ctx context.Context, in inbound.SeedInput) (inb
 	// through the parent chain's memory objects.
 	seedMemory := branchMem
 	if mainMem != nil {
-		seedMemory = domain.MergeDigests(*mainMem, branchMem)
+		seedMemory = domain.MergeDigests(boundCarriedDigest(*mainMem), branchMem)
 	}
-	seedMemory = boundCarriedDigest(seedMemory)
 	seedMemory.SnapshotID = docHash
 	if seedMemory.Provider == "" {
 		seedMemory.Provider = provider

--- a/cli/internal/app/branch_seed_inheritance_test.go
+++ b/cli/internal/app/branch_seed_inheritance_test.go
@@ -419,8 +419,8 @@ func TestBranchSeedCarriedMemoryIsBounded(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(carried.Summary) > memoryCarryBudgetBytes {
-		t.Fatalf("carried seed memory = %d bytes, want <= %d", len(carried.Summary), memoryCarryBudgetBytes)
+	if len(carried.Summary) > memoryCarryBudgetBytes+len("\n\nfresh lineage summary") {
+		t.Fatalf("carried seed memory = %d bytes, inherited carry exceeded %d", len(carried.Summary), memoryCarryBudgetBytes)
 	}
 	if !strings.Contains(carried.Summary, "NEWEST-GENERATION-TAIL") || !strings.Contains(carried.Summary, "fresh lineage summary") {
 		t.Fatal("carried seed memory lost the newest generations")

--- a/cli/internal/app/load_session.go
+++ b/cli/internal/app/load_session.go
@@ -513,11 +513,9 @@ func (s *LoadSessionService) loadMemory(ctx context.Context, cir domain.CIRDocum
 	// Heritage continuation (same logic as memorize): Merge the closest ancestor digest to inherit —
 	// appending the context to memory mode loads the previous context's memory even if the context is merged.
 	if prior, ok := nearestAncestorDigest(ctx, s.store, snap); ok {
+		prior = boundCarriedDigest(prior)
 		digest = domain.MergeDigests(prior, digest)
 	}
-	// Injected provider memory files are a forward working copy too — bounded
-	// carry (#33) keeps the newest tail instead of writing an ever-growing file.
-	digest = boundCarriedDigest(digest)
 	digest.SnapshotID = snap.ID
 	if digest.Provider == "" {
 		digest.Provider = target

--- a/cli/internal/app/memorize.go
+++ b/cli/internal/app/memorize.go
@@ -107,9 +107,9 @@ func (s *MemorizeService) Memorize(ctx context.Context, in inbound.MemorizeInput
 	// Filter noisy prior KeyFacts so tool names and ingestion markers do not propagate forever across generations. Keep only sentence-form facts, using the same rules as the seed filter.
 	if prior, ok := nearestAncestorDigest(ctx, s.store, snap); ok {
 		prior.KeyFacts = seedWorthyFacts(prior.KeyFacts)
+		prior = boundCarriedDigest(prior)
 		digest = domain.MergeDigests(prior, digest)
 	}
-	digest = boundCarriedDigest(digest)
 	digest.SnapshotID = snap.ID
 
 	memHash, err := s.store.PutMemory(ctx, digest)
@@ -160,12 +160,40 @@ func nearestAncestorDigest(ctx context.Context, store outbound.SessionStore, sna
 // ancestor snapshot (content-addressed, never deleted), so complete history
 // remains recoverable through the parent chain.
 const memoryCarryBudgetBytes = 256 << 10
+const memoryCarryListBudgetBytes = 64 << 10
 
-// boundCarriedDigest caps the summary of a digest that will be carried forward
-// (stored on a new snapshot or injected as a provider memory file).
+// boundCarriedDigest caps only an inherited digest before it is merged into a
+// fresh generation. The fresh digest itself is never truncated: otherwise a
+// >256KiB native memory or newly generated summary would be lossy on its first
+// storage and there would be no full ancestor object to recover it from.
 func boundCarriedDigest(d domain.MemoryDigest) domain.MemoryDigest {
 	if len(d.Summary) > memoryCarryBudgetBytes {
 		d.Summary = truncateUTF8Tail(d.Summary, memoryCarryBudgetBytes)
 	}
+	d.KeyFacts = boundStringListTail(d.KeyFacts, memoryCarryListBudgetBytes)
+	d.OpenTasks = boundStringListTail(d.OpenTasks, memoryCarryListBudgetBytes)
 	return d
+}
+
+func boundStringListTail(items []string, maxBytes int) []string {
+	if maxBytes <= 0 || len(items) == 0 {
+		return nil
+	}
+	used := 0
+	start := len(items)
+	for start > 0 {
+		n := len(items[start-1])
+		if used+n > maxBytes {
+			break
+		}
+		used += n
+		start--
+	}
+	if start == 0 {
+		return items
+	}
+	if start == len(items) {
+		return []string{truncateUTF8Tail(items[len(items)-1], maxBytes)}
+	}
+	return append([]string(nil), items[start:]...)
 }

--- a/cli/internal/app/memory_lineage_test.go
+++ b/cli/internal/app/memory_lineage_test.go
@@ -111,3 +111,30 @@ func TestBoundCarriedDigestKeepsNewestTail(t *testing.T) {
 		t.Fatalf("bullets changed: facts=%v tasks=%v", got.KeyFacts, got.OpenTasks)
 	}
 }
+
+// A fresh generation is not a carried ancestor and must remain byte-for-byte
+// intact even when it exceeds the carry budget. Only the inherited side is
+// bounded before MergeDigests.
+func TestBoundedCarryDoesNotTruncateFreshDigest(t *testing.T) {
+	prior := domain.MemoryDigest{Summary: strings.Repeat("old", memoryCarryBudgetBytes)}
+	freshText := "FRESH-HEAD\n" + strings.Repeat("new", memoryCarryBudgetBytes) + "\nFRESH-TAIL"
+	fresh := domain.MemoryDigest{Summary: freshText}
+	merged := domain.MergeDigests(boundCarriedDigest(prior), fresh)
+	if !strings.Contains(merged.Summary, freshText) {
+		t.Fatal("fresh digest was truncated while limiting inherited carry")
+	}
+}
+
+func TestBoundCarriedDigestBoundsStructuredListsFromNewestTail(t *testing.T) {
+	d := domain.MemoryDigest{
+		KeyFacts:  []string{"old-fact", strings.Repeat("f", memoryCarryListBudgetBytes), "new-fact"},
+		OpenTasks: []string{"old-task", strings.Repeat("t", memoryCarryListBudgetBytes), "new-task"},
+	}
+	got := boundCarriedDigest(d)
+	if len(got.KeyFacts) != 1 || got.KeyFacts[0] != "new-fact" {
+		t.Fatalf("facts carry = %v, want newest tail", got.KeyFacts)
+	}
+	if len(got.OpenTasks) != 1 || got.OpenTasks[0] != "new-task" {
+		t.Fatalf("tasks carry = %v, want newest tail", got.OpenTasks)
+	}
+}

--- a/frontend/web/package-lock.json
+++ b/frontend/web/package-lock.json
@@ -2145,9 +2145,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary\n\nFollow-up to the full review of merged PRs #40 and #41.\n\n- prepare and validate checkout/seed recovery **before** superseding any live Claude/Codex session\n- preserve the current session on detached HEAD, materialization failure, memory-only fallback, or invalid restart target\n- exclude the newly materialized seed from old-session isolation and roll back supersede+ledger state if boundary recording fails\n- choose fallback provider from capture-eligible active sessions, not the isolation inventory (which includes excluded recovery files)\n- bound only inherited memory carry (summary 256KiB, facts/tasks 64KiB each); never truncate a fresh generation before its first storage\n- isolate the 202-commit Git fixture from ambient cxt hooks (closes #42)\n- update transitive nanoid 3.3.16 → 3.3.18 to clear the high audit baseline blocking Dependabot PRs\n\n## Validation\n\n- CLI: `go vet ./...`, `go test ./...`, `go test -race ./...`\n- repeated focused transition/hook tests (`-count=5`, boundary/providerfs `-count=3`)\n- backend: `go test ./...`, `go vet ./...`\n- web: `npm ci`, `npm audit --audit-level=high` (0 vulnerabilities), i18n check, production build\n- `scripts/e2e-sync.sh` — all scenarios passed, including switch → isolation → seed → wrapper restart\n- `scripts/public-preflight.sh tree` — passed\n\nCloses #42