### PR TITLE
ops: automate signed GitHub webhook setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,3 +159,5 @@ jobs:
             -v "$RUNNER_TEMP/terraform-data:/tmp/terraform-data" \
             -w /workspace \
             hashicorp/terraform:1.15.8@sha256:7ae513256f7ce67879e218ae8593d6fbe216ec9e123abe6c94e4e10704857963 test
+      - name: Signed GitHub webhook operator tests
+        run: bash scripts/test-github-webhook.sh

--- a/Makefile
+++ b/Makefile
@@ -109,3 +109,10 @@ deploy-check-accounts: ## Read-only check for GCP/Vercel account credentials
 .PHONY: deploy-check-ready
 deploy-check-ready: ## Run final read-only checks for bootstrap resources and the image
 	bash scripts/deploy-preflight.sh ready
+
+.PHONY: webhook-check webhook-apply
+webhook-check: ## Verify the production signed GitHub PR webhook without changes
+	bash scripts/github-webhook.sh check
+
+webhook-apply: ## Create or reconcile the production signed GitHub PR webhook
+	bash scripts/github-webhook.sh apply

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -38,6 +38,19 @@ repository webhook:
 - Events: select **Pull requests**
 - Active: enabled
 
+After the API deployment and same-origin `/api` rewrite are live, reconcile the
+hook without exposing its secret on the command line:
+
+```bash
+scripts/github-webhook.sh apply
+```
+
+The command fails before changing GitHub when the public health endpoint or
+Secret Manager version is unavailable. It then creates or reconciles exactly
+one hook and requires a successful signed GitHub ping. Use `check` for a
+read-only drift check. `TF_VAR_gcp_project` and `TF_VAR_domain` are required;
+`CXT_GITHUB_REPOSITORY=owner/repo` overrides the current `gh` repository.
+
 On a same-repository PR `closed` event with `merged: true`, `cxtd` appends the
 head context branch tip to the base context branch. This preserves the source
 branch and immutable natural snapshot parents; the append is represented by

--- a/scripts/github-webhook.sh
+++ b/scripts/github-webhook.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Verify or reconcile the signed GitHub pull-request webhook used by cxtd.
+# The secret is read into a mode-0700 temporary directory and is never printed.
+set -euo pipefail
+
+MODE="${1:-check}"
+case "$MODE" in check|apply) ;; *) echo "usage: $0 [check|apply]" >&2; exit 2 ;; esac
+
+die() { printf '  ✗ %s\n' "$1" >&2; exit 1; }
+pass() { printf '  ✓ %s\n' "$1"; }
+need() { command -v "$1" >/dev/null 2>&1 || die "Missing required command: $1"; }
+require_env() { [ -n "${!1:-}" ] || die "Missing required environment variable: $1"; }
+
+for cmd in curl gcloud gh jq python3; do need "$cmd"; done
+require_env TF_VAR_gcp_project
+require_env TF_VAR_domain
+
+PROJECT="$TF_VAR_gcp_project"
+DOMAIN="$TF_VAR_domain"
+SECRET_ID="${TF_VAR_github_webhook_secret_id:-cxt-github-webhook-secret}"
+WEBHOOK_URL="https://${DOMAIN}/api/v1/hooks/github"
+HEALTH_URL="https://${DOMAIN}/api/v1/health"
+REPO="${CXT_GITHUB_REPOSITORY:-$(gh repo view --json nameWithOwner --jq .nameWithOwner)}"
+
+case "$DOMAIN" in
+  *[!a-z0-9.-]*|.*|*..*|*.) die "TF_VAR_domain is not a valid lowercase DNS name" ;;
+esac
+[[ "$PROJECT" =~ ^[a-z][a-z0-9-]{4,28}[a-z0-9]$ ]] || die "TF_VAR_gcp_project is invalid"
+[[ "$SECRET_ID" =~ ^[A-Za-z0-9_-]{1,255}$ ]] || die "TF_VAR_github_webhook_secret_id is invalid"
+[[ "$REPO" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] || die "CXT_GITHUB_REPOSITORY must be owner/repo"
+
+tmp="$(mktemp -d)"
+chmod 700 "$tmp"
+trap 'rm -rf "$tmp"' EXIT
+health="$tmp/health.json"
+status="$(curl --silent --show-error --output /dev/null --write-out '%{http_code}' \
+  --max-time 10 "$HEALTH_URL")"
+[ "$status" = "200" ] || die "API health check failed: $HEALTH_URL returned HTTP $status"
+curl --silent --show-error --fail --max-time 10 "$HEALTH_URL" >"$health"
+jq -e '.status == "ok"' "$health" >/dev/null || die "API health response is not cxtd status=ok"
+pass "Public API health endpoint returned 200"
+
+version="$(gcloud secrets versions list "$SECRET_ID" --project "$PROJECT" \
+  --filter='state=ENABLED' --limit=1 --format='value(name)')"
+[ -n "$version" ] || die "No ENABLED version in Secret Manager secret $SECRET_ID"
+pass "GitHub webhook secret has an enabled version"
+
+hooks="$tmp/hooks.json"
+gh api "repos/$REPO/hooks?per_page=100" >"$hooks"
+
+matches="$(jq --arg url "$WEBHOOK_URL" '[.[] | select(.config.url == $url)] | length' "$hooks")"
+[ "$matches" -le 1 ] || die "Multiple GitHub webhooks use $WEBHOOK_URL; reconcile manually"
+
+hook_id="$(jq -r --arg url "$WEBHOOK_URL" '.[] | select(.config.url == $url) | .id' "$hooks")"
+valid=false
+if [ -n "$hook_id" ]; then
+  valid="$(jq -r --arg url "$WEBHOOK_URL" '.[] | select(.config.url == $url) |
+    (.active == true and .config.content_type == "json" and .config.insecure_ssl == "0" and
+     (.events | sort) == ["pull_request"])' "$hooks")"
+fi
+
+if [ "$MODE" = check ]; then
+  [ -n "$hook_id" ] || die "GitHub pull-request webhook is not registered for $REPO"
+  [ "$valid" = true ] || die "GitHub webhook $hook_id has drifted from the required configuration"
+  pass "GitHub webhook $hook_id is active and correctly configured"
+  exit 0
+fi
+
+secret_file="$tmp/secret"
+payload="$tmp/payload.json"
+gcloud secrets versions access latest --secret "$SECRET_ID" --project "$PROJECT" >"$secret_file"
+[ -s "$secret_file" ] || die "Webhook secret version is empty"
+python3 - "$secret_file" "$payload" "$WEBHOOK_URL" <<'PY'
+import json, pathlib, sys
+secret_path = pathlib.Path(sys.argv[1])
+payload_path = pathlib.Path(sys.argv[2])
+url = sys.argv[3]
+secret = secret_path.read_text().rstrip("\r\n")
+if not secret:
+    raise SystemExit("webhook secret is empty")
+payload_path.write_text(json.dumps({
+    "name": "web", "active": True, "events": ["pull_request"],
+    "config": {"url": url, "content_type": "json", "secret": secret, "insecure_ssl": "0"},
+}))
+secret_path.write_text("")
+PY
+
+if [ -n "$hook_id" ]; then
+  gh api --method PATCH "repos/$REPO/hooks/$hook_id" --input "$payload" >/dev/null
+  pass "Reconciled GitHub webhook $hook_id"
+else
+  hook_id="$(gh api --method POST "repos/$REPO/hooks" --input "$payload" --jq .id)"
+  [ -n "$hook_id" ] || die "GitHub webhook creation returned no id"
+  pass "Created GitHub webhook $hook_id"
+fi
+
+gh api "repos/$REPO/hooks/$hook_id" >"$tmp/result.json"
+jq -e --arg url "$WEBHOOK_URL" '
+  .active == true and .config.url == $url and .config.content_type == "json" and
+  .config.insecure_ssl == "0" and (.events | sort) == ["pull_request"]
+' "$tmp/result.json" >/dev/null || die "GitHub webhook verification failed after reconciliation"
+pass "GitHub webhook configuration verified"
+
+# Creation sends a ping automatically; updates need an explicit ping. A successful
+# 2xx proves routing and HMAC configuration without mutating context refs.
+gh api --method POST "repos/$REPO/hooks/$hook_id/pings" >/dev/null
+for _ in 1 2 3 4 5; do
+  sleep 2
+  code="$(gh api "repos/$REPO/hooks/$hook_id/deliveries?per_page=10" \
+    --jq '[.[] | select(.event == "ping")][0].status_code // 0')"
+  case "$code" in 2??) pass "Signed GitHub ping delivery returned HTTP $code"; exit 0 ;; esac
+done
+die "Signed GitHub ping delivery did not return 2xx; inspect hook $hook_id deliveries"

--- a/scripts/test-github-webhook.sh
+++ b/scripts/test-github-webhook.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+bin="$tmp/bin"
+mkdir -p "$bin"
+log="$tmp/gh.log"
+state="$tmp/state"
+
+cat >"$bin/curl" <<'SH'
+#!/usr/bin/env bash
+case " $* " in
+  *" --write-out "*) printf '%s' "${TEST_HTTP_STATUS:-200}" ;;
+  *) printf '%s\n' "${TEST_HEALTH_BODY:-{\"status\":\"ok\"}}" ;;
+esac
+SH
+cat >"$bin/gcloud" <<'SH'
+#!/usr/bin/env bash
+case " $* " in
+  *" versions list "*) printf '7\n' ;;
+  *" versions access "*) printf 'test-signing-secret\n' ;;
+  *) exit 2 ;;
+esac
+SH
+cat >"$bin/sleep" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+cat >"$bin/gh" <<'SH'
+#!/usr/bin/env bash
+printf '%q ' "$@" >>"$TEST_GH_LOG"
+printf '\n' >>"$TEST_GH_LOG"
+if [ "$1" = repo ]; then
+  printf 'acme/project\n'
+  exit
+fi
+path=""
+for arg in "$@"; do
+  case "$arg" in repos/*) path="$arg" ;; esac
+done
+case "$path" in
+  'repos/acme/project/hooks?per_page=100')
+    if [ -s "$TEST_HOOK_STATE" ]; then
+      printf '[{"id":123,"active":true,"events":["pull_request"],"config":{"url":"https://example.com/api/v1/hooks/github","content_type":"json","insecure_ssl":"0"}}]\n'
+    else
+      printf '[]\n'
+    fi
+    ;;
+  'repos/acme/project/hooks')
+    printf x >"$TEST_HOOK_STATE"
+    printf '123\n'
+    ;;
+  'repos/acme/project/hooks/123')
+    printf '{"id":123,"active":true,"events":["pull_request"],"config":{"url":"https://example.com/api/v1/hooks/github","content_type":"json","insecure_ssl":"0"}}\n'
+    ;;
+  'repos/acme/project/hooks/123/pings') printf '{}\n' ;;
+  'repos/acme/project/hooks/123/deliveries?per_page=10') printf '204\n' ;;
+  *) printf 'unexpected gh path: %s\n' "$path" >&2; exit 2 ;;
+esac
+SH
+chmod +x "$bin"/* "$ROOT/scripts/github-webhook.sh"
+
+run_webhook() {
+  PATH="$bin:$PATH" TEST_GH_LOG="$log" TEST_HOOK_STATE="$state" \
+    TF_VAR_gcp_project=test-project TF_VAR_domain=example.com \
+    CXT_GITHUB_REPOSITORY=acme/project \
+    "$ROOT/scripts/github-webhook.sh" "$@"
+}
+
+: >"$log"
+if TEST_HTTP_STATUS=404 run_webhook apply >"$tmp/out" 2>"$tmp/err"; then
+  echo "health failure unexpectedly succeeded" >&2
+  exit 1
+fi
+grep -q 'health check failed' "$tmp/err"
+[ ! -s "$log" ] || { echo "health failure mutated GitHub" >&2; exit 1; }
+
+: >"$log"
+if TEST_HEALTH_BODY='{"status":"wrong"}' run_webhook apply >"$tmp/out" 2>"$tmp/err"; then
+  echo "invalid health body unexpectedly succeeded" >&2
+  exit 1
+fi
+grep -q 'not cxtd status=ok' "$tmp/err"
+[ ! -s "$log" ] || { echo "invalid health body mutated GitHub" >&2; exit 1; }
+
+: >"$log"
+if run_webhook check >"$tmp/out" 2>"$tmp/err"; then
+  echo "missing hook check unexpectedly succeeded" >&2
+  exit 1
+fi
+grep -q 'not registered' "$tmp/err"
+! grep -q -- '--method' "$log"
+
+: >"$log"
+run_webhook apply >"$tmp/out" 2>"$tmp/err"
+grep -q 'Created GitHub webhook 123' "$tmp/out"
+grep -q 'Signed GitHub ping delivery returned HTTP 204' "$tmp/out"
+grep -q -- '--method POST repos/acme/project/hooks ' "$log"
+grep -q -- '--method POST repos/acme/project/hooks/123/pings ' "$log"
+! grep -R -q 'test-signing-secret' "$tmp/out" "$tmp/err" "$log"
+
+: >"$log"
+run_webhook apply >"$tmp/out" 2>"$tmp/err"
+grep -q 'Reconciled GitHub webhook 123' "$tmp/out"
+grep -q -- '--method PATCH repos/acme/project/hooks/123 ' "$log"
+! grep -R -q 'test-signing-secret' "$tmp/out" "$tmp/err" "$log"
+
+: >"$log"
+run_webhook check >"$tmp/out" 2>"$tmp/err"
+grep -q 'active and correctly configured' "$tmp/out"
+! grep -q -- '--method' "$log"
+
+printf '  ✓ GitHub webhook operator check/apply fail-closed tests\n'


### PR DESCRIPTION
Closes #49.

Adds a fail-closed operator workflow for the signed GitHub PR webhook:
- verifies the public cxtd health response and enabled Secret Manager version before mutation
- creates or reconciles exactly one active JSON `pull_request` hook
- keeps the HMAC secret out of process arguments and output
- requires a successful signed ping delivery
- includes stubbed check/create/reconcile/failure regression coverage in CI

Current production remains intentionally unchanged: `cxthub.com/api/v1/health` returns 404, so the operator exits before touching GitHub.