### PR TITLE
fix(context): preserve continuity and project memory

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -33,7 +33,7 @@ body:
     id: environment
     attributes:
       label: Environment
-      placeholder: macOS 15 arm64, Go 1.26.5, FS store
+      placeholder: macOS 15 arm64, Go 1.26.6, FS store
     validations:
       required: true
   - type: textarea

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
           cache: false
       - name: Validate the publishable tree
         run: bash scripts/public-preflight.sh tree
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
           cache-dependency-path: backend/go.sum
       - name: build (both tags)
         working-directory: backend
@@ -71,7 +71,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
           cache: false
       - name: build · vet · test
         working-directory: cli
@@ -105,7 +105,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
           cache-dependency-path: backend/go.sum
       - name: e2e (real binary startup — FS store, full surface)
         run: make e2e
@@ -116,7 +116,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
           cache-dependency-path: backend/go.sum
       - name: Synchronized E2E deep dive (append/graft · memory promotion · session boundary · fetch-only)
         run: make e2e-sync

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -5,7 +5,7 @@
 // External dependencies are limited to the PostgreSQL adapter (pgx) and at-rest compression.
 module github.com/wnsdy95/cxthub/backend
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/jackc/pgx/v5 v5.10.0

--- a/backend/internal/app/fsck_test.go
+++ b/backend/internal/app/fsck_test.go
@@ -78,6 +78,28 @@ func TestFsckReachability(t *testing.T) {
 	}
 }
 
+func TestFsckTreatsPendingAsReachabilityRoot(t *testing.T) {
+	svc, st := newFsckSvc(t)
+	ctx := context.Background()
+	repo := hh("pending-root-repo")
+	if err := st.PutSnapshot(ctx, domain.Snapshot{ID: hh("base"), RepoID: repo, DocHash: hh("base")}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.PutSnapshot(ctx, domain.Snapshot{ID: hh("pending"), RepoID: repo, DocHash: hh("pending"), Parents: []domain.ContentHash{hh("base")}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.PutPending(ctx, repo, domain.Pending{RepoID: repo, SessionID: "session", Branch: "main", Target: hh("pending")}); err != nil {
+		t.Fatal(err)
+	}
+	rep, err := svc.Fsck(ctx, repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rep.Reachable != 2 || len(rep.Unreachable) != 0 {
+		t.Fatalf("pending reachability = %d, unreachable=%v", rep.Reachable, rep.Unreachable)
+	}
+}
+
 // TestFsckDanglingGraftParent: Audit dangling nodes like reachability —
 // edges pointing to nonexistent snapshots in overlay grafts should be reported as corruption (overlay grafts can create exactly this corruption class that the auditor might have missed).
 func TestFsckDanglingGraftParent(t *testing.T) {

--- a/backend/internal/app/service.go
+++ b/backend/internal/app/service.go
@@ -841,6 +841,19 @@ func (s *Service) Fsck(ctx context.Context, repoID domain.ContentHash) (inbound.
 			stack = append(stack, r.Target)
 		}
 	}
+	// Pending pointers are first-class roots outside the committed branch DAG.
+	// Treating active/uncommitted sessions as unreachable makes healthy data look
+	// corrupt and obscures real orphan regressions. Dismissed remains a UI-only
+	// state; its data is intentionally preserved and therefore still reachable.
+	pendings, err := s.meta.ListPendings(ctx, repoID)
+	if err != nil {
+		return inbound.FsckReport{}, err
+	}
+	for _, pending := range pendings {
+		if pending.Target != "" {
+			stack = append(stack, pending.Target)
+		}
+	}
 	// Reachability rule single source: domain.Snapshot.ReachabilityParents(Parents ∪ GraftParents).
 	parentsOf := make(map[domain.ContentHash][]domain.ContentHash, len(snaps))
 	for _, sn := range snaps {
@@ -1000,6 +1013,11 @@ func gitOriginLabel(raw string) string {
 func (s *Service) PutMemoryDigest(ctx context.Context, repoID domain.ContentHash, d domain.MemoryDigest) (domain.ContentHash, error) {
 	if err := validateHashes(repoID, d.SnapshotID); err != nil {
 		return "", err
+	}
+	for _, fragment := range d.Fragments {
+		if err := domain.ValidateContentHash(fragment.SourceSnapshot); err != nil {
+			return "", err
+		}
 	}
 	if _, err := s.meta.GetSnapshot(ctx, repoID, d.SnapshotID); err != nil {
 		return "", err // ErrNotFound → 404

--- a/backend/internal/domain/entities.go
+++ b/backend/internal/domain/entities.go
@@ -237,9 +237,21 @@ type Manifest struct {
 //
 // The backend stores only CIR-neutral digests and does not know provider-native formats.
 type MemoryDigest struct {
-	SnapshotID ContentHash  `json:"snapshot_id"`
-	Summary    string       `json:"summary"`
-	KeyFacts   []string     `json:"key_facts"`
-	OpenTasks  []string     `json:"open_tasks"`
-	Provider   ProviderKind `json:"provider"`
+	SnapshotID ContentHash      `json:"snapshot_id"`
+	Summary    string           `json:"summary"`
+	KeyFacts   []string         `json:"key_facts"`
+	OpenTasks  []string         `json:"open_tasks"`
+	Provider   ProviderKind     `json:"provider"`
+	Fragments  []MemoryFragment `json:"fragments,omitempty"`
+}
+
+// MemoryFragment is one snapshot-scoped memory contribution. The backend
+// treats it as CIR-neutral content and preserves it for deterministic client
+// projection across natural and graft parents.
+type MemoryFragment struct {
+	SourceSnapshot     ContentHash `json:"source_snapshot"`
+	Summary            string      `json:"summary,omitempty"`
+	KeyFacts           []string    `json:"key_facts,omitempty"`
+	OpenTasks          []string    `json:"open_tasks,omitempty"`
+	TasksAuthoritative bool        `json:"tasks_authoritative,omitempty"`
 }

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -3,6 +3,6 @@
 // Hexagonal architecture (ports & adapters); external dependencies are limited to at-rest compression.
 module github.com/wnsdy95/cxthub/cli
 
-go 1.26.5
+go 1.26.6
 
 require github.com/klauspost/compress v1.19.2

--- a/cli/internal/adapters/capture/briefing.go
+++ b/cli/internal/adapters/capture/briefing.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/wnsdy95/cxthub/cli/internal/adapters/providerfs"
@@ -26,8 +27,9 @@ const briefingMaxBytes = 4 << 10
 const briefingTTL = 24 * time.Hour
 
 type briefingFile struct {
-	At   time.Time `json:"at"`
-	Text string    `json:"text"`
+	At    time.Time `json:"at"`
+	Text  string    `json:"text,omitempty"`  // legacy single-entry format
+	Texts []string  `json:"texts,omitempty"` // ordered pull queue
 }
 
 func briefingPath(cwd string) string { return filepath.Join(cwd, ".cxt", "briefing.json") }
@@ -38,10 +40,18 @@ func WriteBriefing(cwd, text string) error {
 	if !cxtEnabled(cwd) || text == "" {
 		return nil
 	}
-	if len(text) > briefingMaxBytes {
-		text = text[:briefingMaxBytes] + "\n…(omitted)"
+	entries := []string{}
+	if data, err := providerfs.ReadRepoFile(cwd, filepath.Join(".cxt", "briefing.json")); err == nil {
+		var old briefingFile
+		if json.Unmarshal(data, &old) == nil && time.Since(old.At) <= briefingTTL {
+			entries = briefingEntries(old)
+		}
 	}
-	b, err := json.Marshal(briefingFile{At: time.Now().UTC(), Text: text})
+	if len(entries) == 0 || entries[len(entries)-1] != text {
+		entries = append(entries, text)
+	}
+	entries = boundBriefingEntries(entries, briefingMaxBytes)
+	b, err := json.Marshal(briefingFile{At: time.Now().UTC(), Texts: entries})
 	if err != nil {
 		return err
 	}
@@ -70,11 +80,40 @@ func ConsumeBriefing(cwd string) (string, bool) {
 		return "", false
 	}
 	var f briefingFile
-	if json.Unmarshal(data, &f) != nil || f.Text == "" {
+	if json.Unmarshal(data, &f) != nil {
 		return "", false
 	}
 	if time.Since(f.At) > briefingTTL {
 		return "", false
 	}
-	return f.Text, true
+	entries := briefingEntries(f)
+	if len(entries) == 0 {
+		return "", false
+	}
+	return strings.Join(entries, "\n\n"), true
+}
+
+func briefingEntries(f briefingFile) []string {
+	if len(f.Texts) > 0 {
+		return append([]string(nil), f.Texts...)
+	}
+	if f.Text != "" {
+		return []string{f.Text}
+	}
+	return nil
+}
+
+func boundBriefingEntries(entries []string, maxBytes int) []string {
+	for len(entries) > 1 && len(strings.Join(entries, "\n\n")) > maxBytes {
+		entries = entries[1:]
+	}
+	if len(entries) == 1 && len(entries[0]) > maxBytes {
+		const marker = "…(earlier text omitted)\n"
+		runes := []rune(entries[0])
+		for len(runes) > 0 && len(string(runes))+len(marker) > maxBytes {
+			runes = runes[1:]
+		}
+		entries[0] = marker + string(runes)
+	}
+	return entries
 }

--- a/cli/internal/adapters/capture/briefing_security_test.go
+++ b/cli/internal/adapters/capture/briefing_security_test.go
@@ -3,7 +3,9 @@ package capture
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"unicode/utf8"
 )
 
 func TestConsumeBriefingRefusesSymlinkedCxtDirectory(t *testing.T) {
@@ -21,5 +23,32 @@ func TestConsumeBriefingRefusesSymlinkedCxtDirectory(t *testing.T) {
 	}
 	if data, err := os.ReadFile(briefing); err != nil || len(data) == 0 {
 		t.Fatalf("outside briefing changed: %q, %v", data, err)
+	}
+}
+
+func TestBriefingQueuesMultiplePullsUntilNextPrompt(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.Mkdir(filepath.Join(repo, ".cxt"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteBriefing(repo, "pull A context"); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteBriefing(repo, "pull B context"); err != nil {
+		t.Fatal(err)
+	}
+	text, ok := ConsumeBriefing(repo)
+	if !ok || text != "pull A context\n\npull B context" {
+		t.Fatalf("queued briefing = %q, ok=%v", text, ok)
+	}
+	if text, ok := ConsumeBriefing(repo); ok || text != "" {
+		t.Fatalf("briefing was consumed twice: %q", text)
+	}
+}
+
+func TestBoundBriefingEntriesKeepsValidBoundedUTF8(t *testing.T) {
+	got := boundBriefingEntries([]string{strings.Repeat("é", briefingMaxBytes)}, briefingMaxBytes)
+	if len(got) != 1 || len(got[0]) > briefingMaxBytes || !utf8.ValidString(got[0]) {
+		t.Fatalf("bounded briefing bytes=%d valid=%v", len(got[0]), utf8.ValidString(got[0]))
 	}
 }

--- a/cli/internal/adapters/capture/session_affinity.go
+++ b/cli/internal/adapters/capture/session_affinity.go
@@ -1,0 +1,71 @@
+package capture
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/wnsdy95/cxthub/cli/internal/adapters/providerfs"
+	"github.com/wnsdy95/cxthub/cli/internal/domain"
+)
+
+const sessionAffinityTTL = 30 * 24 * time.Hour
+
+type sessionAffinityFile struct {
+	Provider  domain.ProviderKind `json:"provider"`
+	SessionID string              `json:"session_id"`
+	UpdatedAt time.Time           `json:"updated_at"`
+}
+
+func terminalIdentity() string {
+	if id := os.Getenv("TERM_SESSION_ID"); id != "" {
+		return id
+	}
+	return os.Getenv("ITERM_SESSION_ID")
+}
+
+func affinityPath(provider domain.ProviderKind) string {
+	terminal := terminalIdentity()
+	if terminal == "" {
+		return ""
+	}
+	key := domain.HashContent([]byte(terminal + "\x00" + string(provider)))
+	return filepath.Join(".cxt", "session-affinity", strings.TrimPrefix(string(key), "sha256:")+".json")
+}
+
+// RecordSessionAffinity binds only this local terminal to its provider session.
+// The opaque terminal ID is hashed and never synchronized to the server.
+func RecordSessionAffinity(cwd string, provider domain.ProviderKind, sessionID string) {
+	if !providerfs.ValidSessionID(sessionID) {
+		return
+	}
+	rel := affinityPath(provider)
+	if rel == "" {
+		return
+	}
+	b, err := json.Marshal(sessionAffinityFile{Provider: provider, SessionID: sessionID, UpdatedAt: time.Now().UTC()})
+	if err != nil {
+		return
+	}
+	_ = providerfs.WriteRepoFileAtomic(cwd, rel, b, 0o600)
+}
+
+// SessionAffinity returns the last capture from this exact terminal/provider.
+func SessionAffinity(cwd string, provider domain.ProviderKind) string {
+	rel := affinityPath(provider)
+	if rel == "" {
+		return ""
+	}
+	b, err := providerfs.ReadRepoFile(cwd, rel)
+	if err != nil {
+		return ""
+	}
+	var affinity sessionAffinityFile
+	if json.Unmarshal(b, &affinity) != nil || affinity.Provider != provider ||
+		!providerfs.ValidSessionID(affinity.SessionID) || time.Since(affinity.UpdatedAt) > sessionAffinityTTL {
+		return ""
+	}
+	return affinity.SessionID
+}

--- a/cli/internal/adapters/capture/session_affinity_test.go
+++ b/cli/internal/adapters/capture/session_affinity_test.go
@@ -1,0 +1,28 @@
+package capture
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/wnsdy95/cxthub/cli/internal/domain"
+)
+
+func TestSessionAffinityIsTerminalAndProviderScoped(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.Mkdir(filepath.Join(repo, ".cxt"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("TERM_SESSION_ID", "terminal-a")
+	RecordSessionAffinity(repo, domain.ProviderCodex, "11111111-1111-4111-8111-111111111111")
+	if got := SessionAffinity(repo, domain.ProviderCodex); got != "11111111-1111-4111-8111-111111111111" {
+		t.Fatalf("same terminal affinity = %q", got)
+	}
+	if got := SessionAffinity(repo, domain.ProviderClaude); got != "" {
+		t.Fatalf("provider leaked affinity = %q", got)
+	}
+	t.Setenv("TERM_SESSION_ID", "terminal-b")
+	if got := SessionAffinity(repo, domain.ProviderCodex); got != "" {
+		t.Fatalf("terminal leaked affinity = %q", got)
+	}
+}

--- a/cli/internal/adapters/delivery/cli/agent_wrapper.go
+++ b/cli/internal/adapters/delivery/cli/agent_wrapper.go
@@ -18,6 +18,8 @@ import (
 	"time"
 
 	"github.com/wnsdy95/cxthub/cli/internal/adapters/boundary"
+	"github.com/wnsdy95/cxthub/cli/internal/adapters/capture"
+	"github.com/wnsdy95/cxthub/cli/internal/adapters/codec"
 	"github.com/wnsdy95/cxthub/cli/internal/adapters/providerfs"
 	"github.com/wnsdy95/cxthub/cli/internal/domain"
 	"github.com/wnsdy95/cxthub/cli/internal/ports/inbound"
@@ -198,7 +200,10 @@ func seedFromBranch(ctx context.Context, c *Container, cwd, agent string) []stri
 		return nil
 	}
 	// PreferPendingTail: If the last session (pre-commit hook capture) connects to the head, use it as the seed — codex transitions from cxt claude without a commit.
-	out, err := c.Load.Load(ctx, inbound.LoadInput{Ref: branch, Cwd: cwd, TargetProvider: domain.ProviderKind(agent), PreferPendingTail: true})
+	out, err := c.Load.Load(ctx, inbound.LoadInput{
+		Ref: branch, Cwd: cwd, TargetProvider: domain.ProviderKind(agent), PreferPendingTail: true,
+		PreferredSessionID: activeSessionID(ctx, cwd, agent),
+	})
 	if err != nil {
 		return nil // No context in branch (new repo, etc.) — pure execution
 	}
@@ -219,4 +224,44 @@ func seedFromBranch(ctx context.Context, c *Container, cwd, agent string) []stri
 	}
 	fmt.Printf("cxt: %q branch context started as seed (fidelity: %s)%s\n", branch, out.Fidelity, note)
 	return f[1:]
+}
+
+// activeSessionID resolves the same capture-eligible provider file used by hook
+// capture and decodes its native identity. Filename/mtime guesses are not
+// sufficient: multiple terminals can run the same provider in one worktree.
+// Failure is conservative — Load then uses its original reachability rule.
+func activeSessionID(ctx context.Context, cwd, agent string) string {
+	provider := domain.ProviderKind(agent)
+	if affinity := capture.SessionAffinity(cwd, provider); affinity != "" {
+		return affinity
+	}
+	var src interface {
+		LocateActiveSession(context.Context, string) (string, error)
+		ReadSession(context.Context, string) ([]byte, error)
+	}
+	var cdc interface {
+		Decode(context.Context, []byte) (domain.CIRDocument, error)
+	}
+	if agent == string(domain.ProviderCodex) {
+		src = capture.NewCodexCapture()
+		cdc = codec.NewCodexCodec()
+	} else if agent == string(domain.ProviderClaude) {
+		src = capture.NewClaudeCapture()
+		cdc = codec.NewClaudeCodec()
+	} else {
+		return ""
+	}
+	path, err := src.LocateActiveSession(ctx, cwd)
+	if err != nil {
+		return ""
+	}
+	raw, err := src.ReadSession(ctx, path)
+	if err != nil {
+		return ""
+	}
+	cir, err := cdc.Decode(ctx, raw)
+	if err != nil {
+		return ""
+	}
+	return cir.Envelope.SessionOriginID
 }

--- a/cli/internal/adapters/memory/distiller.go
+++ b/cli/internal/adapters/memory/distiller.go
@@ -38,7 +38,7 @@ func (d *RuleDistiller) Distill(_ context.Context, cir domain.CIRDocument, nativ
 				// are bounded copies of inherited memory, not the agent's cumulative
 				// compression — promoting one here would source memorize from
 				// boilerplate and mislabel it as agent-written (#38).
-				!isSyntheticSeedText(ev.Blocks[0].Text) {
+				!containsSyntheticSeedText(ev.Blocks[0].Text) {
 				compactSummary = ev.Blocks[0].Text // last wins: newest cumulative summary
 			}
 			if ev.Role == "user" {
@@ -162,6 +162,19 @@ func isSyntheticSeedText(text string) bool {
 	return strings.HasPrefix(t, "[cxt seed] Branch-switch context:") ||
 		strings.HasPrefix(t, "[cxt] This session was resumed from a branch context seed.") ||
 		strings.HasPrefix(t, "<environment_context>")
+}
+
+// containsSyntheticSeedText rejects an agent-written compaction summary that
+// has recursively swallowed a cxt seed. Treating it as a new authoritative
+// generation creates summary-of-summary amplification on every resume. The raw
+// recent conversation remains available to the deterministic extractive
+// fallback, while older project memory stays in provenance fragments.
+func containsSyntheticSeedText(text string) bool {
+	if isSyntheticSeedText(text) {
+		return true
+	}
+	return strings.Contains(text, "[cxt] This session was resumed from a branch context seed.") ||
+		strings.Contains(text, "[cxt seed] Branch-switch context:")
 }
 
 func appendRecentDistinct(items []string, text string, limit int) []string {

--- a/cli/internal/adapters/memory/distiller_test.go
+++ b/cli/internal/adapters/memory/distiller_test.go
@@ -61,6 +61,25 @@ func distillWithSummary(t *testing.T, summary string) domain.MemoryDigest {
 	return d
 }
 
+func TestDistillRejectsAgentSummaryContainingNestedSeed(t *testing.T) {
+	nested := "Agent summary of current work.\n\n[cxt] This session was resumed from a branch context seed. 200 events were omitted.\nold inherited summary"
+	cir := domain.CIRDocument{Envelope: domain.Envelope{SourceProvider: domain.ProviderCodex}, Events: []domain.Event{
+		{Kind: domain.EventMessage, Role: "user", CompactSummary: true, Blocks: []domain.ContentBlock{{Type: "text", Text: nested}}},
+		{Kind: domain.EventMessage, Role: "user", Blocks: []domain.ContentBlock{{Type: "text", Text: "Fix the pull continuity regression."}}},
+		{Kind: domain.EventMessage, Role: "assistant", Blocks: []domain.ContentBlock{{Type: "text", Text: "The exact-session pending test now passes."}}},
+	}}
+	d, err := NewRuleDistiller().Distill(context.Background(), cir, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(d.Summary, "resumed from a branch context seed") || strings.Contains(d.Summary, "old inherited summary") {
+		t.Fatalf("nested seed was re-ingested:\n%s", d.Summary)
+	}
+	if !strings.Contains(d.Summary, "Fix the pull continuity regression.") {
+		t.Fatalf("real recent conversation was lost:\n%s", d.Summary)
+	}
+}
+
 // TestDistillExtractsStructuredFacts fixes distillation extraction:
 // KeyFacts ← "Key Technical Concepts" top-level bullet (last occurrence, emphasis markers removed),
 // OpenTasks ← "Pending Tasks" bullet. Tool name is not mixed with KeyFacts.

--- a/cli/internal/adapters/storage/file_store.go
+++ b/cli/internal/adapters/storage/file_store.go
@@ -656,6 +656,11 @@ func (s *FileStore) PutMemory(_ context.Context, digest domain.MemoryDigest) (do
 	if err := domain.ValidateOptionalContentHash(digest.SnapshotID); err != nil {
 		return "", err
 	}
+	for _, fragment := range digest.Fragments {
+		if err := domain.ValidateContentHash(fragment.SourceSnapshot); err != nil {
+			return "", err
+		}
+	}
 	data, err := json.Marshal(digest)
 	if err != nil {
 		return "", err

--- a/cli/internal/app/branch_seed.go
+++ b/cli/internal/app/branch_seed.go
@@ -97,7 +97,8 @@ func (s *BranchSeedService) Seed(ctx context.Context, in inbound.SeedInput) (inb
 		}
 		if mainMem == nil && mainDocAvailable {
 			if d, derr := s.distiller.Distill(ctx, mainDoc.CIR, nil); derr == nil {
-				if prior, ok := nearestAncestorDigest(ctx, s.store, mainSnap); ok {
+				d.SnapshotID = mainSnap.ID
+				if prior, ok := ancestorMemoryProjection(ctx, s.store, mainSnap); ok {
 					prior = boundCarriedDigest(prior)
 					d = domain.MergeDigests(prior, d)
 				}
@@ -111,7 +112,8 @@ func (s *BranchSeedService) Seed(ctx context.Context, in inbound.SeedInput) (inb
 	if err != nil {
 		return inbound.SeedOutput{}, err
 	}
-	if prior, ok := nearestAncestorDigest(ctx, s.store, fromSnap); ok {
+	branchMem.SnapshotID = fromSnap.ID
+	if prior, ok := ancestorMemoryProjection(ctx, s.store, fromSnap); ok {
 		prior = boundCarriedDigest(prior)
 		branchMem = domain.MergeDigests(prior, branchMem)
 	}
@@ -122,12 +124,13 @@ func (s *BranchSeedService) Seed(ctx context.Context, in inbound.SeedInput) (inb
 	// the recent user-boundary-aligned conversation tail.
 	now := time.Now().UTC().Format(time.RFC3339)
 	seedSession := providerfs.NewSessionID()
-	seedText := renderSeedText(in.FromBranch, in.NewBranch, mainMem, branchMem, seedDigestBudgetBytes)
+	totalBudget, digestBudget := seedBudgets(provider)
+	seedText := renderSeedText(in.FromBranch, in.NewBranch, mainMem, branchMem, digestBudget)
 	summaryEvent := domain.Event{
 		Kind: domain.EventMessage, Role: "user", Ts: now, Seq: 0,
 		Blocks: []domain.ContentBlock{{Type: "text", Text: seedText}},
 	}
-	conversationBudget := seedBudgetBytes - eventsJSONBytes([]domain.Event{summaryEvent})
+	conversationBudget := totalBudget - eventsJSONBytes([]domain.Event{summaryEvent})
 	if conversationBudget < 0 {
 		conversationBudget = 0
 	}

--- a/cli/internal/app/load_pending_tail_test.go
+++ b/cli/internal/app/load_pending_tail_test.go
@@ -28,28 +28,40 @@ func TestPendingTailOf(t *testing.T) {
 	put(q)    // Ignore irrelevant branches (e.g., residual states)
 
 	// No pending → maintain head.
-	if got := svc.pendingTailOf(ctx, repoID, "main", h); got != h {
+	if got := svc.pendingTailOf(ctx, repoID, "main", h, ""); got != h {
 		t.Fatalf("No pending: got %s want %s", got, h)
 	}
 	// Ignore pending from irrelevant branches.
 	if err := st.PutPending(ctx, domain.Pending{RepoID: repoID, SessionID: "sq", Branch: "main", Target: q, UpdatedAt: time.Now().UTC()}); err != nil {
 		t.Fatal(err)
 	}
-	if got := svc.pendingTailOf(ctx, repoID, "main", h); got != h {
+	if got := svc.pendingTailOf(ctx, repoID, "main", h, ""); got != h {
 		t.Fatalf("Irrelevant branch pending adopted: got %s", got)
 	}
 	// Ignore pending from other branches even if connected to head (to prevent cross-branch leakage).
 	if err := st.PutPending(ctx, domain.Pending{RepoID: repoID, SessionID: "sf", Branch: "feature", Target: p, UpdatedAt: time.Now().UTC()}); err != nil {
 		t.Fatal(err)
 	}
-	if got := svc.pendingTailOf(ctx, repoID, "main", h); got != h {
+	if got := svc.pendingTailOf(ctx, repoID, "main", h, ""); got != h {
 		t.Fatalf("Another branch pending adopted: got %s", got)
 	}
 	// Joining head of the same branch → tail adopted.
 	if err := st.PutPending(ctx, domain.Pending{RepoID: repoID, SessionID: "sp", Branch: "main", Target: p, UpdatedAt: time.Now().UTC()}); err != nil {
 		t.Fatal(err)
 	}
-	if got := svc.pendingTailOf(ctx, repoID, "main", h); got != p {
+	if got := svc.pendingTailOf(ctx, repoID, "main", h, ""); got != p {
 		t.Fatalf("Tail not adopted: got %s want %s", got, p)
+	}
+
+	// PR append moves main to a sibling lineage B while the exact live session
+	// remains P→H. Exact session identity preserves P; an anonymous load must not
+	// loosen reachability and accidentally revive it.
+	b := gh('b')
+	put(b, h)
+	if got := svc.pendingTailOf(ctx, repoID, "main", b, ""); got != b {
+		t.Fatalf("anonymous diverged pending adopted: got %s want %s", got, b)
+	}
+	if got := svc.pendingTailOf(ctx, repoID, "main", b, "sp"); got != p {
+		t.Fatalf("live session tail lost after ref append: got %s want %s", got, p)
 	}
 }

--- a/cli/internal/app/load_session.go
+++ b/cli/internal/app/load_session.go
@@ -78,7 +78,7 @@ func (s *LoadSessionService) Load(ctx context.Context, in inbound.LoadInput) (in
 		return inbound.LoadOutput{}, err
 	}
 	if in.PreferPendingTail {
-		snapID = s.pendingTailOf(ctx, in.RepoID, in.Ref, snapID)
+		snapID = s.pendingTailOf(ctx, in.RepoID, in.Ref, snapID, in.PreferredSessionID)
 	}
 	snap, err := s.store.GetSnapshot(ctx, snapID)
 	if err != nil {
@@ -108,8 +108,9 @@ func (s *LoadSessionService) Load(ctx context.Context, in inbound.LoadInput) (in
 	// Recent event tail remains within budget — truncation point is user prompt boundary.
 	seedCIR := cir
 	var omitted []domain.Event
-	if eventsJSONBytes(cir.Events) > seedBudgetBytes {
-		seedCIR, omitted = trimEventsForSeed(cir, seedTailBudgetBytes)
+	totalBudget, digestBudget := seedBudgets(target)
+	if eventsJSONBytes(cir.Events) > totalBudget {
+		seedCIR, omitted = trimEventsForSeed(cir, totalBudget-digestBudget)
 	}
 	dropped := len(omitted)
 	if dropped > 0 {
@@ -158,7 +159,7 @@ func materializationCwd(cwd string) string {
 
 // pendingTailOf returns the latest pending (uncommitted hook capture) snapshot connecting to head.
 // Acceptance conditions: (1) pending.Branch == loaded branch — branching off different branch's uncommitted conversation into same head not allowed (cross-branch leakage). (2) head is ancestor of pending target (parents ∪ graft_parents reachability) — isolate residual other lineages. If none, return head as is. If multiple pending, return with latest UpdatedAt (web "continuing conversation" equivalent).
-func (s *LoadSessionService) pendingTailOf(ctx context.Context, repoID, branch string, head domain.ContentHash) domain.ContentHash {
+func (s *LoadSessionService) pendingTailOf(ctx context.Context, repoID, branch string, head domain.ContentHash, preferredSessionID string) domain.ContentHash {
 	pendings, err := s.store.ListPendings(ctx, repoID)
 	if err != nil {
 		return head
@@ -171,6 +172,14 @@ func (s *LoadSessionService) pendingTailOf(ctx context.Context, repoID, branch s
 		}
 		if _, gerr := s.store.GetSnapshot(ctx, p.Target); gerr != nil {
 			continue
+		}
+		// Session identity outranks branch-head reachability. A PR append can move
+		// the branch from H to B while the live uncommitted session remains P→H.
+		// Requiring P to reach B drops that live conversation on an immediate
+		// restart. This exception is deliberately exact-session only; applying it
+		// to merely recent pending pointers would revive stale terminal sessions.
+		if preferredSessionID != "" && p.SessionID == preferredSessionID {
+			return p.Target
 		}
 		if !s.reachesFrom(ctx, p.Target, head) {
 			continue
@@ -209,15 +218,23 @@ func (s *LoadSessionService) reachesFrom(ctx context.Context, from, anc domain.C
 	return false
 }
 
-// `seedBudgetBytes` is the budget for the event tail of full materialization. Approximately 100k~130k tokens —
-// Claude(200k)/Codex(258k) windows leave room for default instructions and buffer.
-const seedBudgetBytes = 400 << 10
+// Seed budgets are deliberately below provider context windows. Session JSON is
+// not token text, so bytes are conservatively estimated at three bytes/token;
+// the remaining window is reserved for provider system prompts, repository
+// instructions, tool schemas, the next user turn, and model output.
+const seedBudgetBytes = 288 << 10 // absolute maximum (Codex profile)
+const seedDigestBudgetBytes = 72 << 10
 
-// A bounded digest gets a fixed share of the total event budget. Without this
-// reservation, a large inherited digest can dwarf the raw-tail limit and push
-// the materialized session over the target model's context window.
-const seedDigestBudgetBytes = 96 << 10
-const seedTailBudgetBytes = seedBudgetBytes - seedDigestBudgetBytes
+func seedBudgets(provider domain.ProviderKind) (total, digest int) {
+	switch provider {
+	case domain.ProviderCodex:
+		return 288 << 10, 72 << 10 // ~96k estimated input tokens
+	case domain.ProviderClaude:
+		return 192 << 10, 48 << 10 // ~64k estimated input tokens
+	default:
+		return 192 << 10, 48 << 10
+	}
+}
 
 func eventsJSONBytes(evs []domain.Event) int {
 	total := 0
@@ -426,7 +443,10 @@ const seedSummaryPrefix = "[cxt] This session was resumed from a branch context 
 // This preserves decisions, constraints, and open tasks within the seed budget. The compact marker drives
 // the viewer's ◈ rendering and last-write-wins carry-over during memory distillation.
 //
-// Summary source priority: The digest (this snapshot's MemoryHash, or the closest ancestor's if not memorized) is 1st priority — it is copied directly from the memory being uploaded to the DB. In-place head distillation is a supplement to the stored digest, and the two sources are deterministically merged. If both fail, fail-open (seed with only the tail).
+// Summary source priority: The digest on this snapshot, or the deterministic
+// projection of nearest digests across every parent lineage, is first priority.
+// In-place head distillation supplements that project memory. If both fail,
+// fail open with only the recent tail.
 //
 // Deduplication:
 //   - Previous generation seed summary (prefix CompactSummary) in the tail is removed — the new summary takes precedence.
@@ -434,10 +454,11 @@ const seedSummaryPrefix = "[cxt] This session was resumed from a branch context 
 //   - KeyFacts noise such as whitespace-free tool tokens and legacy ingestion markers ("native memory:"/"absorbed from") is excluded from seed content.
 func (s *LoadSessionService) prependTrimDigest(ctx context.Context, omitted, seed domain.CIRDocument, snap domain.Snapshot, target domain.ProviderKind, cwd string) domain.CIRDocument {
 	digest, derr := s.distiller.Distill(ctx, omitted, nil)
+	digest.SnapshotID = snap.ID
 	if derr != nil {
 		digest = domain.MemoryDigest{} // Send the stored digest even if empty
 	}
-	// Prioritize the stored memorize digest (self-snapshot → closest ancestor).
+	// Prioritize the stored memorize digest (self-snapshot → parent projection).
 	stored, hasStored := domain.MemoryDigest{}, false
 	if snap.MemoryHash != "" {
 		if d, gerr := s.store.GetMemory(ctx, snap.MemoryHash); gerr == nil {
@@ -445,7 +466,7 @@ func (s *LoadSessionService) prependTrimDigest(ctx context.Context, omitted, see
 		}
 	}
 	if !hasStored {
-		if d, ok := nearestAncestorDigest(ctx, s.store, snap); ok {
+		if d, ok := ancestorMemoryProjection(ctx, s.store, snap); ok {
 			stored, hasStored = d, true
 		}
 	}
@@ -462,7 +483,8 @@ func (s *LoadSessionService) prependTrimDigest(ctx context.Context, omitted, see
 			digest.Summary = ""
 		}
 	}
-	text := renderSeedDigest(digest, len(omitted.Events), seedDigestBudgetBytes)
+	_, digestBudget := seedBudgets(target)
+	text := renderSeedDigest(digest, len(omitted.Events), digestBudget)
 	ev := domain.Event{Kind: domain.EventMessage, Role: "user", CompactSummary: true, Blocks: []domain.ContentBlock{{Type: "text", Text: text}}}
 	// Remove previous generation seed summary (materialized copy limit): Since the new summary inherits its content,
 	// leaving it would cause ◈ blocks to accumulate per generation. Determination is based on prefix text — legacy seed messages (unmarked user) must also be removed.
@@ -510,13 +532,13 @@ func (s *LoadSessionService) loadMemory(ctx context.Context, cir domain.CIRDocum
 	if err != nil {
 		return inbound.LoadOutput{}, err
 	}
-	// Heritage continuation (same logic as memorize): Merge the closest ancestor digest to inherit —
-	// appending the context to memory mode loads the previous context's memory even if the context is merged.
-	if prior, ok := nearestAncestorDigest(ctx, s.store, snap); ok {
+	digest.SnapshotID = snap.ID
+	// Heritage continuation (same logic as memorize): merge project memory from
+	// every parent lineage, including overlay grafts.
+	if prior, ok := ancestorMemoryProjection(ctx, s.store, snap); ok {
 		prior = boundCarriedDigest(prior)
 		digest = domain.MergeDigests(prior, digest)
 	}
-	digest.SnapshotID = snap.ID
 	if digest.Provider == "" {
 		digest.Provider = target
 	}

--- a/cli/internal/app/memorize.go
+++ b/cli/internal/app/memorize.go
@@ -103,15 +103,15 @@ func (s *MemorizeService) Memorize(ctx context.Context, in inbound.MemorizeInput
 	if err != nil {
 		return inbound.MemorizeOutput{}, err
 	}
-	// Memory follows the same logic as raw — merges closest ancestor digest to inherit (natural grafting irrelevant, memory follows parent links).
+	digest.SnapshotID = snap.ID
+	// Project memory follows every natural/graft lineage and unions provenance
+	// fragments; choosing one globally closest digest loses sibling PR memory.
 	// Filter noisy prior KeyFacts so tool names and ingestion markers do not propagate forever across generations. Keep only sentence-form facts, using the same rules as the seed filter.
-	if prior, ok := nearestAncestorDigest(ctx, s.store, snap); ok {
+	if prior, ok := ancestorMemoryProjection(ctx, s.store, snap); ok {
 		prior.KeyFacts = seedWorthyFacts(prior.KeyFacts)
 		prior = boundCarriedDigest(prior)
 		digest = domain.MergeDigests(prior, digest)
 	}
-	digest.SnapshotID = snap.ID
-
 	memHash, err := s.store.PutMemory(ctx, digest)
 	if err != nil {
 		return inbound.MemorizeOutput{}, err
@@ -127,7 +127,53 @@ func (s *MemorizeService) Memorize(ctx context.Context, in inbound.MemorizeInput
 // Ensure MemorizeService implements inbound.Memorize.
 var _ inbound.Memorize = (*MemorizeService)(nil)
 
-// nearestAncestorDigest finds the MemoryDigest of the nearest ancestor of snap by traversing the reachability parent chain using BFS. If no ancestor is found, ok=false. It walks the raw lineage (parent links) directly, so it doesn't distinguish between natural inheritance, append overlay grafts, or any other logic. The ancestor itself was merged with its parent at the distillation point, so finding the closest one is sufficient (minimal).
+// ancestorMemoryProjection merges the nearest digest from every immediate
+// natural/graft lineage. A single global BFS winner loses memory from sibling
+// PRs. Fragment provenance makes common ancestors idempotent across branches.
+func ancestorMemoryProjection(ctx context.Context, store outbound.SessionStore, snap domain.Snapshot) (domain.MemoryDigest, bool) {
+	var projection domain.MemoryDigest
+	found := false
+	for _, parent := range snap.ReachabilityParents() {
+		digest, ok := nearestDigestFrom(ctx, store, parent)
+		if !ok {
+			continue
+		}
+		if !found {
+			projection = digest
+			found = true
+		} else {
+			projection = domain.MergeDigests(projection, digest)
+		}
+	}
+	return projection, found
+}
+
+func nearestDigestFrom(ctx context.Context, store outbound.SessionStore, start domain.ContentHash) (domain.MemoryDigest, bool) {
+	seen := map[domain.ContentHash]bool{}
+	queue := []domain.ContentHash{start}
+	for len(queue) > 0 {
+		id := queue[0]
+		queue = queue[1:]
+		if id == "" || seen[id] {
+			continue
+		}
+		seen[id] = true
+		ps, err := store.GetSnapshot(ctx, id)
+		if err != nil {
+			continue // Skip local ancestors (partial lineage) — within the available range, the best option
+		}
+		if ps.MemoryHash != "" {
+			if d, derr := store.GetMemory(ctx, ps.MemoryHash); derr == nil {
+				return d, true
+			}
+		}
+		queue = append(queue, ps.ReachabilityParents()...)
+	}
+	return domain.MemoryDigest{}, false
+}
+
+// nearestAncestorDigest is retained for explicit legacy single-nearest callers
+// and compatibility tests. Project inheritance must use ancestorMemoryProjection.
 func nearestAncestorDigest(ctx context.Context, store outbound.SessionStore, snap domain.Snapshot) (domain.MemoryDigest, bool) {
 	seen := map[domain.ContentHash]bool{}
 	queue := append([]domain.ContentHash{}, snap.ReachabilityParents()...)
@@ -140,7 +186,7 @@ func nearestAncestorDigest(ctx context.Context, store outbound.SessionStore, sna
 		seen[id] = true
 		ps, err := store.GetSnapshot(ctx, id)
 		if err != nil {
-			continue // Skip local ancestors (partial lineage) — within the available range, the best option
+			continue
 		}
 		if ps.MemoryHash != "" {
 			if d, derr := store.GetMemory(ctx, ps.MemoryHash); derr == nil {
@@ -172,7 +218,41 @@ func boundCarriedDigest(d domain.MemoryDigest) domain.MemoryDigest {
 	}
 	d.KeyFacts = boundStringListTail(d.KeyFacts, memoryCarryListBudgetBytes)
 	d.OpenTasks = boundStringListTail(d.OpenTasks, memoryCarryListBudgetBytes)
+	if len(d.Fragments) > 0 {
+		remainingSummary := memoryCarryBudgetBytes
+		remainingFacts := memoryCarryListBudgetBytes
+		remainingTasks := memoryCarryListBudgetBytes
+		kept := make([]domain.MemoryFragment, 0, len(d.Fragments))
+		for i := len(d.Fragments) - 1; i >= 0; i-- {
+			fragment := d.Fragments[i]
+			fragment.Summary = truncateUTF8Tail(fragment.Summary, remainingSummary)
+			fragment.KeyFacts = boundStringListTail(fragment.KeyFacts, remainingFacts)
+			fragment.OpenTasks = boundStringListTail(fragment.OpenTasks, remainingTasks)
+			if fragment.Summary == "" && len(fragment.KeyFacts) == 0 && len(fragment.OpenTasks) == 0 {
+				continue
+			}
+			remainingSummary -= len(fragment.Summary)
+			remainingFacts -= stringListBytes(fragment.KeyFacts)
+			remainingTasks -= stringListBytes(fragment.OpenTasks)
+			kept = append(kept, fragment)
+			if remainingSummary <= 0 && remainingFacts <= 0 && remainingTasks <= 0 {
+				break
+			}
+		}
+		for left, right := 0, len(kept)-1; left < right; left, right = left+1, right-1 {
+			kept[left], kept[right] = kept[right], kept[left]
+		}
+		d.Fragments = kept
+	}
 	return d
+}
+
+func stringListBytes(items []string) int {
+	total := 0
+	for _, item := range items {
+		total += len(item)
+	}
+	return total
 }
 
 func boundStringListTail(items []string, maxBytes int) []string {

--- a/cli/internal/app/memory_lineage_test.go
+++ b/cli/internal/app/memory_lineage_test.go
@@ -80,6 +80,45 @@ func TestNearestAncestorDigest(t *testing.T) {
 	}
 }
 
+func TestAncestorMemoryProjectionUnionsParallelGraftFragments(t *testing.T) {
+	ctx := context.Background()
+	st := storage.NewFileStore(t.TempDir())
+	h := func(c byte) domain.ContentHash {
+		return domain.ContentHash("sha256:" + strings.Repeat(string(c), 64))
+	}
+	base := domain.MemoryDigest{SnapshotID: h('a'), Summary: "shared base"}
+	left := domain.MergeDigests(base, domain.MemoryDigest{SnapshotID: h('b'), Summary: "left PR"})
+	right := domain.MergeDigests(base, domain.MemoryDigest{SnapshotID: h('c'), Summary: "right PR"})
+	leftHash, err := st.PutMemory(ctx, left)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rightHash, err := st.PutMemory(ctx, right)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, snap := range []domain.Snapshot{
+		{ID: h('b'), DocHash: h('b'), Branch: "main", MemoryHash: leftHash},
+		{ID: h('c'), DocHash: h('c'), Branch: "main", MemoryHash: rightHash},
+		{ID: h('d'), DocHash: h('d'), Branch: "main", Parents: []domain.ContentHash{h('b')}, GraftParents: []domain.ContentHash{h('c')}, Grafted: true},
+	} {
+		if err := st.PutSnapshot(ctx, snap); err != nil {
+			t.Fatal(err)
+		}
+	}
+	merge, _ := st.GetSnapshot(ctx, h('d'))
+	got, ok := ancestorMemoryProjection(ctx, st, merge)
+	if !ok {
+		t.Fatal("parallel memory projection not found")
+	}
+	if strings.Count(got.Summary, "shared base") != 1 || !strings.Contains(got.Summary, "left PR") || !strings.Contains(got.Summary, "right PR") {
+		t.Fatalf("parallel projection = %q", got.Summary)
+	}
+	if len(got.Fragments) != 3 {
+		t.Fatalf("fragment union = %d, want shared+left+right", len(got.Fragments))
+	}
+}
+
 // TestBoundCarriedDigestKeepsNewestTail (#33 — bounded carry): the forward
 // working set is capped at memoryCarryBudgetBytes keeping the newest tail;
 // under-budget digests pass through unchanged.
@@ -109,6 +148,27 @@ func TestBoundCarriedDigestKeepsNewestTail(t *testing.T) {
 	}
 	if len(got.KeyFacts) != 1 || len(got.OpenTasks) != 1 {
 		t.Fatalf("bullets changed: facts=%v tasks=%v", got.KeyFacts, got.OpenTasks)
+	}
+}
+
+func TestBoundCarriedDigestCapsFragmentProjection(t *testing.T) {
+	var fragments []domain.MemoryFragment
+	for i := 0; i < 8; i++ {
+		fragments = append(fragments, domain.MemoryFragment{
+			SourceSnapshot: domain.ContentHash("sha256:" + strings.Repeat(string(rune('a'+i)), 64)),
+			Summary:        strings.Repeat(string(rune('A'+i)), 80<<10),
+		})
+	}
+	got := boundCarriedDigest(domain.MemoryDigest{Fragments: fragments})
+	total := 0
+	for _, fragment := range got.Fragments {
+		total += len(fragment.Summary)
+	}
+	if total > memoryCarryBudgetBytes {
+		t.Fatalf("fragment projection = %d bytes, want <= %d", total, memoryCarryBudgetBytes)
+	}
+	if len(got.Fragments) == 0 || !strings.Contains(got.Fragments[len(got.Fragments)-1].Summary, "H") {
+		t.Fatal("fragment projection did not retain newest contribution")
 	}
 }
 

--- a/cli/internal/app/save_session.go
+++ b/cli/internal/app/save_session.go
@@ -169,6 +169,7 @@ func (s *SaveSessionService) Save(ctx context.Context, in inbound.SaveInput) (in
 	if err := s.store.PutSnapshot(ctx, snap); err != nil {
 		return inbound.SaveOutput{}, err
 	}
+	capture.RecordSessionAffinity(repo.LocalPath, provider, cir.Envelope.SessionOriginID)
 	if promote {
 		queuePromotion(repo.LocalPath, docHash, msg)
 	}

--- a/cli/internal/domain/entities.go
+++ b/cli/internal/domain/entities.go
@@ -160,14 +160,39 @@ type MemoryDigest struct {
 	TasksAuthoritative bool `json:"-"`
 	// Provider is the injection target provider format hint.
 	Provider ProviderKind `json:"provider"`
+	// Fragments retain provenance for branch-wide memory projection. Summary,
+	// KeyFacts, and OpenTasks remain the rendered compatibility view. Older
+	// digests without fragments are promoted as one immutable legacy fragment.
+	Fragments []MemoryFragment `json:"fragments,omitempty"`
+}
+
+// MemoryFragment is one snapshot's independently distilled contribution.
+// SourceSnapshot plus fragment content is the stable dedup key across natural
+// and graft lineages.
+type MemoryFragment struct {
+	SourceSnapshot     ContentHash `json:"source_snapshot"`
+	Summary            string      `json:"summary,omitempty"`
+	KeyFacts           []string    `json:"key_facts,omitempty"`
+	OpenTasks          []string    `json:"open_tasks,omitempty"`
+	TasksAuthoritative bool        `json:"tasks_authoritative,omitempty"`
 }
 
 // MergeDigests inherits memory (prior) into new distillation (fresh) — deterministic.
 //
 // Memory follows the same logic as raw ancestry: if the snapshot ancestry continues (natural inheritance·append graft irrelevant), memory also continues. Continuous commits in the same session result in deterministic distillation recreating the same items, so dedup absorbs, and new sessions/appends preserve prior items (ancestor precedence).
 func MergeDigests(prior, fresh MemoryDigest) MemoryDigest {
+	if len(memoryFragments(prior)) == 0 && len(memoryFragments(fresh)) == 0 {
+		return mergeLegacyDigests(prior, fresh)
+	}
 	out := fresh
-	if prior.Summary != "" && prior.Summary != fresh.Summary && !strings.Contains(fresh.Summary, prior.Summary) {
+	out.Fragments = mergeMemoryFragments(memoryFragments(prior), memoryFragments(fresh))
+	renderMemoryFragments(&out)
+	return out
+}
+
+func mergeLegacyDigests(prior, fresh MemoryDigest) MemoryDigest {
+	out := fresh
+	if prior.Summary != "" && prior.Summary != fresh.Summary && !strings.Contains(strings.ToLower(fresh.Summary), strings.ToLower(prior.Summary)) {
 		if fresh.Summary == "" {
 			out.Summary = prior.Summary
 		} else {
@@ -176,13 +201,80 @@ func MergeDigests(prior, fresh MemoryDigest) MemoryDigest {
 	}
 	out.KeyFacts = dedupStrings(prior.KeyFacts, fresh.KeyFacts)
 	if fresh.TasksAuthoritative {
-		// The latest summary has authority over the unresolved list — ancestor lists can include completed items, thus being discarded.
-		// (The summary itself is a compaction snapshot, so it can be stale until the next compaction — data freshness limit acceptance.)
 		out.OpenTasks = dedupStrings(fresh.OpenTasks)
 	} else {
 		out.OpenTasks = dedupStrings(prior.OpenTasks, fresh.OpenTasks)
 	}
 	return out
+}
+
+func memoryFragments(d MemoryDigest) []MemoryFragment {
+	if len(d.Fragments) > 0 {
+		return append([]MemoryFragment(nil), d.Fragments...)
+	}
+	if d.SnapshotID == "" || (d.Summary == "" && len(d.KeyFacts) == 0 && len(d.OpenTasks) == 0) {
+		return nil
+	}
+	return []MemoryFragment{{
+		SourceSnapshot: d.SnapshotID, Summary: d.Summary, KeyFacts: d.KeyFacts,
+		OpenTasks: d.OpenTasks, TasksAuthoritative: d.TasksAuthoritative,
+	}}
+}
+
+func mergeMemoryFragments(groups ...[]MemoryFragment) []MemoryFragment {
+	seen := map[string]bool{}
+	var out []MemoryFragment
+	for _, group := range groups {
+		for _, fragment := range group {
+			if fragment.SourceSnapshot == "" {
+				continue
+			}
+			key := memoryFragmentKey(fragment)
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			out = append(out, fragment)
+		}
+	}
+	return out
+}
+
+func memoryFragmentKey(fragment MemoryFragment) string {
+	authority := "0"
+	if fragment.TasksAuthoritative {
+		authority = "1"
+	}
+	return string(fragment.SourceSnapshot) + "\x00" + fragment.Summary + "\x00" +
+		strings.Join(fragment.KeyFacts, "\x00") + "\x00" + strings.Join(fragment.OpenTasks, "\x00") + "\x00" + authority
+}
+
+func renderMemoryFragments(out *MemoryDigest) {
+	var summaries []string
+	var facts, tasks []string
+	for _, fragment := range out.Fragments {
+		if summary := strings.TrimSpace(fragment.Summary); summary != "" && !containsString(summaries, summary) {
+			summaries = append(summaries, summary)
+		}
+		facts = dedupStrings(facts, fragment.KeyFacts)
+		if fragment.TasksAuthoritative {
+			tasks = dedupStrings(fragment.OpenTasks)
+		} else {
+			tasks = dedupStrings(tasks, fragment.OpenTasks)
+		}
+	}
+	out.Summary = strings.Join(summaries, "\n\n")
+	out.KeyFacts = facts
+	out.OpenTasks = tasks
+}
+
+func containsString(items []string, want string) bool {
+	for _, item := range items {
+		if item == want {
+			return true
+		}
+	}
+	return false
 }
 
 // dedupStrings merges multiple lists while preserving order (prior list first) and removing duplicates.

--- a/cli/internal/ports/inbound/ports.go
+++ b/cli/internal/ports/inbound/ports.go
@@ -216,6 +216,12 @@ type LoadInput struct {
 	Cwd string
 	// PreferPendingTail true means that when a latest pending (uncommitted hook capture) exists to connect the Ref interpretation result (branch head), it loads that instead — "on" seed continues from the previous session (e.g., the most recent codex task) before the commit.
 	PreferPendingTail bool
+	// PreferredSessionID identifies the provider session that is actually active in
+	// this working tree. When a pull/PR append moves the branch ref sideways, that
+	// session's pending tail is still the continuation authority even though it is
+	// no longer a descendant of the new branch head. Empty keeps the conservative
+	// reachability-only fallback used by explicit loads.
+	PreferredSessionID string
 }
 
 // LoadOutput is the DTO output of LoadSession.Load.

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,7 +1,7 @@
 # cxtd container — Cloud Run deployment (multi-stage, postgres tag build).
 # build (from repo root): docker build -f deploy/Dockerfile -t <registry>/cxtd:<git-sha> .
 
-FROM golang:1.26.5-alpine@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS build
+FROM golang:1.26.6-alpine@sha256:3889b425f035be855a72fb4755265311293b6d414521f0a519d819df32222d83 AS build
 WORKDIR /src
 COPY backend/ backend/
 RUN cd backend && CGO_ENABLED=0 go build -tags postgres -o /out/cxtd ./cmd/cxtd

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -156,7 +156,7 @@ Starts the read-only MCP server on standard input/output. It exposes:
 |---|---|
 | `context_list` | List local repository snapshots |
 | `context_fetch` | Fetch snapshot metadata, memory, and recent conversation context |
-| `memory_load` | Load the nearest available memory digest for a ref |
+| `memory_load` | Load the bounded memory projection across all natural and graft parent lineages for a ref |
 | `context_search` | Search synchronized team context through the configured origin |
 
 ### `cxt hook`

--- a/frontend/web/src/onhold.ts
+++ b/frontend/web/src/onhold.ts
@@ -41,13 +41,14 @@ export function unsyncChains(unsyncs: Unsync[], snapshots: Snapshot[], shared: S
   const hold = new Set<string>();
   for (const u of unsyncs) {
     const stack = [u.target];
-    while (stack.length > 0 && hold.size < 500) {
+    while (stack.length > 0) {
       const id = stack.pop() as string;
       if (!id || hold.has(id) || shared.has(id)) continue;
       const s = byId.get(id);
       if (!s) continue;
       hold.add(id);
       for (const p of s.parents ?? []) stack.push(p);
+      for (const g of s.graft_parents ?? []) stack.push(g);
     }
   }
   // 2) Connectivity clustering (union-find, only parent edges within holds).
@@ -65,7 +66,8 @@ export function unsyncChains(unsyncs: Unsync[], snapshots: Snapshot[], shared: S
   };
   for (const id of hold) root.set(id, id);
   for (const id of hold) {
-    for (const p of byId.get(id)?.parents ?? []) {
+    const snap = byId.get(id);
+    for (const p of [...(snap?.parents ?? []), ...(snap?.graft_parents ?? [])]) {
       if (hold.has(p)) root.set(find(id), find(p));
     }
   }

--- a/schemas/openapi.yaml
+++ b/schemas/openapi.yaml
@@ -328,6 +328,26 @@ components:
         provider:
           type: string
           enum: [claude, codex, unknown]
+        fragments:
+          type: array
+          description: "Snapshot-scoped memory contributions used for deterministic projection across natural and graft lineages. Legacy digests may omit this field."
+          items:
+            type: object
+            required: [source_snapshot]
+            additionalProperties: false
+            properties:
+              source_snapshot:
+                $ref: "#/components/schemas/ContentHash"
+              summary:
+                type: string
+              key_facts:
+                type: array
+                items: { type: string }
+              open_tasks:
+                type: array
+                items: { type: string }
+              tasks_authoritative:
+                type: boolean
 
     ErrorResponse:
       type: object

--- a/scripts/e2e-sync.sh
+++ b/scripts/e2e-sync.sh
@@ -152,7 +152,7 @@ expect "upstream hint output" "$(echo "$HOOKOUT" | grep -ci 'new context')" 1
 # Pull briefing: summarize and store the incoming codeB/codeC range, then consume it once
 # from the next prompt hook as additionalContext (the shared Claude/Codex live-injection channel).
 expect "briefing creation notice output" "$(echo "$HOOKOUT" | grep -c 'briefed to the agent')" 1
-expect "team member commit summary included in briefing" "$(python3 -c "import json;print('codeC' in json.load(open('.cxt/briefing.json'))['text'])" 2>/dev/null)" True
+expect "team member commit summary included in briefing" "$(python3 -c "import json;d=json.load(open('.cxt/briefing.json'));print('codeC' in '\n'.join(d.get('texts') or [d.get('text','')]))" 2>/dev/null)" True
 BRIEF=$(echo "{\"cwd\":\"$TMP/repo1\",\"prompt\":\"go on\"}" | cxt hook --provider claude --event UserPromptSubmit)
 expect "hook emits additionalContext JSON" "$(echo "$BRIEF" | python3 -c "
 import json,sys


### PR DESCRIPTION
## Summary
- preserve the exact active terminal session across pull/PR ref appends without grafting uncommitted data into commit history
- project bounded memory from every natural and graft lineage using provenance fragments, and reject recursively nested cxt seed summaries
- use conservative provider-specific seed budgets, queue pull briefings, include graft edges in On Hold, and treat pending pointers as fsck roots
- update Go/Docker/CI to 1.26.6 to clear standard-library vulnerabilities

## Invariants
- session documents and existing memory objects remain immutable and recoverable
- pending context remains outside the committed branch DAG
- terminal affinity is repo-local and never synchronized
- inherited fragment projection is bounded; full source fragments stay on ancestor snapshots

## Verification
- CLI full test + focused race + vet
- backend full test/vet + PostgreSQL smoke + govulncheck
- web audit/i18n/Vercel/typecheck/build
- full E2E + sync E2E + Docker build + public preflight
