### PR TITLE
fix(memory): exclude legacy seed recursion from projection

### DIFF
--- a/cli/internal/app/memorize.go
+++ b/cli/internal/app/memorize.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"strings"
 
 	"github.com/wnsdy95/cxthub/cli/internal/domain"
 	"github.com/wnsdy95/cxthub/cli/internal/ports/inbound"
@@ -213,6 +214,13 @@ const memoryCarryListBudgetBytes = 64 << 10
 // >256KiB native memory or newly generated summary would be lossy on its first
 // storage and there would be no full ancestor object to recover it from.
 func boundCarriedDigest(d domain.MemoryDigest) domain.MemoryDigest {
+	// Legacy memories can contain recursively materialized cxt seed summaries.
+	// They remain immutable on their ancestor snapshots, but must not be copied
+	// into the active projection again. Structured facts/tasks are retained and
+	// the fresh snapshot contributes a clean extractive/provider summary.
+	if hasNestedSeedSummary(d.Summary) {
+		d.Summary = ""
+	}
 	if len(d.Summary) > memoryCarryBudgetBytes {
 		d.Summary = truncateUTF8Tail(d.Summary, memoryCarryBudgetBytes)
 	}
@@ -225,6 +233,9 @@ func boundCarriedDigest(d domain.MemoryDigest) domain.MemoryDigest {
 		kept := make([]domain.MemoryFragment, 0, len(d.Fragments))
 		for i := len(d.Fragments) - 1; i >= 0; i-- {
 			fragment := d.Fragments[i]
+			if hasNestedSeedSummary(fragment.Summary) {
+				fragment.Summary = ""
+			}
 			fragment.Summary = truncateUTF8Tail(fragment.Summary, remainingSummary)
 			fragment.KeyFacts = boundStringListTail(fragment.KeyFacts, remainingFacts)
 			fragment.OpenTasks = boundStringListTail(fragment.OpenTasks, remainingTasks)
@@ -245,6 +256,11 @@ func boundCarriedDigest(d domain.MemoryDigest) domain.MemoryDigest {
 		d.Fragments = kept
 	}
 	return d
+}
+
+func hasNestedSeedSummary(summary string) bool {
+	return strings.Contains(summary, seedSummaryPrefix) ||
+		strings.Contains(summary, "[cxt seed] Branch-switch context:")
 }
 
 func stringListBytes(items []string) int {

--- a/cli/internal/app/memory_lineage_test.go
+++ b/cli/internal/app/memory_lineage_test.go
@@ -172,6 +172,31 @@ func TestBoundCarriedDigestCapsFragmentProjection(t *testing.T) {
 	}
 }
 
+func TestBoundCarriedDigestDropsNestedSeedNarrativeButKeepsStructure(t *testing.T) {
+	source := domain.ContentHash("sha256:" + strings.Repeat("a", 64))
+	prior := domain.MemoryDigest{
+		SnapshotID: source,
+		Summary:    "project history\n" + seedSummaryPrefix + " 99 events omitted\nrecursive history",
+		KeyFacts:   []string{"The immutable parent rule remains in force."},
+		OpenTasks:  []string{"Verify the clean projection."},
+		Fragments: []domain.MemoryFragment{{
+			SourceSnapshot: source,
+			Summary:        "project history\n" + seedSummaryPrefix + " 99 events omitted\nrecursive history",
+			KeyFacts:       []string{"The immutable parent rule remains in force."},
+			OpenTasks:      []string{"Verify the clean projection."},
+		}},
+	}
+	carried := boundCarriedDigest(prior)
+	fresh := domain.MemoryDigest{SnapshotID: domain.ContentHash("sha256:" + strings.Repeat("b", 64)), Summary: "clean current work"}
+	got := domain.MergeDigests(carried, fresh)
+	if strings.Contains(got.Summary, seedSummaryPrefix) || strings.Contains(got.Summary, "recursive history") {
+		t.Fatalf("nested legacy narrative survived:\n%s", got.Summary)
+	}
+	if !strings.Contains(got.Summary, "clean current work") || len(got.KeyFacts) != 1 || len(got.OpenTasks) != 1 {
+		t.Fatalf("clean projection lost structure: %+v", got)
+	}
+}
+
 // A fresh generation is not a carried ancestor and must remain byte-for-byte
 // intact even when it exceeds the carry budget. Only the inherited side is
 // bounded before MergeDigests.


### PR DESCRIPTION
## Summary
- keep legacy memory objects immutable but exclude recursively nested cxt seed narrative from inherited active projections
- retain structured facts/tasks and fresh clean conversation summaries
- add a regression covering nested legacy fragments

## Dogfood finding
After #54, the current repository produced a 548KB memory projection with 57 nested seed markers inherited from a legacy ancestor. This follow-up fixes that migration boundary rather than deleting or rewriting the ancestor object.

## Verification
- CLI full tests
- CLI vet
