### PR TITLE
fix(github): reuse gh keyring token for PR resolution

### DIFF
--- a/cli/internal/adapters/gitctx/pull_request.go
+++ b/cli/internal/adapters/gitctx/pull_request.go
@@ -8,8 +8,10 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"os/exec"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/wnsdy95/cxthub/cli/internal/ports/outbound"
@@ -37,8 +39,17 @@ func NewGitHubPRMergeResolver() *GitHubPRMergeResolver {
 	return newGitHubPRMergeResolver(
 		&http.Client{Timeout: githubResolveWindow},
 		githubAPIBase,
-		githubToken,
+		cachedToken(githubToken),
 	)
+}
+
+func cachedToken(resolve func() string) func() string {
+	var once sync.Once
+	var token string
+	return func() string {
+		once.Do(func() { token = resolve() })
+		return token
+	}
 }
 
 func newGitHubPRMergeResolver(client *http.Client, apiBase string, token func() string) *GitHubPRMergeResolver {
@@ -50,12 +61,33 @@ func newGitHubPRMergeResolver(client *http.Client, apiBase string, token func() 
 }
 
 func githubToken() string {
+	return discoverGitHubToken(os.Getenv, githubCLIToken)
+}
+
+func discoverGitHubToken(getenv func(string) string, cliToken func() string) string {
 	for _, name := range []string{"CXT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"} {
-		if token := strings.TrimSpace(os.Getenv(name)); token != "" {
+		if token := strings.TrimSpace(getenv(name)); token != "" {
 			return token
 		}
 	}
+	if cliToken != nil {
+		return strings.TrimSpace(cliToken())
+	}
 	return ""
+}
+
+// githubCLIToken reuses the user's existing `gh auth login` credential when
+// no explicit environment token is configured. gh may keep the token in the
+// OS keyring (not ~/.config/gh), so invoking its non-interactive token command
+// is the only portable discovery path. Keep this bounded inside Git hooks.
+func githubCLIToken() string {
+	ctx, cancel := context.WithTimeout(context.Background(), 750*time.Millisecond)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "gh", "auth", "token", "--hostname", "github.com").Output()
+	if err != nil {
+		return ""
+	}
+	return string(out)
 }
 
 type githubPullRequest struct {
@@ -185,6 +217,10 @@ func (r *GitHubPRMergeResolver) getJSON(ctx context.Context, endpoint string, ou
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4<<10))
+		remaining := strings.TrimSpace(resp.Header.Get("X-RateLimit-Remaining"))
+		if remaining != "" {
+			return fmt.Errorf("github PR resolver: GitHub API returned %s (rate-limit remaining=%s)", resp.Status, remaining)
+		}
 		return fmt.Errorf("github PR resolver: GitHub API returned %s", resp.Status)
 	}
 	if err := json.NewDecoder(io.LimitReader(resp.Body, 16<<20)).Decode(out); err != nil {

--- a/cli/internal/adapters/gitctx/pull_request_test.go
+++ b/cli/internal/adapters/gitctx/pull_request_test.go
@@ -41,6 +41,37 @@ func TestGitHubRepository(t *testing.T) {
 	}
 }
 
+func TestDiscoverGitHubTokenPrecedenceAndCLIFallback(t *testing.T) {
+	values := map[string]string{
+		"CXT_GITHUB_TOKEN": " cxt-token ",
+		"GH_TOKEN":         "gh-env-token",
+		"GITHUB_TOKEN":     "actions-token",
+	}
+	getenv := func(name string) string { return values[name] }
+	cliCalls := 0
+	cli := func() string { cliCalls++; return "gh-keyring-token" }
+	if got := discoverGitHubToken(getenv, cli); got != "cxt-token" || cliCalls != 0 {
+		t.Fatalf("explicit precedence = %q, cli calls=%d", got, cliCalls)
+	}
+	delete(values, "CXT_GITHUB_TOKEN")
+	if got := discoverGitHubToken(getenv, cli); got != "gh-env-token" || cliCalls != 0 {
+		t.Fatalf("GH_TOKEN precedence = %q, cli calls=%d", got, cliCalls)
+	}
+	delete(values, "GH_TOKEN")
+	delete(values, "GITHUB_TOKEN")
+	if got := discoverGitHubToken(getenv, cli); got != "gh-keyring-token" || cliCalls != 1 {
+		t.Fatalf("CLI fallback = %q, cli calls=%d", got, cliCalls)
+	}
+}
+
+func TestCachedTokenResolvesOnce(t *testing.T) {
+	calls := 0
+	resolve := cachedToken(func() string { calls++; return "token" })
+	if resolve() != "token" || resolve() != "token" || calls != 1 {
+		t.Fatalf("cached token calls=%d", calls)
+	}
+}
+
 func TestGitHubPRMergeResolver(t *testing.T) {
 	t.Parallel()
 
@@ -146,6 +177,7 @@ func TestGitHubPRMergeResolverHTTPFailure(t *testing.T) {
 	t.Parallel()
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("X-RateLimit-Remaining", "0")
 		http.Error(w, "rate limited with secret details", http.StatusForbidden)
 	}))
 	defer server.Close()
@@ -159,6 +191,9 @@ func TestGitHubPRMergeResolverHTTPFailure(t *testing.T) {
 	)
 	if err == nil || !strings.Contains(err.Error(), "403 Forbidden") {
 		t.Fatalf("error = %v, want sanitized HTTP status", err)
+	}
+	if !strings.Contains(err.Error(), "rate-limit remaining=0") {
+		t.Fatalf("error omitted safe rate-limit diagnostic: %v", err)
 	}
 	if strings.Contains(err.Error(), "secret details") {
 		t.Fatalf("error leaked response body: %v", err)


### PR DESCRIPTION
## Summary\n\nThe post-merge PR resolver returned `403 Forbidden` even though `gh auth status` was healthy and authenticated core rate-limit remained 4998/5000. Root cause: cxt only read `CXT_GITHUB_TOKEN`, `GH_TOKEN`, and `GITHUB_TOKEN`; this machine stores the gh credential in the OS keyring, so cxt made anonymous requests and exhausted the shared 60/hour limit.\n\n- preserve explicit environment-token precedence\n- fall back to non-interactive `gh auth token --hostname github.com` with a 750ms timeout\n- cache token discovery per resolver (up to 10 API pages, one keyring lookup)\n- add sanitized `X-RateLimit-Remaining` diagnostics on non-200 responses\n\n## Validation\n\n- token precedence, gh fallback, one-time cache, HTTP diagnostic tests\n- touched package `-count=3`\n- CLI `go vet ./...`, `go test ./...`\n- local keyring lookup measured 0.10s\n\nThe branch-worktree creation itself also dogfooded #46’s failure path: recovery was not restartable, and the installed cxt reported that the current session was preserved rather than superseding it.