### PR TITLE
fix(storage): chunk oversized events with v2 CAS

### DIFF
--- a/backend/internal/adapters/delivery/http/server.go
+++ b/backend/internal/adapters/delivery/http/server.go
@@ -1001,10 +1001,11 @@ func (s *Server) joinSnapshot(w http.ResponseWriter, r *http.Request) {
 }
 
 type pullBody struct {
-	SnapshotWants    []domain.ContentHash `json:"snapshot_wants"`
-	DocWants         []domain.ContentHash `json:"doc_wants"`
-	DocManifestWants []domain.ContentHash `json:"doc_manifest_wants"`
-	ChunkWants       []domain.ContentHash `json:"chunk_wants"`
+	SnapshotWants         []domain.ContentHash `json:"snapshot_wants"`
+	DocWants              []domain.ContentHash `json:"doc_wants"`
+	DocManifestWants      []domain.ContentHash `json:"doc_manifest_wants"`
+	ChunkWants            []domain.ContentHash `json:"chunk_wants"`
+	ChunkFormatsSupported []string             `json:"chunk_formats_supported"`
 }
 
 type pullChunksBody struct {
@@ -1025,7 +1026,7 @@ func (s *Server) pullObjects(w http.ResponseWriter, r *http.Request) {
 	if !s.decode(w, r, &body) {
 		return
 	}
-	out, err := s.b.Send(r.Context(), inbound.PullSendInput{RepoID: s.repoID(r), SnapshotWants: body.SnapshotWants, DocWants: body.DocWants, DocManifestWants: body.DocManifestWants, ChunkWants: body.ChunkWants})
+	out, err := s.b.Send(r.Context(), inbound.PullSendInput{RepoID: s.repoID(r), SnapshotWants: body.SnapshotWants, DocWants: body.DocWants, DocManifestWants: body.DocManifestWants, ChunkWants: body.ChunkWants, ChunkFormatsSupported: body.ChunkFormatsSupported})
 	s.respond(w, out, err)
 }
 

--- a/backend/internal/adapters/store/doc_chunks.go
+++ b/backend/internal/adapters/store/doc_chunks.go
@@ -5,7 +5,7 @@
 // so only the storage layer is chunked:
 //
 //	repos/<r>/objects/docs/<hash>   = zstd(mani{format, envelope, chunks[]})  ← or legacy zstd(comprehensive)
-//	repos/<r>/objects/chunks/<h_i>  = zstd(event canonical fragments joined by '\n')
+//	repos/<r>/objects/chunks/<h_i>  = zstd(v2 canonical event-stream byte range; v1 remains readable)
 //
 // The integrity hash (DocHash=Snapshot.ID) remains the same as the comprehensive canonical standard — protocol·validation unchanged,
 // legacy comprehensives can be repacked losslessly with the same hash. Pre-write reassembly==original validation (mismatch triggers
@@ -30,24 +30,36 @@ func (s *FSStore) chunkPath(repoID, hash domain.ContentHash) string {
 }
 
 // putDocChunked stores canonical bytes as chunk+manifest (returns false — comprehensive fallback if not possible).
-func (s *FSStore) putDocChunked(repoID, h domain.ContentHash, cb []byte) (bool, error) {
+func (s *FSStore) putDocChunked(repoID, h domain.ContentHash, cb []byte) (bool, int64, error) {
 	plan, ok := domain.PlanDocChunks(cb)
 	if !ok {
-		return false, nil
+		return false, 0, nil
 	}
+	var added int64
 	for _, ch := range plan.Order {
 		p := s.chunkPath(repoID, ch)
-		if !exists(p) {
-			if err := writeAtomic(p, docCompress(plan.Bodies[ch])); err != nil {
-				return false, err
+		if exists(p) {
+			raw, err := os.ReadFile(p)
+			if err != nil {
+				return false, added, err
 			}
+			existing, err := docDecompress(raw)
+			if err != nil || !bytes.Equal(existing, plan.Bodies[ch]) {
+				return false, added, domain.ErrIntegrity
+			}
+		} else {
+			compressed := docCompress(plan.Bodies[ch])
+			if err := writeAtomic(p, compressed); err != nil {
+				return false, added, err
+			}
+			added += int64(len(compressed))
 		}
 	}
 	mb, err := json.Marshal(plan.Manifest)
 	if err != nil {
-		return false, err
+		return false, added, err
 	}
-	return true, writeAtomic(s.docPath(repoID, h), docCompress(mb))
+	return true, added, writeAtomic(s.docPath(repoID, h), docCompress(mb))
 }
 
 // getDocChunked reassembles manifest from chunks. If isManifest=false, it's a legacy comprehensive.
@@ -181,7 +193,7 @@ func (s *FSStore) GetDocManifest(ctx context.Context, repoID, hash domain.Conten
 		}
 		data = cb
 	}
-	ok, perr := s.putDocChunked(repoID, hash, data)
+	ok, _, perr := s.putDocChunked(repoID, hash, data)
 	if perr != nil || !ok {
 		return domain.DocChunkManifest{}, domain.ErrNotFound
 	}
@@ -254,14 +266,24 @@ func (s *FSStore) repackRepo(repoID domain.ContentHash) (converted int, saved in
 		if derr != nil {
 			continue
 		}
-		if _, isMan, _ := s.getDocChunked(repoID, hash, data); isMan {
+		if cb, isMan, chunkErr := s.getDocChunked(repoID, hash, data); isMan {
 			var man domain.DocChunkManifest
-			if json.Unmarshal(data, &man) == nil {
+			if json.Unmarshal(data, &man) != nil {
+				continue
+			}
+			if chunkErr != nil {
 				for _, ch := range man.Chunks {
 					live[ch] = true
 				}
+				continue
 			}
-			continue
+			if man.Format == domain.ChunkFormatV2 {
+				for _, ch := range man.Chunks {
+					live[ch] = true
+				}
+				continue
+			}
+			data = cb
 		}
 		if domain.HashContent(data) != hash {
 			// Legacy non-canonical storage (server records before canonical sorting — empirically verified 162/214): raw bytes may differ, but if parsing→canonical recalculation matches the hash, it is a valid doc. Also normalizes storage by repacking into canonical form. If recalculation also mismatches, it is corrupted — fsck's job.
@@ -276,7 +298,7 @@ func (s *FSStore) repackRepo(repoID domain.ContentHash) (converted int, saved in
 			data = cb
 		}
 		before := int64(len(raw))
-		ok, perr := s.putDocChunked(repoID, hash, data)
+		ok, added, perr := s.putDocChunked(repoID, hash, data)
 		if perr != nil {
 			return converted, saved, perr
 		}
@@ -289,7 +311,7 @@ func (s *FSStore) repackRepo(repoID domain.ContentHash) (converted int, saved in
 				for _, ch := range man.Chunks {
 					live[ch] = true
 				}
-				saved += before - int64(len(mraw))
+				saved += before - int64(len(mraw)) - added
 			}
 		}
 		converted++

--- a/backend/internal/adapters/store/doc_chunks_test.go
+++ b/backend/internal/adapters/store/doc_chunks_test.go
@@ -133,3 +133,70 @@ func TestFSDocChunkRoundtripAndRepack(t *testing.T) {
 		t.Fatalf("Post-normalization repacking GetDoc: %v", err)
 	}
 }
+
+func TestFSRepackDocsUpgradesV1ManifestToV2(t *testing.T) {
+	ctx := context.Background()
+	st := NewFSStore(t.TempDir())
+	repo := rlHash('1')
+	canonical, err := domain.CanonicalBytes(chunkBigDoc(40))
+	if err != nil {
+		t.Fatal(err)
+	}
+	hash := domain.HashContent(canonical)
+	plan, ok := domain.PlanDocChunksV1(canonical)
+	if !ok {
+		t.Fatal("v1 test plan unavailable")
+	}
+	for _, chunkHash := range plan.Order {
+		if err := writeAtomic(st.chunkPath(repo, chunkHash), docCompress(plan.Bodies[chunkHash])); err != nil {
+			t.Fatal(err)
+		}
+	}
+	manifest, _ := json.Marshal(plan.Manifest)
+	if err := writeAtomic(st.docPath(repo, hash), docCompress(manifest)); err != nil {
+		t.Fatal(err)
+	}
+
+	converted, _, err := st.RepackDocs()
+	if err != nil || converted != 1 {
+		t.Fatalf("v1 repack converted=%d err=%v", converted, err)
+	}
+	raw, err := os.ReadFile(st.docPath(repo, hash))
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, _ = docDecompress(raw)
+	gotManifest, isManifest := domain.ParseDocChunkManifest(raw)
+	if !isManifest || gotManifest.Format != domain.ChunkFormatV2 {
+		t.Fatalf("manifest=%+v isManifest=%v, want v2", gotManifest, isManifest)
+	}
+	got, err := st.GetDoc(ctx, repo, hash)
+	if err != nil || domain.ValidateSessionDocHash(got) != nil {
+		t.Fatalf("post-upgrade roundtrip err=%v", err)
+	}
+}
+
+func TestFSRepackDocsPreservesMonolithOnChunkCollision(t *testing.T) {
+	ctx := context.Background()
+	st := NewFSStore(t.TempDir())
+	repo := rlHash('2')
+	canonical, _ := domain.CanonicalBytes(chunkBigDoc(40))
+	hash := domain.HashContent(canonical)
+	if err := writeAtomic(st.docPath(repo, hash), docCompress(canonical)); err != nil {
+		t.Fatal(err)
+	}
+	plan, ok := domain.PlanDocChunks(canonical)
+	if !ok {
+		t.Fatal("v2 plan unavailable")
+	}
+	if err := writeAtomic(st.chunkPath(repo, plan.Order[0]), docCompress([]byte("wrong body"))); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := st.RepackDocs(); err == nil {
+		t.Fatal("chunk collision was not detected")
+	}
+	got, err := st.GetDoc(ctx, repo, hash)
+	if err != nil || domain.ValidateSessionDocHash(got) != nil {
+		t.Fatalf("source monolith was not preserved: %v", err)
+	}
+}

--- a/backend/internal/adapters/store/fs_store.go
+++ b/backend/internal/adapters/store/fs_store.go
@@ -2012,7 +2012,7 @@ func (s *FSStore) PutDoc(_ context.Context, repoID domain.ContentHash, doc domai
 	}
 	// Chunk CAS basic (doc_chunks.go) — append-only session prefixes are deduped across pushes.
 	// Inapplicable chunking falls back to whole. Integrity hash remains whole canonical.
-	chunked, err := s.putDocChunked(repoID, doc.Hash, data)
+	chunked, _, err := s.putDocChunked(repoID, doc.Hash, data)
 	if err != nil {
 		return false, err
 	}

--- a/backend/internal/adapters/store/postgres_smoke_test.go
+++ b/backend/internal/adapters/store/postgres_smoke_test.go
@@ -4,8 +4,10 @@ package store
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -147,5 +149,148 @@ func TestPGSmoke(t *testing.T) {
 	}
 	if got, err := st.GetSnapshot(ctx, repo2, snapID); err != nil || got.RepoID != repo2 {
 		t.Fatalf("repo2 snapshot: repo=%s err=%v", got.RepoID, err)
+	}
+
+	// Rolling v1→v2 dedup: a v2 writer must migrate the global manifest and grant
+	// every old/new doc owner the v2 chunks instead of retaining two representations.
+	v1CIR := domain.CIRDocument{
+		Envelope: domain.CIREnvelope{CIRVersion: "1", SourceProvider: domain.ProviderClaude},
+		Events: []domain.CIREvent{{Kind: domain.EventMessage, Seq: 0, Role: domain.RoleUser,
+			Blocks: []domain.ContentBlock{{Type: "text", Text: strings.Repeat("v1", 400<<10)}}}},
+	}
+	v1Canonical, _ := domain.CanonicalBytes(v1CIR)
+	v1Hash := domain.HashContent(v1Canonical)
+	v1Plan, ok := domain.PlanDocChunksV1(v1Canonical)
+	if !ok {
+		t.Fatal("v1 PG fixture plan unavailable")
+	}
+	for _, chunkHash := range v1Plan.Order {
+		if _, err := st.pool.Exec(ctx, `INSERT INTO blobs (hash,bytes) VALUES ($1,$2)`, string(chunkHash), docCompress(v1Plan.Bodies[chunkHash])); err != nil {
+			t.Fatalf("v1 chunk fixture: %v", err)
+		}
+		if _, err := st.pool.Exec(ctx, `INSERT INTO repo_blobs (repo_id,kind,hash) VALUES ($1,'chunk',$2)`, string(repoID), string(chunkHash)); err != nil {
+			t.Fatalf("v1 chunk owner fixture: %v", err)
+		}
+	}
+	v1Manifest, _ := json.Marshal(v1Plan.Manifest)
+	if _, err := st.pool.Exec(ctx, `INSERT INTO blobs (hash,bytes) VALUES ($1,$2)`, string(v1Hash), docCompress(v1Manifest)); err != nil {
+		t.Fatalf("v1 manifest fixture: %v", err)
+	}
+	if _, err := st.pool.Exec(ctx, `INSERT INTO repo_blobs (repo_id,kind,hash) VALUES ($1,'doc',$2)`, string(repoID), string(v1Hash)); err != nil {
+		t.Fatalf("v1 doc owner fixture: %v", err)
+	}
+	if _, err := st.PutDoc(ctx, repo2, domain.SessionDoc{Hash: v1Hash, CIR: v1CIR}); err != nil {
+		t.Fatalf("v2 writer dedup against v1: %v", err)
+	}
+	var migratedRaw []byte
+	if err := st.pool.QueryRow(ctx, `SELECT bytes FROM blobs WHERE hash=$1`, string(v1Hash)).Scan(&migratedRaw); err != nil {
+		t.Fatalf("read migrated manifest: %v", err)
+	}
+	migratedRaw, err = docDecompress(migratedRaw)
+	if err != nil {
+		t.Fatalf("decompress migrated manifest: %v", err)
+	}
+	migrated, ok := domain.ParseDocChunkManifest(migratedRaw)
+	if !ok || migrated.Format != domain.ChunkFormatV2 {
+		t.Fatalf("stored representation was not migrated to v2: %+v", migrated)
+	}
+	for _, owner := range []domain.ContentHash{repoID, repo2} {
+		if got, err := st.GetDoc(ctx, owner, v1Hash); err != nil || domain.ValidateSessionDocHash(got) != nil {
+			t.Fatalf("owner %s cannot read migrated v2 representation: %v", owner, err)
+		}
+		for _, chunkHash := range migrated.Chunks {
+			if _, err := st.GetChunk(ctx, owner, chunkHash); err != nil {
+				t.Fatalf("owner %s lacks migrated chunk %s: %v", owner, chunkHash, err)
+			}
+		}
+	}
+
+	// Legacy global monolith repack must grant chunks to every repo that owns
+	// the doc before replacing the shared blob with a v2 manifest.
+	legacyCIR := domain.CIRDocument{
+		Envelope: domain.CIREnvelope{CIRVersion: "1", SourceProvider: domain.ProviderCodex},
+		Events: []domain.CIREvent{{Kind: domain.EventMessage, Seq: 0, Role: domain.RoleUser,
+			Blocks: []domain.ContentBlock{{Type: "text", Text: strings.Repeat("x", domain.MaxPortableChunkBytes+1)}}}},
+	}
+	legacyCanonical, _ := domain.CanonicalBytes(legacyCIR)
+	legacyHash := domain.HashContent(legacyCanonical)
+	if _, err := st.pool.Exec(ctx, `INSERT INTO blobs (hash,bytes) VALUES ($1,$2)`, string(legacyHash), docCompress(legacyCanonical)); err != nil {
+		t.Fatalf("legacy blob fixture: %v", err)
+	}
+	for _, owner := range []domain.ContentHash{repoID, repo2} {
+		if _, err := st.pool.Exec(ctx, `INSERT INTO repo_blobs (repo_id,kind,hash) VALUES ($1,'doc',$2)`, string(owner), string(legacyHash)); err != nil {
+			t.Fatalf("legacy owner fixture: %v", err)
+		}
+	}
+	manifest, err := st.GetDocManifest(ctx, repoID, legacyHash)
+	if err != nil || manifest.Format != domain.ChunkFormatV2 || len(manifest.Chunks) < 2 {
+		t.Fatalf("legacy manifest=%+v err=%v", manifest, err)
+	}
+	for _, owner := range []domain.ContentHash{repoID, repo2} {
+		got, err := st.GetDoc(ctx, owner, legacyHash)
+		if err != nil || domain.ValidateSessionDocHash(got) != nil {
+			t.Fatalf("owner %s lost repacked doc: %v", owner, err)
+		}
+	}
+
+	// PutDoc and lazy GetDocManifest both acquire doc → chunk locks. Exercise the
+	// same legacy row concurrently so an inverted order would surface as a timeout
+	// or PostgreSQL deadlock error instead of an intermittent production failure.
+	raceCIR := domain.CIRDocument{
+		Envelope: domain.CIREnvelope{CIRVersion: "1", SourceProvider: domain.ProviderClaude},
+		Events: []domain.CIREvent{{Kind: domain.EventMessage, Seq: 0, Role: domain.RoleUser,
+			Blocks: []domain.ContentBlock{{Type: "text", Text: strings.Repeat("lock-order", 96<<10)}}}},
+	}
+	raceCanonical, _ := domain.CanonicalBytes(raceCIR)
+	raceHash := domain.HashContent(raceCanonical)
+	if _, err := st.pool.Exec(ctx, `INSERT INTO blobs (hash,bytes) VALUES ($1,$2)`, string(raceHash), docCompress(raceCanonical)); err != nil {
+		t.Fatalf("lock-order blob fixture: %v", err)
+	}
+	if _, err := st.pool.Exec(ctx, `INSERT INTO repo_blobs (repo_id,kind,hash) VALUES ($1,'doc',$2)`, string(repoID), string(raceHash)); err != nil {
+		t.Fatalf("lock-order owner fixture: %v", err)
+	}
+	raceCtx, cancelRace := context.WithTimeout(ctx, 10*time.Second)
+	defer cancelRace()
+	startRace := make(chan struct{})
+	raceErrs := make(chan error, 2)
+	go func() {
+		<-startRace
+		_, err := st.GetDocManifest(raceCtx, repoID, raceHash)
+		raceErrs <- err
+	}()
+	go func() {
+		<-startRace
+		_, err := st.PutDoc(raceCtx, repo2, domain.SessionDoc{Hash: raceHash, CIR: raceCIR})
+		raceErrs <- err
+	}()
+	close(startRace)
+	for i := 0; i < 2; i++ {
+		if err := <-raceErrs; err != nil {
+			t.Fatalf("concurrent doc/chunk lock ordering: %v", err)
+		}
+	}
+
+	// A corrupt globally deduplicated chunk must abort the whole new-doc
+	// transaction; the manifest row must not survive the rollback.
+	corruptCIR := domain.CIRDocument{
+		Envelope: domain.CIREnvelope{CIRVersion: "1", SourceProvider: domain.ProviderCodex},
+		Events: []domain.CIREvent{{Kind: domain.EventMessage, Seq: 0, Role: domain.RoleUser,
+			Blocks: []domain.ContentBlock{{Type: "text", Text: strings.Repeat("collision", 80<<10)}}}},
+	}
+	corruptCanonical, _ := domain.CanonicalBytes(corruptCIR)
+	corruptHash := domain.HashContent(corruptCanonical)
+	corruptPlan, ok := domain.PlanDocChunks(corruptCanonical)
+	if !ok {
+		t.Fatal("corrupt chunk fixture plan unavailable")
+	}
+	badChunk := corruptPlan.Order[0]
+	if _, err := st.pool.Exec(ctx, `INSERT INTO blobs (hash,bytes) VALUES ($1,$2)`, string(badChunk), docCompress([]byte("corrupt body"))); err != nil {
+		t.Fatalf("corrupt chunk fixture: %v", err)
+	}
+	if _, err := st.PutDoc(ctx, repoID, domain.SessionDoc{Hash: corruptHash, CIR: corruptCIR}); !errors.Is(err, domain.ErrIntegrity) {
+		t.Fatalf("corrupt chunk PutDoc err=%v, want ErrIntegrity", err)
+	}
+	if _, err := st.GetDoc(ctx, repoID, corruptHash); !errors.Is(err, domain.ErrNotFound) {
+		t.Fatalf("failed PutDoc left a visible doc: %v", err)
 	}
 }

--- a/backend/internal/adapters/store/postgres_store.go
+++ b/backend/internal/adapters/store/postgres_store.go
@@ -787,21 +787,11 @@ func (s *PostgresStore) PutDoc(ctx context.Context, repoID domain.ContentHash, d
 		return false, err
 	}
 	defer tx.Rollback(ctx)
-	// Chunk CAS base (doc_chunks.go common plan): doc blob is the manifest, event fragments are chunk blobs — prefix of append-only sessions is deduplicated during push. Chunk ownership is isolated in repo_blobs(kind='chunk') (0032). Non-chunkable forms fall back to legacy blob.
+	// Lock order is doc → chunks, matching GetDocManifest. A new manifest row is
+	// invisible until this transaction also stores its chunks and commits.
 	plan, chunked := domain.PlanDocChunks(canonical)
 	payload := docCompress(canonical)
 	if chunked {
-		for _, ch := range plan.Order {
-			if _, err := tx.Exec(ctx, `INSERT INTO blobs (hash, bytes) VALUES ($1,$2) ON CONFLICT (hash) DO NOTHING`,
-				string(ch), docCompress(plan.Bodies[ch])); err != nil {
-				return false, err
-			}
-			if _, err := tx.Exec(ctx,
-				`INSERT INTO repo_blobs (repo_id, kind, hash) VALUES ($1,'chunk',$2) ON CONFLICT DO NOTHING`,
-				string(repoID), string(ch)); err != nil {
-				return false, err
-			}
-		}
 		mb, merr := json.Marshal(plan.Manifest)
 		if merr != nil {
 			return false, merr
@@ -813,21 +803,76 @@ func (s *PostgresStore) PutDoc(ctx context.Context, repoID domain.ContentHash, d
 	if err != nil {
 		return false, err
 	}
+	created := ct.RowsAffected() > 0
 	// Blob validation: For existing rows that are legacy blobs or manifests, the original/reshuffled content must match the canonical bytes — blocking content injection under the hash (maintaining existing contract).
 	var stored []byte
-	if err := tx.QueryRow(ctx, `SELECT bytes FROM blobs WHERE hash=$1`, string(doc.Hash)).Scan(&stored); err != nil {
+	if err := tx.QueryRow(ctx, `SELECT bytes FROM blobs WHERE hash=$1 FOR UPDATE`, string(doc.Hash)).Scan(&stored); err != nil {
 		return false, err
 	}
 	stored, err = docDecompress(stored)
 	if err != nil {
 		return false, fmt.Errorf("%w: stored blob undecodable for doc %s", domain.ErrIntegrity, doc.Hash)
 	}
-	if cb, isMan, cerr := s.reassembleManifestTx(ctx, tx, stored); isMan {
-		if cerr != nil || !bytes.Equal(cb, canonical) {
-			return false, fmt.Errorf("%w: stored manifest disagrees with doc hash %s", domain.ErrIntegrity, doc.Hash)
+	storedMan, isMan := domain.ParseDocChunkManifest(stored)
+	if !created {
+		if cb, _, cerr := s.reassembleManifestTx(ctx, tx, stored, doc.Hash); isMan {
+			if cerr != nil || !bytes.Equal(cb, canonical) {
+				return false, fmt.Errorf("%w: stored manifest disagrees with doc hash %s", domain.ErrIntegrity, doc.Hash)
+			}
+		} else if !bytes.Equal(stored, canonical) {
+			return false, fmt.Errorf("%w: stored blob disagrees with doc hash %s", domain.ErrIntegrity, doc.Hash)
 		}
-	} else if !bytes.Equal(stored, canonical) {
-		return false, fmt.Errorf("%w: stored blob disagrees with doc hash %s", domain.ErrIntegrity, doc.Hash)
+	}
+	if chunked {
+		for _, ch := range plan.Order {
+			if _, err := tx.Exec(ctx, `INSERT INTO blobs (hash, bytes) VALUES ($1,$2) ON CONFLICT (hash) DO NOTHING`,
+				string(ch), docCompress(plan.Bodies[ch])); err != nil {
+				return false, err
+			}
+			var existing []byte
+			if err := tx.QueryRow(ctx, `SELECT bytes FROM blobs WHERE hash=$1`, string(ch)).Scan(&existing); err != nil {
+				return false, err
+			}
+			existing, err = docDecompress(existing)
+			if err != nil || !bytes.Equal(existing, plan.Bodies[ch]) {
+				return false, domain.ErrIntegrity
+			}
+			if _, err := tx.Exec(ctx,
+				`INSERT INTO repo_blobs (repo_id, kind, hash) VALUES ($1,'chunk',$2) ON CONFLICT DO NOTHING`,
+				string(repoID), string(ch)); err != nil {
+				return false, err
+			}
+		}
+	}
+	if !created && chunked && (!isMan || storedMan.Format != plan.Manifest.Format) {
+		// A global blob can be shared by several repos. Migrate a legacy/v1 body
+		// only after every existing doc owner can read the v2 chunks. The current
+		// writer already owns them from the planning loop above.
+		for _, ch := range plan.Order {
+			if _, err := tx.Exec(ctx,
+				`INSERT INTO repo_blobs (repo_id, kind, hash)
+				 SELECT repo_id, 'chunk', $2 FROM repo_blobs WHERE kind='doc' AND hash=$1
+				 ON CONFLICT DO NOTHING`, string(doc.Hash), string(ch)); err != nil {
+				return false, err
+			}
+		}
+		mb, merr := json.Marshal(plan.Manifest)
+		if merr != nil {
+			return false, merr
+		}
+		if _, err := tx.Exec(ctx, `UPDATE blobs SET bytes=$1 WHERE hash=$2`, docCompress(mb), string(doc.Hash)); err != nil {
+			return false, err
+		}
+	} else if isMan {
+		// If the stored representation is newer/different from this writer's plan,
+		// ownership must follow the manifest that readers will actually assemble.
+		for _, ch := range storedMan.Chunks {
+			if _, err := tx.Exec(ctx,
+				`INSERT INTO repo_blobs (repo_id, kind, hash) VALUES ($1,'chunk',$2) ON CONFLICT DO NOTHING`,
+				string(repoID), string(ch)); err != nil {
+				return false, err
+			}
+		}
 	}
 	if _, err := tx.Exec(ctx,
 		`INSERT INTO repo_blobs (repo_id, kind, hash) VALUES ($1,'doc',$2) ON CONFLICT DO NOTHING`,
@@ -837,20 +882,16 @@ func (s *PostgresStore) PutDoc(ctx context.Context, repoID domain.ContentHash, d
 	if err := tx.Commit(ctx); err != nil {
 		return false, err
 	}
-	return ct.RowsAffected() > 0, nil
+	return created, nil
 }
 
 // reassembleManifestTx reassembles canonical bytes from chunks in blobs if the stored blob is a manifest (for PutDoc blob validation — transaction integrity check, unnecessary owner join).
-func (s *PostgresStore) reassembleManifestTx(ctx context.Context, tx pgx.Tx, data []byte) ([]byte, bool, error) {
-	limit := len(data)
-	if limit > 64 {
-		limit = 64
-	}
+func (s *PostgresStore) reassembleManifestTx(ctx context.Context, tx pgx.Tx, data []byte, want domain.ContentHash) ([]byte, bool, error) {
 	man, isMan := domain.ParseDocChunkManifest(data)
 	if !isMan {
 		return nil, false, nil
 	}
-	events := make([][]byte, 0, len(man.Chunks)*8)
+	chunks := make([][]byte, 0, len(man.Chunks))
 	for _, ch := range man.Chunks {
 		var raw []byte
 		if err := tx.QueryRow(ctx, `SELECT bytes FROM blobs WHERE hash=$1`, string(ch)).Scan(&raw); err != nil {
@@ -860,9 +901,10 @@ func (s *PostgresStore) reassembleManifestTx(ctx context.Context, tx pgx.Tx, dat
 		if err != nil {
 			return nil, true, err
 		}
-		events = append(events, domain.SplitDocChunk(c)...)
+		chunks = append(chunks, c)
 	}
-	return domain.AssembleCanonicalDoc(man.Envelope, events), true, nil
+	cb, err := domain.AssembleDocChunks(man, chunks, want)
+	return cb, true, err
 }
 
 func (s *PostgresStore) GetDoc(ctx context.Context, repoID, hash domain.ContentHash) (domain.SessionDoc, error) {
@@ -998,10 +1040,15 @@ func (s *PostgresStore) GetDocManifest(ctx context.Context, repoID, hash domain.
 	if err := validateHashes(repoID, hash); err != nil {
 		return domain.DocChunkManifest{}, err
 	}
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return domain.DocChunkManifest{}, err
+	}
+	defer tx.Rollback(ctx)
 	var raw []byte
-	if err := s.pool.QueryRow(ctx,
+	if err := tx.QueryRow(ctx,
 		`SELECT b.bytes FROM repo_blobs rb JOIN blobs b ON b.hash=rb.hash
-		 WHERE rb.repo_id=$1 AND rb.kind='doc' AND rb.hash=$2`,
+		 WHERE rb.repo_id=$1 AND rb.kind='doc' AND rb.hash=$2 FOR UPDATE OF b`,
 		string(repoID), string(hash)).Scan(&raw); err != nil {
 		return domain.DocChunkManifest{}, mapNoRows(err)
 	}
@@ -1027,21 +1074,35 @@ func (s *PostgresStore) GetDocManifest(ctx context.Context, repoID, hash domain.
 	if !ok {
 		return domain.DocChunkManifest{}, domain.ErrNotFound // Plan not possible — legacy response fallback
 	}
-	tx, err := s.pool.Begin(ctx)
-	if err != nil {
-		return domain.DocChunkManifest{}, err
-	}
-	defer tx.Rollback(ctx)
 	for _, ch := range plan.Order {
 		if _, err := tx.Exec(ctx, `INSERT INTO blobs (hash, bytes) VALUES ($1,$2) ON CONFLICT (hash) DO NOTHING`,
 			string(ch), docCompress(plan.Bodies[ch])); err != nil {
 			return domain.DocChunkManifest{}, err
 		}
-		if _, err := tx.Exec(ctx,
-			`INSERT INTO repo_blobs (repo_id, kind, hash) VALUES ($1,'chunk',$2) ON CONFLICT DO NOTHING`,
-			string(repoID), string(ch)); err != nil {
+		var existing []byte
+		if err := tx.QueryRow(ctx, `SELECT bytes FROM blobs WHERE hash=$1`, string(ch)).Scan(&existing); err != nil {
 			return domain.DocChunkManifest{}, err
 		}
+		existing, err = docDecompress(existing)
+		if err != nil || !bytes.Equal(existing, plan.Bodies[ch]) {
+			return domain.DocChunkManifest{}, domain.ErrIntegrity
+		}
+		// blobs are globally deduplicated while ownership is repo-scoped. Before
+		// replacing the shared doc body with a manifest, grant every current doc
+		// owner all referenced chunks so another repo cannot lose read access.
+		if _, err := tx.Exec(ctx,
+			`INSERT INTO repo_blobs (repo_id, kind, hash)
+			 SELECT repo_id, 'chunk', $2 FROM repo_blobs WHERE kind='doc' AND hash=$1
+			 ON CONFLICT DO NOTHING`, string(hash), string(ch)); err != nil {
+			return domain.DocChunkManifest{}, err
+		}
+	}
+	manifest, err := json.Marshal(plan.Manifest)
+	if err != nil {
+		return domain.DocChunkManifest{}, err
+	}
+	if _, err := tx.Exec(ctx, `UPDATE blobs SET bytes=$1 WHERE hash=$2`, docCompress(manifest), string(hash)); err != nil {
+		return domain.DocChunkManifest{}, err
 	}
 	if err := tx.Commit(ctx); err != nil {
 		return domain.DocChunkManifest{}, err

--- a/backend/internal/app/chunk_transport_test.go
+++ b/backend/internal/app/chunk_transport_test.go
@@ -69,9 +69,19 @@ func TestBoundedChunkStorePullAndRepoScope(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !neg.ChunksSupported || !neg.BoundedChunksSupported || len(neg.ChunkWants) != 0 {
+	if !neg.ChunksSupported || !neg.BoundedChunksSupported || len(neg.ChunkWants) != 0 ||
+		!containsString(neg.ChunkFormatsSupported, domain.ChunkFormatV1) || !containsString(neg.ChunkFormatsSupported, domain.ChunkFormatV2) {
 		t.Fatalf("negotiate after staging = %+v", neg)
 	}
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }
 
 func TestBoundedChunkStoreRejectsInvalidBatchBeforeWriting(t *testing.T) {
@@ -137,7 +147,7 @@ func TestCommitUsesPreviouslyStagedChunks(t *testing.T) {
 			ID: docHash, RepoID: repo, Branch: "main", DocHash: docHash,
 			Provider: domain.ProviderClaude, Fidelity: domain.FidelityFull,
 		}},
-		ChunkedDocs: []inbound.ChunkedDoc{{Hash: docHash, Envelope: plan.Manifest.Envelope, Chunks: plan.Manifest.Chunks}},
+		ChunkedDocs: []inbound.ChunkedDoc{{Hash: docHash, Format: plan.Manifest.Format, Envelope: plan.Manifest.Envelope, Chunks: plan.Manifest.Chunks}},
 	})
 	if err != nil {
 		t.Fatalf("commit staged manifest: %v", err)
@@ -148,5 +158,35 @@ func TestCommitUsesPreviouslyStagedChunks(t *testing.T) {
 	got, err := st.GetDoc(ctx, repo, docHash)
 	if err != nil || len(got.CIR.Events) != len(cir.Events) {
 		t.Fatalf("staged doc roundtrip events=%d err=%v", len(got.CIR.Events), err)
+	}
+	legacyPull, err := svc.Send(ctx, inbound.PullSendInput{RepoID: repo, DocManifestWants: []domain.ContentHash{docHash}})
+	if err != nil || len(legacyPull.Docs) != 1 || len(legacyPull.DocManifests) != 0 {
+		t.Fatalf("legacy pull projection=%+v err=%v", legacyPull, err)
+	}
+}
+
+func TestPullOversizedEventRequiresExplicitV2Capability(t *testing.T) {
+	svc, st := newFsckSvc(t)
+	ctx := context.Background()
+	repo := hh("v2-capability-repo")
+	bindCommitTestRepo(t, st, repo)
+	cir := domain.CIRDocument{
+		Envelope: domain.CIREnvelope{CIRVersion: "1", SourceProvider: domain.ProviderCodex},
+		Events: []domain.CIREvent{{Kind: domain.EventMessage, Seq: 0, Role: domain.RoleUser,
+			Blocks: []domain.ContentBlock{{Type: "text", Text: strings.Repeat("x", domain.MaxPortableChunkBytes+1)}}}},
+	}
+	canonical, _ := domain.CanonicalBytes(cir)
+	hash := domain.HashContent(canonical)
+	if _, err := st.PutDoc(ctx, repo, domain.SessionDoc{Hash: hash, CIR: cir}); err != nil {
+		t.Fatal(err)
+	}
+
+	legacy, err := svc.Send(ctx, inbound.PullSendInput{RepoID: repo, DocManifestWants: []domain.ContentHash{hash}})
+	if err != nil || len(legacy.Docs) != 1 || len(legacy.DocManifests) != 0 {
+		t.Fatalf("legacy oversized response docs=%d manifests=%d err=%v", len(legacy.Docs), len(legacy.DocManifests), err)
+	}
+	v2, err := svc.Send(ctx, inbound.PullSendInput{RepoID: repo, DocManifestWants: []domain.ContentHash{hash}, ChunkFormatsSupported: []string{domain.ChunkFormatV1, domain.ChunkFormatV2}})
+	if err != nil || len(v2.DocManifests) != 1 || v2.DocManifests[0].Format != domain.ChunkFormatV2 || len(v2.Docs) != 0 {
+		t.Fatalf("v2 oversized response=%+v err=%v", v2, err)
 	}
 }

--- a/backend/internal/app/service.go
+++ b/backend/internal/app/service.go
@@ -260,6 +260,7 @@ func (s *Service) Negotiate(ctx context.Context, in inbound.PushNegotiateInput) 
 		DocWants:               difference(in.DocHaves, haveDocs),
 		ChunksSupported:        true,
 		BoundedChunksSupported: true,
+		ChunkFormatsSupported:  []string{domain.ChunkFormatV1, domain.ChunkFormatV2},
 		ChunkWants:             chunkWants,
 	}, nil
 }
@@ -364,6 +365,13 @@ func (s *Service) Commit(ctx context.Context, in inbound.CommitInput) (inbound.C
 			if err := domain.ValidateContentHash(cd.Hash); err != nil {
 				return inbound.CommitOutput{}, err
 			}
+			format := cd.Format
+			if format == "" {
+				format = domain.ChunkFormatV1
+			}
+			if !domain.SupportedChunkFormat(format) {
+				return inbound.CommitOutput{}, fmt.Errorf("%w: chunked doc %s uses unsupported format %q", domain.ErrValidation, cd.Hash, cd.Format)
+			}
 			chunks := make([][]byte, 0, len(cd.Chunks))
 			for _, ch := range cd.Chunks {
 				if err := domain.ValidateContentHash(ch); err != nil {
@@ -378,7 +386,7 @@ func (s *Service) Commit(ctx context.Context, in inbound.CommitInput) (inbound.C
 				}
 				chunks = append(chunks, b)
 			}
-			cb, aerr := domain.AssembleDocChunks(domain.DocChunkManifest{Format: domain.ChunkFormat, Envelope: cd.Envelope, Chunks: cd.Chunks}, chunks, cd.Hash)
+			cb, aerr := domain.AssembleDocChunks(domain.DocChunkManifest{Format: format, Envelope: cd.Envelope, Chunks: cd.Chunks}, chunks, cd.Hash)
 			if aerr != nil {
 				return inbound.CommitOutput{}, fmt.Errorf("%w: chunked doc %s reassembly mismatch", domain.ErrIntegrity, cd.Hash)
 			}
@@ -681,6 +689,7 @@ func (s *Service) Send(ctx context.Context, in inbound.PullSendInput) (inbound.P
 	if err := validateHashes(in.DocManifestWants...); err != nil {
 		return inbound.PullSendOutput{}, err
 	}
+	supportedFormats := requestedChunkFormats(in.ChunkFormatsSupported)
 	for _, h := range in.DocManifestWants {
 		man, merr := s.blobs.GetDocManifest(ctx, in.RepoID, h)
 		if merr != nil {
@@ -694,7 +703,18 @@ func (s *Service) Send(ctx context.Context, in inbound.PullSendInput) (inbound.P
 			}
 			return inbound.PullSendOutput{}, merr
 		}
-		out.DocManifests = append(out.DocManifests, inbound.ChunkedDoc{Hash: h, Envelope: man.Envelope, Chunks: man.Chunks})
+		if supportedFormats[man.Format] {
+			out.DocManifests = append(out.DocManifests, inbound.ChunkedDoc{Hash: h, Format: man.Format, Envelope: man.Envelope, Chunks: man.Chunks})
+			continue
+		}
+		// The stored representation is newer/different from the requesting peer.
+		// Return the complete document instead of materializing a second chunk
+		// format as a side effect of this read-only operation.
+		doc, derr := s.blobs.GetDoc(ctx, in.RepoID, h)
+		if derr != nil {
+			return inbound.PullSendOutput{}, derr
+		}
+		out.Docs = append(out.Docs, doc)
 	}
 	if err := validateHashes(in.ChunkWants...); err != nil {
 		return inbound.PullSendOutput{}, err
@@ -707,6 +727,22 @@ func (s *Service) Send(ctx context.Context, in inbound.PullSendInput) (inbound.P
 		out.ChunkObjects = append(out.ChunkObjects, inbound.ChunkObject{Hash: ch, Data: b})
 	}
 	return out, nil
+}
+
+func requestedChunkFormats(formats []string) map[string]bool {
+	if len(formats) == 0 {
+		return map[string]bool{domain.ChunkFormatV1: true}
+	}
+	out := make(map[string]bool, len(formats))
+	for _, format := range formats {
+		if domain.SupportedChunkFormat(format) {
+			if format == "" {
+				format = domain.ChunkFormatV1
+			}
+			out[format] = true
+		}
+	}
+	return out
 }
 
 // PromoteSnapshotMessage: hook label → commit message one-way promotion (idempotent).

--- a/backend/internal/domain/chunks.go
+++ b/backend/internal/domain/chunks.go
@@ -5,9 +5,9 @@
 // adapters/chunkcas must follow the same rules (module separation — contract mirror).
 //
 //   - Canonical bytes must be exactly `{"envelope":<env>,"events":[<e1>,…]}` (key sorting/compaction).
-//   - Accumulating event canonical fragments in order to pass ChunkTarget closes the chunk
-//     (prefix-stable — in an append-only session, closed chunks are consistent across captures).
-//   - Chunk bytes = pieces joined by '\n'. Chunk hash = HashContent(chunk bytes).
+//   - v1 accumulates whole event fragments and joins them with '\n'. It remains readable for compatibility.
+//   - v2 chunks the canonical events-array interior byte stream at fixed boundaries. This keeps
+//     append-only prefixes stable while allowing a chunk boundary inside an arbitrarily large event.
 //   - Integrity (DocHash) is always the hash of the entire canonical — unchanged by chunking.
 package domain
 
@@ -19,12 +19,16 @@ import (
 // ChunkTarget is the size threshold (uncompressed canonical byte count) that closes a chunk.
 const ChunkTarget = 512 << 10
 
-// MaxPortableChunkBytes is the upper limit of a single chunk that can be safely transported
-// using bounded HTTP transport. If an event is larger than this, PlanDocChunks selects a full doc fallback.
+// MaxPortableChunkBytes is the raw body limit for one bounded HTTP batch. v2 chunks are always
+// smaller than this; v1 compatibility planning falls back when a whole event would exceed it.
 const MaxPortableChunkBytes = 2 << 20
 
-// ChunkFormat is the chunk doc manifest identifier (canonical doc starts with "envelope" key — no overlap).
-const ChunkFormat = "cxt-doc-chunks-v1"
+const (
+	ChunkFormatV1 = "cxt-doc-chunks-v1"
+	ChunkFormatV2 = "cxt-doc-chunks-v2"
+	// ChunkFormat is the format emitted by new storage writes.
+	ChunkFormat = ChunkFormatV2
+)
 
 // DocChunkManifest is the manifest of a chunk doc (common form for storage and wire).
 type DocChunkManifest struct {
@@ -40,8 +44,22 @@ type DocChunkPlan struct {
 	Order    []ContentHash
 }
 
-// PlanDocChunks splits canonical bytes and validates reassembly integrity. ok=false falls back to legacy.
+// PlanDocChunks emits the current bounded stream format. It is independent of event size.
 func PlanDocChunks(cb []byte) (DocChunkPlan, bool) {
+	env, events, err := splitCanonicalDocBytes(cb)
+	if err != nil || len(env) == 0 || len(events) == 0 {
+		return DocChunkPlan{}, false
+	}
+	stream := joinEventStream(events)
+	raw := chunkByteStream(stream)
+	if !bytes.Equal(assembleCanonicalEventStream(env, bytes.Join(raw, nil)), cb) {
+		return DocChunkPlan{}, false
+	}
+	return buildDocChunkPlan(ChunkFormatV2, env, raw), true
+}
+
+// PlanDocChunksV1 retains the old event-boundary wire plan for peers that do not advertise v2.
+func PlanDocChunksV1(cb []byte) (DocChunkPlan, bool) {
 	env, events, err := splitCanonicalDocBytes(cb)
 	if err != nil || len(env) == 0 || len(events) == 0 {
 		return DocChunkPlan{}, false
@@ -59,14 +77,18 @@ func PlanDocChunks(cb []byte) (DocChunkPlan, bool) {
 	if !bytes.Equal(AssembleCanonicalDoc(env, flat), cb) {
 		return DocChunkPlan{}, false
 	}
-	p := DocChunkPlan{Manifest: DocChunkManifest{Format: ChunkFormat, Envelope: env}, Bodies: make(map[ContentHash][]byte, len(raw))}
+	return buildDocChunkPlan(ChunkFormatV1, env, raw), true
+}
+
+func buildDocChunkPlan(format string, env json.RawMessage, raw [][]byte) DocChunkPlan {
+	p := DocChunkPlan{Manifest: DocChunkManifest{Format: format, Envelope: env}, Bodies: make(map[ContentHash][]byte, len(raw))}
 	for _, c := range raw {
 		h := HashContent(c)
 		p.Manifest.Chunks = append(p.Manifest.Chunks, h)
 		p.Order = append(p.Order, h)
 		p.Bodies[h] = c
 	}
-	return p, true
+	return p
 }
 
 // ParseDocChunkManifest parses data if it's a chunk manifest (otherwise ok=false — legacy fallback).
@@ -75,11 +97,11 @@ func ParseDocChunkManifest(data []byte) (DocChunkManifest, bool) {
 	if limit > 64 {
 		limit = 64
 	}
-	if !bytes.Contains(data[:limit], []byte(ChunkFormat)) {
+	if !bytes.Contains(data[:limit], []byte("cxt-doc-chunks-v")) {
 		return DocChunkManifest{}, false
 	}
 	var man DocChunkManifest
-	if err := json.Unmarshal(data, &man); err != nil || man.Format != ChunkFormat {
+	if err := json.Unmarshal(data, &man); err != nil || !SupportedChunkFormat(man.Format) || len(man.Envelope) == 0 || len(man.Chunks) == 0 {
 		return DocChunkManifest{}, false
 	}
 	return man, true
@@ -104,15 +126,37 @@ func AssembleCanonicalDoc(env json.RawMessage, events [][]byte) []byte {
 
 // AssembleDocChunks reconstructs canonical bytes from chunk bytes in manifest order and validates integrity (detects chunk corruption and manifest tampering).
 func AssembleDocChunks(man DocChunkManifest, chunks [][]byte, want ContentHash) ([]byte, error) {
-	events := make([][]byte, 0, len(chunks)*8)
-	for _, c := range chunks {
-		events = append(events, SplitDocChunk(c)...)
+	var cb []byte
+	switch normalizeChunkFormat(man.Format) {
+	case ChunkFormatV1:
+		events := make([][]byte, 0, len(chunks)*8)
+		for _, c := range chunks {
+			events = append(events, SplitDocChunk(c)...)
+		}
+		cb = AssembleCanonicalDoc(man.Envelope, events)
+	case ChunkFormatV2:
+		cb = assembleCanonicalEventStream(man.Envelope, bytes.Join(chunks, nil))
+	default:
+		return nil, ErrIntegrity
 	}
-	cb := AssembleCanonicalDoc(man.Envelope, events)
 	if HashContent(cb) != want {
 		return nil, ErrIntegrity
 	}
 	return cb, nil
+}
+
+// SupportedChunkFormat reports manifest formats this binary can safely assemble.
+func SupportedChunkFormat(format string) bool {
+	format = normalizeChunkFormat(format)
+	return format == ChunkFormatV1 || format == ChunkFormatV2
+}
+
+// Empty format is the pre-versioned wire representation and therefore means v1.
+func normalizeChunkFormat(format string) string {
+	if format == "" {
+		return ChunkFormatV1
+	}
+	return format
 }
 
 // SplitDocChunk splits chunk bytes into event pieces.
@@ -146,4 +190,39 @@ func chunkEventFragments(events []json.RawMessage) [][]byte {
 		chunks = append(chunks, append([]byte(nil), cur.Bytes()...))
 	}
 	return chunks
+}
+
+func chunkByteStream(stream []byte) [][]byte {
+	chunks := make([][]byte, 0, (len(stream)+ChunkTarget-1)/ChunkTarget)
+	for len(stream) > 0 {
+		n := ChunkTarget
+		if len(stream) < n {
+			n = len(stream)
+		}
+		chunks = append(chunks, append([]byte(nil), stream[:n]...))
+		stream = stream[n:]
+	}
+	return chunks
+}
+
+func joinEventStream(events []json.RawMessage) []byte {
+	var b bytes.Buffer
+	for i, event := range events {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		b.Write(event)
+	}
+	return b.Bytes()
+}
+
+func assembleCanonicalEventStream(env json.RawMessage, stream []byte) []byte {
+	var b bytes.Buffer
+	b.Grow(len(env) + len(stream) + 32)
+	b.WriteString(`{"envelope":`)
+	b.Write(env)
+	b.WriteString(`,"events":[`)
+	b.Write(stream)
+	b.WriteString(`]}`)
+	return b.Bytes()
 }

--- a/backend/internal/domain/chunks_test.go
+++ b/backend/internal/domain/chunks_test.go
@@ -2,10 +2,11 @@ package domain
 
 import (
 	"bytes"
+	"encoding/json"
 	"testing"
 )
 
-func TestPlanDocChunksFallsBackForOversizedSingleEvent(t *testing.T) {
+func TestPlanDocChunksV2SplitsOversizedSingleEvent(t *testing.T) {
 	prefix := []byte(`{"envelope":{},"events":[{"text":"`)
 	suffix := []byte(`"}]}`)
 	canonical := make([]byte, 0, len(prefix)+MaxPortableChunkBytes+1+len(suffix))
@@ -13,7 +14,58 @@ func TestPlanDocChunksFallsBackForOversizedSingleEvent(t *testing.T) {
 	canonical = append(canonical, bytes.Repeat([]byte{'x'}, MaxPortableChunkBytes+1)...)
 	canonical = append(canonical, suffix...)
 
-	if _, ok := PlanDocChunks(canonical); ok {
-		t.Fatal("oversized single event must use the full-doc fallback")
+	plan, ok := PlanDocChunks(canonical)
+	if !ok {
+		t.Fatal("v2 must chunk an oversized event without a full-doc fallback")
+	}
+	if plan.Manifest.Format != ChunkFormatV2 || len(plan.Order) < 2 {
+		t.Fatalf("format=%q chunks=%d, want v2 multi-chunk", plan.Manifest.Format, len(plan.Order))
+	}
+	chunks := make([][]byte, 0, len(plan.Order))
+	for _, hash := range plan.Order {
+		body := plan.Bodies[hash]
+		if len(body) > ChunkTarget {
+			t.Fatalf("chunk %s is %d bytes, want <= %d", hash, len(body), ChunkTarget)
+		}
+		chunks = append(chunks, body)
+	}
+	got, err := AssembleDocChunks(plan.Manifest, chunks, HashContent(canonical))
+	if err != nil || !bytes.Equal(got, canonical) {
+		t.Fatalf("v2 roundtrip err=%v equal=%v", err, bytes.Equal(got, canonical))
+	}
+}
+
+func TestV1ManifestAndEmptyWireFormatRemainReadable(t *testing.T) {
+	canonical := []byte(`{"envelope":{},"events":[{"text":"a"},{"text":"b"}]}`)
+	plan, ok := PlanDocChunksV1(canonical)
+	if !ok {
+		t.Fatal("v1 plan unavailable")
+	}
+	encoded, _ := json.Marshal(plan.Manifest)
+	parsed, ok := ParseDocChunkManifest(encoded)
+	if !ok || parsed.Format != ChunkFormatV1 {
+		t.Fatalf("parsed=%+v ok=%v", parsed, ok)
+	}
+	chunks := make([][]byte, 0, len(plan.Order))
+	for _, hash := range plan.Order {
+		chunks = append(chunks, plan.Bodies[hash])
+	}
+	parsed.Format = ""
+	got, err := AssembleDocChunks(parsed, chunks, HashContent(canonical))
+	if err != nil || !bytes.Equal(got, canonical) {
+		t.Fatalf("empty v1 wire roundtrip err=%v", err)
+	}
+	parsed.Format = "cxt-doc-chunks-v999"
+	if _, err := AssembleDocChunks(parsed, chunks, HashContent(canonical)); err == nil {
+		t.Fatal("unknown manifest format was accepted")
+	}
+}
+
+func TestPlanDocChunksV1CompatibilityStillFallsBack(t *testing.T) {
+	prefix := []byte(`{"envelope":{},"events":[{"text":"`)
+	suffix := []byte(`"}]}`)
+	canonical := append(append(append([]byte{}, prefix...), bytes.Repeat([]byte{'x'}, MaxPortableChunkBytes+1)...), suffix...)
+	if _, ok := PlanDocChunksV1(canonical); ok {
+		t.Fatal("v1 cannot transport an event above its single-chunk bound")
 	}
 }

--- a/backend/internal/ports/inbound/inbound.go
+++ b/backend/internal/ports/inbound/inbound.go
@@ -100,7 +100,9 @@ type Authenticate interface {
 
 // ChunkedDoc represents a doc as a manifest (envelope+chunk hash) in a wire format (chunk delta transmission).
 type ChunkedDoc struct {
-	Hash     domain.ContentHash   `json:"hash"`
+	Hash domain.ContentHash `json:"hash"`
+	// Format is explicit for v2. Empty is the legacy wire representation and means v1.
+	Format   string               `json:"format,omitempty"`
 	Envelope json.RawMessage      `json:"envelope"`
 	Chunks   []domain.ContentHash `json:"chunks"`
 }
@@ -112,7 +114,7 @@ type ChunkObject struct {
 }
 
 const (
-	// Limit raw batch to 2MiB to comfortably fit within 4MiB, even with JSON base64 overhead. Explicitly reject chunks larger than this for a single event.
+	// Limit raw batch to 2MiB to comfortably fit within 4MiB, even with JSON base64 overhead.
 	MaxChunkWireRawBytes = domain.MaxPortableChunkBytes
 	MaxChunkWireObjects  = 32
 	MaxChunkWireJSONBody = 4 << 20
@@ -247,6 +249,7 @@ type PushNegotiateOutput struct {
 	ChunksSupported bool `json:"chunks_supported,omitempty"`
 	// BoundedChunksSupported true if chunk bodies are sent as bounded batches to /push/chunks·/pull/chunks. For old servers, the existing push/objects compatibility paths are used.
 	BoundedChunksSupported bool                 `json:"bounded_chunks_supported,omitempty"`
+	ChunkFormatsSupported  []string             `json:"chunk_formats_supported,omitempty"`
 	ChunkWants             []domain.ContentHash `json:"chunk_wants,omitempty"`
 }
 
@@ -258,6 +261,8 @@ type PullSendInput struct {
 	// Chunk Wire (Delta Download): Manifest/Chunk Body Request.
 	DocManifestWants []domain.ContentHash
 	ChunkWants       []domain.ContentHash
+	// Empty means a pre-v2 client, which can safely consume v1 only.
+	ChunkFormatsSupported []string
 }
 
 // PullSendOutput: Download Target Object (push/objects Request Body Equivalent). (wire: snake_case)

--- a/cli/internal/adapters/backendclient/backend_client.go
+++ b/cli/internal/adapters/backendclient/backend_client.go
@@ -52,12 +52,14 @@ type negotiateResp struct {
 	// ChunksSupported true = chunk wire support server (old servers lack field → false — blanket fallback).
 	ChunksSupported        bool                 `json:"chunks_supported,omitempty"`
 	BoundedChunksSupported bool                 `json:"bounded_chunks_supported,omitempty"`
+	ChunkFormatsSupported  []string             `json:"chunk_formats_supported,omitempty"`
 	ChunkWants             []domain.ContentHash `json:"chunk_wants,omitempty"`
 }
 
 // chunkedDocWire is the wire form sending doc as manifest (envelope+chunk hash).
 type chunkedDocWire struct {
 	Hash     domain.ContentHash   `json:"hash"`
+	Format   string               `json:"format,omitempty"`
 	Envelope json.RawMessage      `json:"envelope"`
 	Chunks   []domain.ContentHash `json:"chunks"`
 }
@@ -82,8 +84,9 @@ type pullReq struct {
 	SnapshotWants []domain.ContentHash `json:"snapshot_wants"`
 	DocWants      []domain.ContentHash `json:"doc_wants"`
 	// Chunk wire (new type): receive doc as manifest and only missing chunk bodies (delta download).
-	DocManifestWants []domain.ContentHash `json:"doc_manifest_wants,omitempty"`
-	ChunkWants       []domain.ContentHash `json:"chunk_wants,omitempty"`
+	DocManifestWants      []domain.ContentHash `json:"doc_manifest_wants,omitempty"`
+	ChunkWants            []domain.ContentHash `json:"chunk_wants,omitempty"`
+	ChunkFormatsSupported []string             `json:"chunk_formats_supported,omitempty"`
 }
 type pullResp struct {
 	Snapshots              []domain.Snapshot   `json:"snapshots"`
@@ -597,7 +600,12 @@ func (c *BackendClient) Push(ctx context.Context, repoID string, snapshots []dom
 			return domain.ErrHashMismatch
 		}
 		docHaves = append(docHaves, d.Hash)
-		if plan, ok := chunkcas.PlanDoc(cb); ok {
+		// Storage and transport use the same v2 chunk identities. Sending v1 to a
+		// v2 server would leave a second, unreferenced chunk representation in its
+		// CAS. A pre-v2 server gets the complete document below; correctness is
+		// preserved during rolling upgrades at the cost of temporary delta upload.
+		plan, ok := chunkcas.PlanDoc(cb)
+		if ok {
 			plans[d.Hash] = plan
 			for _, ch := range plan.Order {
 				if !seenChunk[ch] {
@@ -642,11 +650,18 @@ func (c *BackendClient) Push(ctx context.Context, repoID string, snapshots []dom
 			continue
 		}
 		plan, planned := plans[d.Hash]
+		if planned && plan.Manifest.Format == chunkcas.FormatV2 && !containsString(neg.ChunkFormatsSupported, chunkcas.FormatV2) {
+			planned = false
+		}
 		if !neg.ChunksSupported || !planned {
 			sendDocs = append(sendDocs, d) // fallback to old server/plan — full (original path)
 			continue
 		}
-		chunkedDocs = append(chunkedDocs, chunkedDocWire{Hash: d.Hash, Envelope: plan.Manifest.Envelope, Chunks: plan.Manifest.Chunks})
+		wireFormat := plan.Manifest.Format
+		if wireFormat == chunkcas.FormatV1 {
+			wireFormat = "" // pre-v2 servers interpret the omitted field as v1
+		}
+		chunkedDocs = append(chunkedDocs, chunkedDocWire{Hash: d.Hash, Format: wireFormat, Envelope: plan.Manifest.Envelope, Chunks: plan.Manifest.Chunks})
 		for _, ch := range plan.Order {
 			if wantChunk[ch] && !sentChunk[ch] {
 				sentChunk[ch] = true
@@ -686,6 +701,15 @@ func (c *BackendClient) Push(ctx context.Context, repoID string, snapshots []dom
 		return fmt.Errorf("%w: %s", domain.ErrSyncConflict, strings.Join(rejected, ", "))
 	}
 	return nil
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }
 
 func snapshotForCreate(s domain.Snapshot) domain.Snapshot {
@@ -800,7 +824,7 @@ func (c *BackendClient) pullDocs(ctx context.Context, repoID string, docWants []
 	// 1) Manifest request (new) — old server ignores fields, returns empty response → fallback to entire body.
 	// New server can return entire body for unplanable docs (mixed response).
 	var manResp pullResp
-	if err := c.do(ctx, http.MethodPost, c.reposPath(repoID)+"/pull/objects", pullReq{DocManifestWants: docWants}, &manResp); err != nil {
+	if err := c.do(ctx, http.MethodPost, c.reposPath(repoID)+"/pull/objects", pullReq{DocManifestWants: docWants, ChunkFormatsSupported: []string{chunkcas.FormatV1, chunkcas.FormatV2}}, &manResp); err != nil {
 		return nil, err
 	}
 	if len(manResp.DocManifests) == 0 && len(manResp.Docs) == 0 {
@@ -840,7 +864,7 @@ func (c *BackendClient) pullDocs(ctx context.Context, repoID string, docWants []
 	var need []domain.ContentHash
 	bodies := map[domain.ContentHash][]byte{}
 	for _, m := range manResp.DocManifests {
-		if !docWantSet[m.Hash] || seenMan[m.Hash] || len(m.Chunks) == 0 {
+		if !docWantSet[m.Hash] || seenMan[m.Hash] || len(m.Chunks) == 0 || !chunkcas.SupportedFormat(m.Format) {
 			return nil, domain.ErrHashMismatch
 		}
 		seenMan[m.Hash] = true
@@ -914,7 +938,7 @@ func (c *BackendClient) pullDocs(ctx context.Context, repoID string, docWants []
 			chunks = append(chunks, b)
 		}
 		// AssembleChunks validates integrity hashes (equivalent to ValidateSessionDocHash for entire path).
-		cb, aerr := chunkcas.AssembleChunks(chunkcas.Manifest{Format: chunkcas.Format, Envelope: m.Envelope, Chunks: m.Chunks}, chunks, m.Hash)
+		cb, aerr := chunkcas.AssembleChunks(chunkcas.Manifest{Format: m.Format, Envelope: m.Envelope, Chunks: m.Chunks}, chunks, m.Hash)
 		if aerr != nil {
 			return nil, aerr
 		}

--- a/cli/internal/adapters/backendclient/backend_client_test.go
+++ b/cli/internal/adapters/backendclient/backend_client_test.go
@@ -103,8 +103,8 @@ func makeChunkedClientDoc(t *testing.T, events int) (domain.SessionDoc, chunkcas
 	}
 	doc := domain.SessionDoc{Hash: domain.HashContent(canonical), CIR: cir}
 	plan, ok := chunkcas.PlanDoc(canonical)
-	if !ok || len(plan.Order) != events {
-		t.Fatalf("chunk plan ok=%v chunks=%d, want %d", ok, len(plan.Order), events)
+	if !ok || len(plan.Order) < 2 {
+		t.Fatalf("chunk plan ok=%v chunks=%d, want multiple", ok, len(plan.Order))
 	}
 	return doc, plan
 }
@@ -159,6 +159,7 @@ func TestPushUploadsBoundedChunksBeforeManifestCommit(t *testing.T) {
 			_ = json.NewEncoder(w).Encode(negotiateResp{
 				SnapshotWants: req.SnapshotHaves, DocWants: req.DocHaves, ChunkWants: req.ChunkHaves,
 				ChunksSupported: true, BoundedChunksSupported: true,
+				ChunkFormatsSupported: []string{chunkcas.FormatV1, chunkcas.FormatV2},
 			})
 		case "/repos/" + string(repoID) + "/push/chunks":
 			var req chunksReq
@@ -204,12 +205,12 @@ func TestPushUploadsBoundedChunksBeforeManifestCommit(t *testing.T) {
 	if len(committed.ChunkObjects) != 0 || len(committed.Docs) != 0 {
 		t.Fatalf("bounded final commit leaked inline bodies: docs=%d chunks=%d", len(committed.Docs), len(committed.ChunkObjects))
 	}
-	if len(plan.Order) != 7 {
-		t.Fatalf("test precondition chunks=%d", len(plan.Order))
+	if committed.ChunkedDocs[0].Format != chunkcas.FormatV2 || len(plan.Order) < 2 {
+		t.Fatalf("format=%q test chunks=%d", committed.ChunkedDocs[0].Format, len(plan.Order))
 	}
 }
 
-func TestPushKeepsInlineChunksForChunkAwareLegacyServer(t *testing.T) {
+func TestPushFallsBackToFullDocForChunkAwareV1Server(t *testing.T) {
 	repoID := domain.HashContent([]byte("legacy-chunk-push-repo"))
 	doc, plan := makeChunkedClientDoc(t, 2)
 	snap := domain.Snapshot{ID: doc.Hash, RepoID: string(repoID), Branch: "main", DocHash: doc.Hash}
@@ -239,12 +240,13 @@ func TestPushKeepsInlineChunksForChunkAwareLegacyServer(t *testing.T) {
 	if err := c.Push(context.Background(), string(repoID), []domain.Snapshot{snap}, []domain.SessionDoc{doc}, nil, false, false); err != nil {
 		t.Fatal(err)
 	}
-	if pushChunksCalled || len(committed.ChunkObjects) != len(plan.Order) || len(committed.ChunkedDocs) != 1 {
-		t.Fatalf("legacy fallback pushChunks=%v manifests=%d chunks=%d", pushChunksCalled, len(committed.ChunkedDocs), len(committed.ChunkObjects))
+	if pushChunksCalled || len(committed.Docs) != 1 || len(committed.ChunkObjects) != 0 || len(committed.ChunkedDocs) != 0 {
+		t.Fatalf("v1 fallback pushChunks=%v docs=%d manifests=%d chunks=%d", pushChunksCalled, len(committed.Docs), len(committed.ChunkedDocs), len(committed.ChunkObjects))
 	}
+	_ = plan
 }
 
-func TestPushFallsBackToFullDocForOversizedSingleEvent(t *testing.T) {
+func TestPushUsesV2ForOversizedSingleEvent(t *testing.T) {
 	repoID := domain.HashContent([]byte("oversized-event-push-repo"))
 	cir := domain.CIRDocument{
 		Envelope: domain.Envelope{CIRVersion: "1", SourceProvider: domain.ProviderClaude, Fidelity: domain.FidelityFull, GitBranch: "main"},
@@ -266,16 +268,17 @@ func TestPushFallsBackToFullDocForOversizedSingleEvent(t *testing.T) {
 		case "/repos/" + string(repoID) + "/push/negotiate":
 			var req negotiateReq
 			_ = json.NewDecoder(r.Body).Decode(&req)
-			if len(req.ChunkHaves) != 0 {
-				t.Errorf("oversized doc advertised chunk haves: %d", len(req.ChunkHaves))
+			if len(req.ChunkHaves) < 2 {
+				t.Errorf("oversized doc advertised only %d chunk haves", len(req.ChunkHaves))
 			}
 			_ = json.NewEncoder(w).Encode(negotiateResp{
-				SnapshotWants: req.SnapshotHaves, DocWants: req.DocHaves,
+				SnapshotWants: req.SnapshotHaves, DocWants: req.DocHaves, ChunkWants: req.ChunkHaves,
 				ChunksSupported: true, BoundedChunksSupported: true,
+				ChunkFormatsSupported: []string{chunkcas.FormatV1, chunkcas.FormatV2},
 			})
 		case "/repos/" + string(repoID) + "/push/chunks":
 			pushChunksCalled = true
-			http.Error(w, "unexpected", http.StatusInternalServerError)
+			_ = json.NewEncoder(w).Encode(map[string]int{})
 		case "/repos/" + string(repoID) + "/push/objects":
 			_ = json.NewDecoder(r.Body).Decode(&committed)
 			_ = json.NewEncoder(w).Encode(map[string]int{})
@@ -289,8 +292,42 @@ func TestPushFallsBackToFullDocForOversizedSingleEvent(t *testing.T) {
 	if err := c.Push(context.Background(), string(repoID), []domain.Snapshot{snap}, []domain.SessionDoc{doc}, nil, false, false); err != nil {
 		t.Fatal(err)
 	}
-	if pushChunksCalled || len(committed.Docs) != 1 || len(committed.ChunkedDocs) != 0 || len(committed.ChunkObjects) != 0 {
-		t.Fatalf("oversized fallback pushChunks=%v docs=%d manifests=%d chunks=%d", pushChunksCalled, len(committed.Docs), len(committed.ChunkedDocs), len(committed.ChunkObjects))
+	format := ""
+	if len(committed.ChunkedDocs) == 1 {
+		format = committed.ChunkedDocs[0].Format
+	}
+	if !pushChunksCalled || len(committed.Docs) != 0 || len(committed.ChunkedDocs) != 1 || format != chunkcas.FormatV2 || len(committed.ChunkObjects) != 0 {
+		t.Fatalf("oversized v2 pushChunks=%v docs=%d manifests=%d chunks=%d format=%q", pushChunksCalled, len(committed.Docs), len(committed.ChunkedDocs), len(committed.ChunkObjects), format)
+	}
+}
+
+func TestPushFallsBackToFullDocForOversizedEventOnV1Server(t *testing.T) {
+	repoID := domain.HashContent([]byte("oversized-event-old-server"))
+	cir := domain.CIRDocument{Envelope: domain.Envelope{CIRVersion: "1"}, Events: []domain.Event{{Kind: domain.EventMessage, Seq: 0, Role: "user", Blocks: []domain.ContentBlock{{Type: "text", Text: strings.Repeat("x", chunkcas.MaxPortableChunkBytes+1)}}}}}
+	canonical, _ := domain.CanonicalBytes(cir)
+	doc := domain.SessionDoc{Hash: domain.HashContent(canonical), CIR: cir}
+	snap := domain.Snapshot{ID: doc.Hash, RepoID: string(repoID), Branch: "main", DocHash: doc.Hash}
+	var committed objectsReq
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/" + string(repoID) + "/push/negotiate":
+			var req negotiateReq
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			_ = json.NewEncoder(w).Encode(negotiateResp{SnapshotWants: req.SnapshotHaves, DocWants: req.DocHaves, ChunkWants: req.ChunkHaves, ChunksSupported: true, BoundedChunksSupported: true})
+		case "/repos/" + string(repoID) + "/push/objects":
+			_ = json.NewDecoder(r.Body).Decode(&committed)
+			_ = json.NewEncoder(w).Encode(map[string]int{})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+	c := NewBackendClient(func() string { return ts.URL }, func() string { return "" }, domain.TeamIdentity{})
+	if err := c.Push(context.Background(), string(repoID), []domain.Snapshot{snap}, []domain.SessionDoc{doc}, nil, false, false); err != nil {
+		t.Fatal(err)
+	}
+	if len(committed.Docs) != 1 || len(committed.ChunkedDocs) != 0 {
+		t.Fatalf("old-server fallback docs=%d manifests=%d", len(committed.Docs), len(committed.ChunkedDocs))
 	}
 }
 
@@ -306,8 +343,11 @@ func TestPullFetchesBoundedChunkPrefixesUntilComplete(t *testing.T) {
 			if len(req.DocManifestWants) != 1 || req.DocManifestWants[0] != doc.Hash {
 				t.Errorf("manifest wants=%v", req.DocManifestWants)
 			}
+			if !containsString(req.ChunkFormatsSupported, chunkcas.FormatV2) {
+				t.Errorf("client formats=%v", req.ChunkFormatsSupported)
+			}
 			_ = json.NewEncoder(w).Encode(pullResp{
-				DocManifests:           []chunkedDocWire{{Hash: doc.Hash, Envelope: plan.Manifest.Envelope, Chunks: plan.Manifest.Chunks}},
+				DocManifests:           []chunkedDocWire{{Hash: doc.Hash, Format: plan.Manifest.Format, Envelope: plan.Manifest.Envelope, Chunks: plan.Manifest.Chunks}},
 				BoundedChunksSupported: true,
 			})
 		case "/repos/" + string(repoID) + "/pull/chunks":
@@ -333,8 +373,9 @@ func TestPullFetchesBoundedChunkPrefixesUntilComplete(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if pullCalls != 4 {
-		t.Fatalf("pull/chunks calls=%d, want 4", pullCalls)
+	wantCalls := (len(plan.Order) + 1) / 2
+	if pullCalls != wantCalls {
+		t.Fatalf("pull/chunks calls=%d, want %d", pullCalls, wantCalls)
 	}
 	if len(docs) != 1 || docs[0].Hash != doc.Hash || len(docs[0].CIR.Events) != 7 {
 		t.Fatalf("pulled docs=%+v", docs)

--- a/cli/internal/adapters/chunkcas/chunkcas.go
+++ b/cli/internal/adapters/chunkcas/chunkcas.go
@@ -3,8 +3,9 @@
 // Adapters/storage and adapters/backendclient must use the same rules to ensure that chunk hashes match locally ↔ server for deduplication/delta transmission to work. Rules:
 //
 //   - Canonical bytes must be exactly `{"envelope":<env>,"events":[<e1>,…]}` (key sorted and compact).
-//   - Accumulate canonical event fragments in order to pass ChunkTarget, which closes the chunk (prefix-stable — append-only sessions have the same captured chunks).
-//   - Chunk bytes = concatenating fragments with '\n'. Chunk hash = HashContent(chunk bytes).
+//   - v1 keeps whole canonical events joined with '\n' for old peer compatibility.
+//   - v2 chunks the canonical events-array interior at fixed byte offsets, so one event can be arbitrarily large.
+//   - Both formats keep closed append-only prefixes stable. Chunk hash = HashContent(chunk bytes).
 //   - DocHash is always the hash of the entire canonical — unchanged regardless of chunking.
 //
 // Plan returns only the plan for reassembly==original validation (ok=false — fallback).
@@ -20,11 +21,16 @@ import (
 // ChunkTarget is the chunk closure size threshold (uncompressed canonical byte count).
 const ChunkTarget = 512 << 10
 
-// MaxPortableChunkBytes is the upper limit for a single chunk that can be safely transported using bounded HTTP transport. If an event is larger than this, PlanDoc selects a full doc fallback.
+// MaxPortableChunkBytes is the raw body limit for one bounded HTTP batch. v2 chunks are always
+// below it; only PlanDocV1 falls back when one whole event exceeds it.
 const MaxPortableChunkBytes = 2 << 20
 
-// Format is the chunk doc manifest identifier (canonical doc starts with "envelope" key — no overlap).
-const Format = "cxt-doc-chunks-v1"
+const (
+	FormatV1 = "cxt-doc-chunks-v1"
+	FormatV2 = "cxt-doc-chunks-v2"
+	// Format is emitted by new local storage writes.
+	Format = FormatV2
+)
 
 // Manifest is the chunk doc manifest (common form for storage and wire).
 type Manifest struct {
@@ -42,8 +48,22 @@ type Plan struct {
 	Order []domain.ContentHash
 }
 
-// PlanDoc distills canonical bytes and validates reassembly integrity. ok=false falls back to legacy.
+// PlanDoc emits the current byte-stream format, whose chunks remain bounded even when one event is huge.
 func PlanDoc(cb []byte) (Plan, bool) {
+	env, events, err := split(cb)
+	if err != nil || len(env) == 0 || len(events) == 0 {
+		return Plan{}, false
+	}
+	stream := joinEventStream(events)
+	raw := chunkByteStream(stream)
+	if !bytes.Equal(assembleStream(env, bytes.Join(raw, nil)), cb) {
+		return Plan{}, false
+	}
+	return buildPlan(FormatV2, env, raw), true
+}
+
+// PlanDocV1 retains the old whole-event format for compatibility with peers without v2 capability.
+func PlanDocV1(cb []byte) (Plan, bool) {
 	env, events, err := split(cb)
 	if err != nil || len(env) == 0 || len(events) == 0 {
 		return Plan{}, false
@@ -61,14 +81,18 @@ func PlanDoc(cb []byte) (Plan, bool) {
 	if !bytes.Equal(Assemble(env, flat), cb) {
 		return Plan{}, false
 	}
-	p := Plan{Manifest: Manifest{Format: Format, Envelope: env}, Bodies: make(map[domain.ContentHash][]byte, len(raw))}
+	return buildPlan(FormatV1, env, raw), true
+}
+
+func buildPlan(format string, env json.RawMessage, raw [][]byte) Plan {
+	p := Plan{Manifest: Manifest{Format: format, Envelope: env}, Bodies: make(map[domain.ContentHash][]byte, len(raw))}
 	for _, c := range raw {
 		h := domain.HashContent(c)
 		p.Manifest.Chunks = append(p.Manifest.Chunks, h)
 		p.Order = append(p.Order, h)
 		p.Bodies[h] = c
 	}
-	return p, true
+	return p
 }
 
 // ParseManifest parses data if it's a chunk manifest (otherwise ok=false — legacy fallback).
@@ -77,11 +101,11 @@ func ParseManifest(data []byte) (Manifest, bool) {
 	if limit > 64 {
 		limit = 64
 	}
-	if !bytes.Contains(data[:limit], []byte(Format)) {
+	if !bytes.Contains(data[:limit], []byte("cxt-doc-chunks-v")) {
 		return Manifest{}, false
 	}
 	var man Manifest
-	if err := json.Unmarshal(data, &man); err != nil || man.Format != Format {
+	if err := json.Unmarshal(data, &man); err != nil || !SupportedFormat(man.Format) || len(man.Envelope) == 0 || len(man.Chunks) == 0 {
 		return Manifest{}, false
 	}
 	return man, true
@@ -106,15 +130,35 @@ func Assemble(env json.RawMessage, events [][]byte) []byte {
 
 // AssembleChunks recovers canonical bytes from chunk bytes in manifest order and compares integrity hash (dirt detection).
 func AssembleChunks(man Manifest, chunks [][]byte, want domain.ContentHash) ([]byte, error) {
-	events := make([][]byte, 0, len(chunks)*8)
-	for _, c := range chunks {
-		events = append(events, SplitChunk(c)...)
+	var cb []byte
+	switch normalizeFormat(man.Format) {
+	case FormatV1:
+		events := make([][]byte, 0, len(chunks)*8)
+		for _, c := range chunks {
+			events = append(events, SplitChunk(c)...)
+		}
+		cb = Assemble(man.Envelope, events)
+	case FormatV2:
+		cb = assembleStream(man.Envelope, bytes.Join(chunks, nil))
+	default:
+		return nil, domain.ErrHashMismatch
 	}
-	cb := Assemble(man.Envelope, events)
 	if domain.HashContent(cb) != want {
 		return nil, domain.ErrHashMismatch
 	}
 	return cb, nil
+}
+
+func SupportedFormat(format string) bool {
+	format = normalizeFormat(format)
+	return format == FormatV1 || format == FormatV2
+}
+
+func normalizeFormat(format string) string {
+	if format == "" {
+		return FormatV1
+	}
+	return format
 }
 
 // SplitChunk converts chunk bytes back into event fragments.
@@ -148,4 +192,39 @@ func chunkEvents(events []json.RawMessage) [][]byte {
 		chunks = append(chunks, append([]byte(nil), cur.Bytes()...))
 	}
 	return chunks
+}
+
+func chunkByteStream(stream []byte) [][]byte {
+	chunks := make([][]byte, 0, (len(stream)+ChunkTarget-1)/ChunkTarget)
+	for len(stream) > 0 {
+		n := ChunkTarget
+		if len(stream) < n {
+			n = len(stream)
+		}
+		chunks = append(chunks, append([]byte(nil), stream[:n]...))
+		stream = stream[n:]
+	}
+	return chunks
+}
+
+func joinEventStream(events []json.RawMessage) []byte {
+	var b bytes.Buffer
+	for i, event := range events {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		b.Write(event)
+	}
+	return b.Bytes()
+}
+
+func assembleStream(env json.RawMessage, stream []byte) []byte {
+	var b bytes.Buffer
+	b.Grow(len(env) + len(stream) + 32)
+	b.WriteString(`{"envelope":`)
+	b.Write(env)
+	b.WriteString(`,"events":[`)
+	b.Write(stream)
+	b.WriteString(`]}`)
+	return b.Bytes()
 }

--- a/cli/internal/adapters/chunkcas/chunkcas_test.go
+++ b/cli/internal/adapters/chunkcas/chunkcas_test.go
@@ -2,10 +2,13 @@ package chunkcas
 
 import (
 	"bytes"
+	"encoding/json"
 	"testing"
+
+	"github.com/wnsdy95/cxthub/cli/internal/domain"
 )
 
-func TestPlanDocFallsBackForOversizedSingleEvent(t *testing.T) {
+func TestPlanDocV2SplitsOversizedSingleEvent(t *testing.T) {
 	prefix := []byte(`{"envelope":{},"events":[{"text":"`)
 	suffix := []byte(`"}]}`)
 	canonical := make([]byte, 0, len(prefix)+MaxPortableChunkBytes+1+len(suffix))
@@ -13,7 +16,58 @@ func TestPlanDocFallsBackForOversizedSingleEvent(t *testing.T) {
 	canonical = append(canonical, bytes.Repeat([]byte{'x'}, MaxPortableChunkBytes+1)...)
 	canonical = append(canonical, suffix...)
 
-	if _, ok := PlanDoc(canonical); ok {
-		t.Fatal("oversized single event must use the full-doc fallback")
+	plan, ok := PlanDoc(canonical)
+	if !ok {
+		t.Fatal("v2 must chunk an oversized event without a full-doc fallback")
+	}
+	if plan.Manifest.Format != FormatV2 || len(plan.Order) < 2 {
+		t.Fatalf("format=%q chunks=%d, want v2 multi-chunk", plan.Manifest.Format, len(plan.Order))
+	}
+	chunks := make([][]byte, 0, len(plan.Order))
+	for _, hash := range plan.Order {
+		body := plan.Bodies[hash]
+		if len(body) > ChunkTarget {
+			t.Fatalf("chunk %s is %d bytes, want <= %d", hash, len(body), ChunkTarget)
+		}
+		chunks = append(chunks, body)
+	}
+	got, err := AssembleChunks(plan.Manifest, chunks, domain.HashContent(canonical))
+	if err != nil || !bytes.Equal(got, canonical) {
+		t.Fatalf("v2 roundtrip err=%v equal=%v", err, bytes.Equal(got, canonical))
+	}
+}
+
+func TestV1ManifestAndEmptyWireFormatRemainReadable(t *testing.T) {
+	canonical := []byte(`{"envelope":{},"events":[{"text":"a"},{"text":"b"}]}`)
+	plan, ok := PlanDocV1(canonical)
+	if !ok {
+		t.Fatal("v1 plan unavailable")
+	}
+	encoded, _ := json.Marshal(plan.Manifest)
+	parsed, ok := ParseManifest(encoded)
+	if !ok || parsed.Format != FormatV1 {
+		t.Fatalf("parsed=%+v ok=%v", parsed, ok)
+	}
+	chunks := make([][]byte, 0, len(plan.Order))
+	for _, hash := range plan.Order {
+		chunks = append(chunks, plan.Bodies[hash])
+	}
+	parsed.Format = ""
+	got, err := AssembleChunks(parsed, chunks, domain.HashContent(canonical))
+	if err != nil || !bytes.Equal(got, canonical) {
+		t.Fatalf("empty v1 wire roundtrip err=%v", err)
+	}
+	parsed.Format = "cxt-doc-chunks-v999"
+	if _, err := AssembleChunks(parsed, chunks, domain.HashContent(canonical)); err == nil {
+		t.Fatal("unknown manifest format was accepted")
+	}
+}
+
+func TestPlanDocV1CompatibilityStillFallsBack(t *testing.T) {
+	prefix := []byte(`{"envelope":{},"events":[{"text":"`)
+	suffix := []byte(`"}]}`)
+	canonical := append(append(append([]byte{}, prefix...), bytes.Repeat([]byte{'x'}, MaxPortableChunkBytes+1)...), suffix...)
+	if _, ok := PlanDocV1(canonical); ok {
+		t.Fatal("v1 cannot transport an event above its single-chunk bound")
 	}
 }

--- a/cli/internal/adapters/storage/doc_chunks.go
+++ b/cli/internal/adapters/storage/doc_chunks.go
@@ -7,14 +7,15 @@
 // Layout:
 //
 //	objects/docs/<hash>   = zstd(manifest JSON {format, envelope, chunks[]})  ← or legacy zstd(entire)
-//	objects/chunks/<h_i>  = zstd(event canonical fragments joined by '\n' bytes)
+//	objects/chunks/<h_i>  = zstd(v2 canonical event-stream byte range; v1 whole-event group remains readable)
 //
 // Canonical bytes are exactly `{"envelope":<env>,"events":[<e1>,<e2>,…]}` form (key sorting: envelope < events, compact) so the envelope fragment + event fragment list can be reassembled byte-by-byte. On write, reassembly==validation, and if mismatched, fallback to full storage (fail-safe — even if the shape assumption is broken, data is always stored correctly). On read, compare the hash of the reassembly result with the requested hash to detect chunk corruption (free of charge).
 //
-// Chunk boundaries are prefix-dependent and deterministic: when accumulating event fragments exceeds docChunkTarget, it closes. Closed chunks from append-only growth are the same bytes in subsequent captures → same hash for deduplication, and only the last open chunk is rewritten (capture increase ≈ delta + one open chunk).
+// v2 chunk boundaries are fixed offsets in the canonical events-array interior. Closed chunks from append-only growth are the same bytes in subsequent captures → same hash for deduplication, and only the last open chunk is rewritten (capture increase ≈ delta + one open chunk), even when one event is larger than the transport bound.
 package storage
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -27,24 +28,36 @@ import (
 
 // putDocChunked stores canonical bytes as chunks+manifest.
 // Returns false if reassembly does not match the original byte-for-byte (caller should fallback to full storage).
-func (s *FileStore) putDocChunked(h domain.ContentHash, cb []byte) (bool, error) {
+func (s *FileStore) putDocChunked(h domain.ContentHash, cb []byte) (bool, int64, error) {
 	plan, ok := chunkcas.PlanDoc(cb)
 	if !ok {
-		return false, nil // shape assumption failure/reassembly mismatch — fallback to full storage
+		return false, 0, nil // shape assumption failure/reassembly mismatch — fallback to full storage
 	}
+	var added int64
 	for _, ch := range plan.Order {
 		p := s.objectPath("chunks", ch)
-		if !fileExists(p) {
-			if err := writeAtomic(p, docCompress(plan.Bodies[ch])); err != nil {
-				return false, err
+		if fileExists(p) {
+			raw, err := readCxtFile(p)
+			if err != nil {
+				return false, added, err
 			}
+			existing, err := docDecompress(raw)
+			if err != nil || !bytes.Equal(existing, plan.Bodies[ch]) {
+				return false, added, domain.ErrHashMismatch
+			}
+		} else {
+			compressed := docCompress(plan.Bodies[ch])
+			if err := writeAtomic(p, compressed); err != nil {
+				return false, added, err
+			}
+			added += int64(len(compressed))
 		}
 	}
 	mb, err := json.Marshal(plan.Manifest)
 	if err != nil {
-		return false, err
+		return false, added, err
 	}
-	return true, writeAtomic(s.objectPath("docs", h), docCompress(mb))
+	return true, added, writeAtomic(s.objectPath("docs", h), docCompress(mb))
 }
 
 // getDocChunked reconstructs canonical bytes from manifest in chunks.
@@ -129,14 +142,28 @@ func (s *FileStore) RepackDocs() (converted int, saved int64, err error) {
 		if derr != nil {
 			continue
 		}
-		if _, isMan, _ := s.getDocChunked(hash, data); isMan {
+		if cb, isMan, chunkErr := s.getDocChunked(hash, data); isMan {
 			var man chunkcas.Manifest
-			if json.Unmarshal(data, &man) == nil {
+			if json.Unmarshal(data, &man) != nil {
+				continue
+			}
+			if chunkErr != nil {
+				// Preserve every referenced body when an existing manifest cannot be
+				// reassembled. Repack is maintenance, never corruption repair.
 				for _, ch := range man.Chunks {
 					live[ch] = true
 				}
+				continue
 			}
-			continue // already chunked
+			if man.Format == chunkcas.FormatV2 {
+				for _, ch := range man.Chunks {
+					live[ch] = true
+				}
+				continue
+			}
+			// A valid v1 manifest is a migration source. Reassemble first, then
+			// atomically replace only the manifest after all v2 chunks exist.
+			data = cb
 		}
 		// Legacy monolithic: hash verification then chunk transformation.
 		if domain.HashContent(data) != hash {
@@ -153,7 +180,7 @@ func (s *FileStore) RepackDocs() (converted int, saved int64, err error) {
 			data = cb
 		}
 		before := int64(len(raw))
-		ok, perr := s.putDocChunked(hash, data)
+		ok, added, perr := s.putDocChunked(hash, data)
 		if perr != nil {
 			return converted, saved, perr
 		}
@@ -166,7 +193,7 @@ func (s *FileStore) RepackDocs() (converted int, saved int64, err error) {
 				for _, ch := range man.Chunks {
 					live[ch] = true
 				}
-				saved += before - int64(len(mraw))
+				saved += before - int64(len(mraw)) - added
 			}
 		}
 		converted++

--- a/cli/internal/adapters/storage/doc_chunks_test.go
+++ b/cli/internal/adapters/storage/doc_chunks_test.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/wnsdy95/cxthub/cli/internal/adapters/chunkcas"
 	"github.com/wnsdy95/cxthub/cli/internal/domain"
 )
 
@@ -168,6 +170,9 @@ func TestRepackDocsLegacyBlob(t *testing.T) {
 	if sizeAfter >= sizeBefore {
 		t.Fatalf("disk size did not decrease after repacking: %d → %d (saved=%d)", sizeBefore, sizeAfter, saved)
 	}
+	if saved != sizeBefore-sizeAfter {
+		t.Fatalf("reported reclaimed bytes=%d, actual=%d", saved, sizeBefore-sizeAfter)
+	}
 	for _, h := range []domain.ContentHash{h1, h2} {
 		got, gerr := st.GetDoc(ctx, h)
 		if gerr != nil {
@@ -180,6 +185,73 @@ func TestRepackDocsLegacyBlob(t *testing.T) {
 	// idempotence: running again results in 0 conversions.
 	if n2, _, _ := st.RepackDocs(); n2 != 0 {
 		t.Fatalf("repack idempotence violation: second pass converted %d documents", n2)
+	}
+}
+
+func TestRepackDocsUpgradesV1ManifestToV2(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	st := NewFileStore(root)
+	canonical, err := domain.CanonicalBytes(bigDoc(40))
+	if err != nil {
+		t.Fatal(err)
+	}
+	hash := domain.HashContent(canonical)
+	plan, ok := chunkcas.PlanDocV1(canonical)
+	if !ok {
+		t.Fatal("v1 test plan unavailable")
+	}
+	for _, chunkHash := range plan.Order {
+		if err := writeAtomic(st.objectPath("chunks", chunkHash), docCompress(plan.Bodies[chunkHash])); err != nil {
+			t.Fatal(err)
+		}
+	}
+	manifest, _ := json.Marshal(plan.Manifest)
+	if err := writeAtomic(st.objectPath("docs", hash), docCompress(manifest)); err != nil {
+		t.Fatal(err)
+	}
+
+	converted, _, err := st.RepackDocs()
+	if err != nil || converted != 1 {
+		t.Fatalf("v1 repack converted=%d err=%v", converted, err)
+	}
+	raw, err := readCxtFile(st.objectPath("docs", hash))
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, _ = docDecompress(raw)
+	gotManifest, isManifest := chunkcas.ParseManifest(raw)
+	if !isManifest || gotManifest.Format != chunkcas.FormatV2 {
+		t.Fatalf("manifest=%+v isManifest=%v, want v2", gotManifest, isManifest)
+	}
+	got, err := st.GetDoc(ctx, hash)
+	if err != nil || domain.ValidateSessionDocHash(got) != nil {
+		t.Fatalf("post-upgrade roundtrip err=%v", err)
+	}
+}
+
+func TestRepackDocsPreservesMonolithOnChunkCollision(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	st := NewFileStore(root)
+	canonical, _ := domain.CanonicalBytes(bigDoc(40))
+	hash := domain.HashContent(canonical)
+	if err := writeAtomic(st.objectPath("docs", hash), docCompress(canonical)); err != nil {
+		t.Fatal(err)
+	}
+	plan, ok := chunkcas.PlanDoc(canonical)
+	if !ok {
+		t.Fatal("v2 plan unavailable")
+	}
+	if err := writeAtomic(st.objectPath("chunks", plan.Order[0]), docCompress([]byte("wrong body"))); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := st.RepackDocs(); err == nil {
+		t.Fatal("chunk collision was not detected")
+	}
+	got, err := st.GetDoc(ctx, hash)
+	if err != nil || domain.ValidateSessionDocHash(got) != nil {
+		t.Fatalf("source monolith was not preserved: %v", err)
 	}
 }
 

--- a/cli/internal/adapters/storage/file_store.go
+++ b/cli/internal/adapters/storage/file_store.go
@@ -246,7 +246,7 @@ func (s *FileStore) PutDoc(_ context.Context, doc domain.SessionDoc) (domain.Con
 		}
 		return h, nil
 	}
-	chunked, err := s.putDocChunked(h, cb)
+	chunked, _, err := s.putDocChunked(h, cb)
 	if err != nil {
 		return "", err
 	}

--- a/schemas/openapi.yaml
+++ b/schemas/openapi.yaml
@@ -222,6 +222,10 @@ components:
       properties:
         hash:
           $ref: "#/components/schemas/ContentHash"
+        format:
+          type: string
+          enum: [cxt-doc-chunks-v1, cxt-doc-chunks-v2]
+          description: "Manifest assembly format. Omitted legacy wire values mean cxt-doc-chunks-v1."
         envelope:
           type: object
           additionalProperties: true
@@ -1227,6 +1231,12 @@ paths:
                   bounded_chunks_supported:
                     type: boolean
                     description: "If true, chunk bodies are sent to /push/chunks and /pull/chunks paths."
+                  chunk_formats_supported:
+                    type: array
+                    description: "Manifest formats accepted by this server. Absence means a pre-v2 server."
+                    items:
+                      type: string
+                      enum: [cxt-doc-chunks-v1, cxt-doc-chunks-v2]
                   chunk_wants:
                     type: array
                     description: "Chunk hashes the server does not have."
@@ -1410,6 +1420,12 @@ paths:
                   description: "Doc hash to receive instead of a full doc manifest."
                   items:
                     $ref: "#/components/schemas/ContentHash"
+                chunk_formats_supported:
+                  type: array
+                  description: "Manifest formats the requesting client can assemble. Absence means v1 only."
+                  items:
+                    type: string
+                    enum: [cxt-doc-chunks-v1, cxt-doc-chunks-v2]
                 chunk_wants:
                   type: array
                   deprecated: true

--- a/scripts/e2e-sync.sh
+++ b/scripts/e2e-sync.sh
@@ -9,6 +9,7 @@
 #   D. repo2 commits new session C                              → session boundary metadata
 #   E. repo1 runs post-merge                                    → fetch-only, preserving local refs
 #   F. repo1 pushes after both sides moved                      → automatic rebase-graft
+#   K. oversized single event                                  → v2 bounded push/pull + v1 fallback
 #
 # Run with isolated TMP, HOME, and a randomized port; no local state is retained.
 set -u
@@ -57,6 +58,20 @@ session() { # session <cwd> <label> — write a synthetic Claude JSONL session w
 {"type":"user","cwd":"$1","sessionId":"sess-$2","gitBranch":"main","timestamp":"2026-07-05T00:00:00Z","message":{"role":"user","content":"task $2"}}
 {"type":"assistant","cwd":"$1","sessionId":"sess-$2","gitBranch":"main","timestamp":"2026-07-05T00:00:01Z","message":{"role":"assistant","model":"claude-fable-5","content":[{"type":"text","text":"done $2"}],"usage":{"input_tokens":100,"output_tokens":10}}}
 EOF
+}
+
+large_session() { # large_session <cwd> <label> — one event exceeds the v1 2MiB bound.
+  session "$1" "$2"
+  D="$HOME/.claude/projects/$(python3 -c "import re,sys;print(re.sub(r'[^A-Za-z0-9]','-',sys.argv[1]))" "$1")"
+  python3 - "$D/s-$2.jsonl" <<'PY'
+import json,sys
+path=sys.argv[1]
+rows=[json.loads(line) for line in open(path)]
+rows[0]['message']['content']='x' * ((2 << 20) + (32 << 10))
+with open(path,'w') as f:
+    for row in rows:
+        f.write(json.dumps(row,separators=(',',':'))+'\n')
+PY
 }
 
 echo "── A. repo1: Session A push + memorize"
@@ -338,6 +353,29 @@ cxt setup --no-login >"$TMP/setup2.out" 2>&1
 H2=$(shasum "$HOME/.codex/hooks.json" .claude/settings.json | shasum)
 expect "setup idempotence: hook file unchanged" "$H2" "$H1"
 expect "setup idempotence: already registered reported" "$(grep -c 'already registered' "$TMP/setup2.out")" 2
+
+echo "── K. Chunk CAS v2: oversized event push/pull + old-client fallback"
+git clone -q "$TMP/bare.git" "$TMP/repo4"
+cd "$TMP/repo4"; cxt init >/dev/null 2>&1; cxt remote add origin "$REMOTE" >/dev/null 2>&1
+large_session "$TMP/repo4" BIG
+echo big > big.txt; git add big.txt; git commit -qm big-event >/dev/null 2>&1
+git push -q origin main >"$TMP/big-push.out" 2>&1
+BIG_HEAD=$(main_head)
+BIG_MANIFEST=$(ccurl -sb "$J" -X POST "$B/repos/$RID/pull/objects" -H 'Content-Type: application/json' \
+  -d "{\"doc_manifest_wants\":[\"$BIG_HEAD\"],\"chunk_formats_supported\":[\"cxt-doc-chunks-v1\",\"cxt-doc-chunks-v2\"]}" | python3 -c "
+import json,sys
+r=json.load(sys.stdin); m=(r.get('doc_manifests') or [{}])[0]
+print(f\"{m.get('format','')}:{len(m.get('chunks') or [])}\")
+")
+expect "oversized event stored and served as v2" "$(echo "$BIG_MANIFEST" | cut -d: -f1)" cxt-doc-chunks-v2
+expect "oversized event split into bounded chunks" "$([ "$(echo "$BIG_MANIFEST" | cut -d: -f2)" -gt 1 ] && echo yes)" yes
+OLD_FALLBACK=$(ccurl -sb "$J" -X POST "$B/repos/$RID/pull/objects" -H 'Content-Type: application/json' \
+  -d "{\"doc_manifest_wants\":[\"$BIG_HEAD\"]}" | python3 -c "import json,sys;r=json.load(sys.stdin);print(f\"{len(r.get('docs') or [])}:{len(r.get('doc_manifests') or [])}\")")
+expect "client without v2 capability receives full-doc fallback" "$OLD_FALLBACK" 1:0
+git clone -q "$TMP/bare.git" "$TMP/repo5"
+cd "$TMP/repo5"; cxt init >/dev/null 2>&1; cxt remote add origin "$REMOTE" >/dev/null 2>&1
+cxt pull >/dev/null 2>&1
+expect "fresh client pulls and verifies v2 history" "$(cxt fsck | grep -c 'Missing 0')" 1
 
 echo
 if [ "$FAIL" = 0 ]; then echo "SYNC E2E: All passed ✓"; else echo "SYNC E2E: Failures exist ✗"; fi


### PR DESCRIPTION
## Problem

Chunk CAS v1 fell back to monolithic storage whenever one CIR event exceeded the 2 MiB wire bound. Five reachable dogfood snapshots were therefore stored as cumulative 14.6–15.0 MB blobs even though the offending event exceeded the limit by only about 17 KiB.

## Fix

- add cxt-doc-chunks-v2 over fixed 512 KiB slices of the canonical events-array byte stream
- preserve DocHash and Snapshot.ID over the complete canonical CIR
- retain legacy monolith and v1 reads; negotiate v2 explicitly and use full-doc fallback for peers without support
- keep transport and storage on the same v2 chunk identities to avoid dual-format accumulation
- upgrade local and FS-server v1/legacy objects through lossless, collision-checked repack
- migrate shared PostgreSQL blobs atomically while granting chunks to every repo owner
- use a consistent doc-to-chunk lock order and verify rollback on corrupted shared chunks
- document the capability fields in OpenAPI and cover a real oversized hook push/pull in sync E2E

## Evidence

- local data copy: 201 MiB to 138 MiB total, about 66.9 MB reclaimed; docs 72 MiB to 1.2 MiB
- server data copy: about 65.9 MB reclaimed
- second repack is idempotent with 0 conversions; fsck reports Missing 0 and Orphans 0
- backend and CLI full tests, vet, and race pass
- real PostgreSQL migration, multi-repo ownership, concurrent lock, and corruption rollback tests pass
- full sync E2E, public preflight, Terraform, web build, production Docker build and health pass

Closes #56