### PR TITLE
test(cli): disable ambient Git maintenance in commit fixture

### DIFF
--- a/cli/internal/adapters/delivery/cli/githook_pr_test.go
+++ b/cli/internal/adapters/delivery/cli/githook_pr_test.go
@@ -151,7 +151,11 @@ func TestIncomingCommitSHAsOldestFirstAndBounded(t *testing.T) {
 	// Keep this repository hermetic. Developer/CI machines can have a global
 	// cxt hooksPath; running 202 commits through those hooks performs real
 	// checkpoint/network work and made this pure rev-list test flaky (#42).
+	// Disable ambient auto-maintenance too: a background pack can race TempDir
+	// cleanup after the 202-commit loop.
 	runGitForTest(t, repo, "config", "core.hooksPath", t.TempDir())
+	runGitForTest(t, repo, "config", "gc.auto", "0")
+	runGitForTest(t, repo, "config", "maintenance.auto", "false")
 	runGitForTest(t, repo, "config", "user.name", "Test")
 	runGitForTest(t, repo, "config", "user.email", "test@example.com")
 	for i := 0; i < 202; i++ {


### PR DESCRIPTION
## Summary\n\nFollow-up to #46 / #42 after CI exposed the second ambient dependency in `TestIncomingCommitSHAsOldestFirstAndBounded`: Git background pack/maintenance could still race `t.TempDir` cleanup after the 202-commit loop.\n\nThe temporary repository now sets:\n\n- `core.hooksPath` to an empty directory (merged in #46)\n- `gc.auto=0`\n- `maintenance.auto=false`\n\nFocused test passed 20 consecutive runs (`72.5s`).\n\nCloses #42