### PR TITLE
fix(storage): deduplicate cumulative memory objects

### DIFF
--- a/backend/cmd/cxtd/main.go
+++ b/backend/cmd/cxtd/main.go
@@ -1,6 +1,7 @@
 // Command cxtd is the central cxt server binary (module boundary: Go, container).
 //
-// The only subcommand is 'serve' (starts an HTTP REST server). Frontend static assets are not served (CDN/Vercel).
+// 'serve' starts the HTTP REST server; 'repack' performs offline-compatible FS
+// object maintenance. Frontend static assets are not served (CDN/Vercel).
 //
 // Store: Default build uses FSStore (file-based, --data directory). `go build -tags postgres` + CXT_POSTGRES_DSN
 // for PostgreSQL adapter (pgx). store.Open(factory) selects based on build tags.
@@ -41,7 +42,8 @@ func isLoopback(addr string) bool {
 
 func main() {
 	if len(os.Args) >= 2 && os.Args[1] == "repack" {
-		// Maintenance: repack legacy monolithic FS-store documents into chunk CAS (lossless and idempotent).
+		// Maintenance: repack legacy FS-store transcript and memory objects into
+		// their chunk CAS forms (lossless and idempotent).
 		// It is safe alongside a live server because replacement is atomic and newly created chunks receive a sweep grace period.
 		dataDir := flagOr(os.Args[2:], "--data", os.Getenv("CXT_DATA"), "./cxt-data")
 		fs, err := store.OpenFSStore(dataDir)
@@ -49,12 +51,12 @@ func main() {
 			fmt.Fprintln(os.Stderr, "cxtd repack:", err)
 			os.Exit(1)
 		}
-		n, saved, err := fs.RepackDocs()
+		n, saved, err := fs.RepackObjects()
 		if err != nil {
 			fmt.Fprintln(os.Stderr, "cxtd repack:", err)
 			os.Exit(1)
 		}
-		fmt.Printf("repacked %d doc(s), reclaimed %.1f MB\n", n, float64(saved)/1e6)
+		fmt.Printf("repacked %d object(s), reclaimed %.1f MB\n", n, float64(saved)/1e6)
 		return
 	}
 	if len(os.Args) < 2 || os.Args[1] != "serve" {

--- a/backend/internal/adapters/store/fs_store.go
+++ b/backend/internal/adapters/store/fs_store.go
@@ -39,7 +39,9 @@ type Store interface {
 //
 //	dataDir/repos/<repoHex>/repo.json
 //	dataDir/repos/<repoHex>/objects/docs/<docHex>          (SessionDoc.CIR JSON; key = client-provided doc.Hash)
+//	dataDir/repos/<repoHex>/objects/chunks/<chunkHex>      (compressed transcript component)
 //	dataDir/repos/<repoHex>/objects/memories/<hex>         (MemoryDigest JSON)
+//	dataDir/repos/<repoHex>/objects/memory_chunks/<hex>    (compressed memory component)
 //	dataDir/repos/<repoHex>/snapshots/<idHex>              (Snapshot metadata JSON; key = client-provided snap.ID)
 //	dataDir/repos/<repoHex>/refs/heads/<name> · refs/sessions/<name> · refs/tags/<name> · HEAD
 //	dataDir/repos/<repoHex>/memmeta/<snapHex>.json         (MemoryDigest metadata)
@@ -2088,7 +2090,7 @@ func (s *FSStore) PutMemory(_ context.Context, repoID domain.ContentHash, digest
 	if err := validateHash(repoID); err != nil {
 		return "", err
 	}
-	if err := domain.ValidateOptionalContentHash(digest.SnapshotID); err != nil {
+	if err := validateMemoryDigestRefs(digest); err != nil {
 		return "", err
 	}
 	data, err := json.Marshal(digest)
@@ -2105,8 +2107,14 @@ func (s *FSStore) PutMemory(_ context.Context, repoID domain.ContentHash, digest
 			return "", err
 		}
 	} else {
-		if err := writeAtomic(p, data); err != nil {
+		chunked, _, err := s.putMemoryChunked(repoID, h, digest)
+		if err != nil {
 			return "", err
+		}
+		if !chunked {
+			if err := writeAtomic(p, data); err != nil {
+				return "", err
+			}
 		}
 	}
 	return h, nil
@@ -2123,6 +2131,12 @@ func (s *FSStore) GetMemory(_ context.Context, repoID, hash domain.ContentHash) 
 		}
 		return domain.MemoryDigest{}, err
 	}
+	if chunked, isManifest, chunkErr := s.getMemoryChunked(repoID, hash, data); isManifest {
+		if chunkErr != nil {
+			return domain.MemoryDigest{}, chunkErr
+		}
+		return chunked, nil
+	}
 	var d domain.MemoryDigest
 	if err := json.Unmarshal(data, &d); err != nil {
 		return domain.MemoryDigest{}, err
@@ -2134,7 +2148,7 @@ func (s *FSStore) GetMemory(_ context.Context, repoID, hash domain.ContentHash) 
 	if got != hash {
 		return domain.MemoryDigest{}, domain.ErrIntegrity
 	}
-	if err := domain.ValidateOptionalContentHash(d.SnapshotID); err != nil {
+	if err := validateMemoryDigestRefs(d); err != nil {
 		return domain.MemoryDigest{}, err
 	}
 	return d, nil

--- a/backend/internal/adapters/store/memory_chunks.go
+++ b/backend/internal/adapters/store/memory_chunks.go
@@ -1,0 +1,297 @@
+package store
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/wnsdy95/cxthub/backend/internal/domain"
+)
+
+func validateMemoryDigestRefs(digest domain.MemoryDigest) error {
+	if err := domain.ValidateOptionalContentHash(digest.SnapshotID); err != nil {
+		return err
+	}
+	for _, fragment := range digest.Fragments {
+		if err := validateHash(fragment.SourceSnapshot); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *FSStore) memoryChunkPath(repoID, hash domain.ContentHash) string {
+	return filepath.Join(s.repoDir(repoID), "objects", "memory_chunks", hexOf(hash))
+}
+
+func (s *FSStore) putMemoryChunked(repoID, hash domain.ContentHash, digest domain.MemoryDigest) (bool, int64, error) {
+	plan, ok, err := domain.PlanMemoryChunks(digest)
+	if err != nil || !ok {
+		return false, 0, err
+	}
+	var added int64
+	for _, chunkHash := range plan.Order {
+		path := s.memoryChunkPath(repoID, chunkHash)
+		body := plan.Bodies[chunkHash]
+		if exists(path) {
+			raw, err := os.ReadFile(path)
+			if err != nil {
+				return false, added, err
+			}
+			existing, err := docDecompress(raw)
+			if err != nil || !bytes.Equal(existing, body) {
+				return false, added, domain.ErrIntegrity
+			}
+			continue
+		}
+		compressed := docCompress(body)
+		if err := writeAtomic(path, compressed); err != nil {
+			return false, added, err
+		}
+		added += int64(len(compressed))
+	}
+	manifest, err := json.Marshal(plan.Manifest)
+	if err != nil {
+		return false, added, err
+	}
+	if err := writeAtomic(s.memPath(repoID, hash), manifest); err != nil {
+		return false, added, err
+	}
+	return true, added, nil
+}
+
+func (s *FSStore) getMemoryChunked(repoID, hash domain.ContentHash, data []byte) (domain.MemoryDigest, bool, error) {
+	manifest, isManifest, err := domain.ParseMemoryChunkManifest(data)
+	if !isManifest {
+		return domain.MemoryDigest{}, false, nil
+	}
+	if err != nil {
+		return domain.MemoryDigest{}, true, err
+	}
+	bodies := make(map[domain.ContentHash][]byte, len(manifest.SummaryChunks)+len(manifest.FragmentChunks))
+	all := append(append([]domain.ContentHash{}, manifest.SummaryChunks...), manifest.FragmentChunks...)
+	for _, chunkHash := range all {
+		if _, loaded := bodies[chunkHash]; loaded {
+			continue
+		}
+		if err := validateHash(chunkHash); err != nil {
+			return domain.MemoryDigest{}, true, err
+		}
+		raw, err := os.ReadFile(s.memoryChunkPath(repoID, chunkHash))
+		if err != nil {
+			if os.IsNotExist(err) {
+				return domain.MemoryDigest{}, true, fmt.Errorf("%w: memory %s missing component %s", domain.ErrIntegrity, hash, chunkHash)
+			}
+			return domain.MemoryDigest{}, true, err
+		}
+		body, err := docDecompress(raw)
+		if err != nil {
+			return domain.MemoryDigest{}, true, domain.ErrIntegrity
+		}
+		bodies[chunkHash] = body
+	}
+	digest, err := domain.AssembleMemoryChunks(manifest, bodies)
+	if err != nil {
+		return domain.MemoryDigest{}, true, err
+	}
+	if err := validateMemoryDigestRefs(digest); err != nil {
+		return domain.MemoryDigest{}, true, err
+	}
+	got, err := domain.MemoryDigestHash(digest)
+	if err != nil || got != hash {
+		return domain.MemoryDigest{}, true, domain.ErrIntegrity
+	}
+	return digest, true, nil
+}
+
+// RepackMemories upgrades every FS repo's large legacy memory object and
+// removes the obsolete full memmeta copy only when an authoritative snapshot
+// pointer and a valid blob prove the data remains reachable.
+func (s *FSStore) RepackMemories() (converted int, saved int64, err error) {
+	reposDir := filepath.Join(s.dataDir, "repos")
+	repos, err := os.ReadDir(reposDir)
+	if os.IsNotExist(err) {
+		return 0, 0, nil
+	}
+	if err != nil {
+		return 0, 0, err
+	}
+	for _, repoEntry := range repos {
+		if !repoEntry.IsDir() {
+			continue
+		}
+		repoID, ok := hashFromObjectName(repoEntry.Name())
+		if !ok {
+			continue
+		}
+		count, reclaimed, repackErr := s.repackMemoryRepo(repoID)
+		converted += count
+		saved += reclaimed
+		if repackErr != nil {
+			return converted, saved, repackErr
+		}
+	}
+	return converted, saved, nil
+}
+
+func (s *FSStore) repackMemoryRepo(repoID domain.ContentHash) (converted int, saved int64, err error) {
+	memoriesDir := filepath.Join(s.repoDir(repoID), "objects", "memories")
+	entries, readDirErr := os.ReadDir(memoriesDir)
+	if readDirErr != nil && !os.IsNotExist(readDirErr) {
+		return 0, 0, readDirErr
+	}
+	live := map[domain.ContentHash]bool{}
+	sweepSafe := true
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		hash, ok := hashFromObjectName(entry.Name())
+		if !ok {
+			continue
+		}
+		path := filepath.Join(memoriesDir, entry.Name())
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			continue
+		}
+		if _, isManifest, manifestErr := s.getMemoryChunked(repoID, hash, data); isManifest {
+			var manifest domain.MemoryChunkManifest
+			if json.Unmarshal(data, &manifest) == nil {
+				for _, chunkHash := range append(manifest.SummaryChunks, manifest.FragmentChunks...) {
+					live[chunkHash] = true
+				}
+				if manifest.Format != domain.MemoryChunkFormatV1 {
+					sweepSafe = false
+				}
+			} else {
+				sweepSafe = false
+			}
+			if manifestErr != nil {
+				continue
+			}
+			continue
+		}
+		var digest domain.MemoryDigest
+		if json.Unmarshal(data, &digest) != nil {
+			continue
+		}
+		got, hashErr := domain.MemoryDigestHash(digest)
+		if hashErr != nil || got != hash {
+			continue
+		}
+		before := int64(len(data))
+		chunked, added, putErr := s.putMemoryChunked(repoID, hash, digest)
+		if putErr != nil {
+			return converted, saved, putErr
+		}
+		if !chunked {
+			continue
+		}
+		manifestData, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return converted, saved, readErr
+		}
+		manifest, isManifest, parseErr := domain.ParseMemoryChunkManifest(manifestData)
+		if parseErr != nil || !isManifest {
+			return converted, saved, domain.ErrIntegrity
+		}
+		for _, chunkHash := range append(manifest.SummaryChunks, manifest.FragmentChunks...) {
+			live[chunkHash] = true
+		}
+		saved += before - int64(len(manifestData)) - added
+		converted++
+	}
+
+	if !sweepSafe {
+		metaSaved, cleanupErr := s.cleanupRedundantMemoryMeta(context.Background(), repoID)
+		return converted, saved + metaSaved, cleanupErr
+	}
+	chunksDir := filepath.Join(s.repoDir(repoID), "objects", "memory_chunks")
+	chunkEntries, chunkErr := os.ReadDir(chunksDir)
+	if chunkErr != nil && !os.IsNotExist(chunkErr) {
+		return converted, saved, chunkErr
+	}
+	for _, entry := range chunkEntries {
+		if entry.IsDir() {
+			continue
+		}
+		chunkHash, ok := hashFromObjectName(entry.Name())
+		if !ok || live[chunkHash] {
+			continue
+		}
+		info, infoErr := entry.Info()
+		if infoErr != nil || time.Since(info.ModTime()) < 10*time.Minute {
+			continue
+		}
+		saved += info.Size()
+		_ = os.Remove(filepath.Join(chunksDir, entry.Name()))
+	}
+
+	metaSaved, cleanupErr := s.cleanupRedundantMemoryMeta(context.Background(), repoID)
+	saved += metaSaved
+	if cleanupErr != nil {
+		return converted, saved, cleanupErr
+	}
+	return converted, saved, nil
+}
+
+func (s *FSStore) cleanupRedundantMemoryMeta(ctx context.Context, repoID domain.ContentHash) (int64, error) {
+	dir := filepath.Join(s.repoDir(repoID), "memmeta")
+	entries, err := os.ReadDir(dir)
+	if os.IsNotExist(err) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, err
+	}
+	var saved int64
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+		snapshotID, ok := hashFromObjectName(strings.TrimSuffix(entry.Name(), ".json"))
+		if !ok {
+			continue
+		}
+		meta, err := s.GetMemoryMeta(ctx, repoID, snapshotID)
+		if err != nil {
+			continue
+		}
+		memoryHash, err := domain.MemoryDigestHash(meta)
+		if err != nil {
+			continue
+		}
+		snapshot, err := s.GetSnapshot(ctx, repoID, snapshotID)
+		if err != nil || snapshot.MemoryHash != memoryHash {
+			continue
+		}
+		stored, err := s.GetMemory(ctx, repoID, memoryHash)
+		if err != nil || stored.SnapshotID != snapshotID {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+		if err := os.Remove(filepath.Join(dir, entry.Name())); err != nil {
+			return saved, err
+		}
+		saved += info.Size()
+	}
+	return saved, nil
+}
+
+func (s *FSStore) RepackObjects() (converted int, saved int64, err error) {
+	docs, docSaved, err := s.RepackDocs()
+	if err != nil {
+		return docs, docSaved, err
+	}
+	memories, memorySaved, err := s.RepackMemories()
+	return docs + memories, docSaved + memorySaved, err
+}

--- a/backend/internal/adapters/store/memory_chunks_test.go
+++ b/backend/internal/adapters/store/memory_chunks_test.go
@@ -1,0 +1,175 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/wnsdy95/cxthub/backend/internal/domain"
+)
+
+func largeServerMemory(label string, extra int) domain.MemoryDigest {
+	return domain.MemoryDigest{
+		SnapshotID: domain.HashContent([]byte("snapshot-" + label)),
+		Summary:    strings.Repeat("shared-memory-prefix-", 12<<10) + strings.Repeat(label, extra),
+		KeyFacts:   []string{"memory identity is immutable"},
+		OpenTasks:  []string{},
+		Provider:   domain.ProviderCodex,
+		Fragments: []domain.MemoryFragment{{
+			SourceSnapshot: domain.HashContent([]byte("source-" + label)),
+			Summary:        strings.Repeat("fragment-", 10<<10),
+		}},
+	}
+}
+
+func serverTreeSize(t *testing.T, dir string) int64 {
+	t.Helper()
+	var total int64
+	if err := filepath.Walk(dir, func(_ string, info os.FileInfo, err error) error {
+		if err == nil && !info.IsDir() {
+			total += info.Size()
+		}
+		return nil
+	}); err != nil && !os.IsNotExist(err) {
+		t.Fatal(err)
+	}
+	return total
+}
+
+func TestFSMemoryChunkRoundtripPrefixDedupAndCorruption(t *testing.T) {
+	ctx := context.Background()
+	st := NewFSStore(t.TempDir())
+	repo := rlHash('3')
+	first := largeServerMemory("first", 8<<10)
+	hash, err := st.PutMemory(ctx, repo, first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := st.GetMemory(ctx, repo, hash)
+	if err != nil {
+		t.Fatalf("GetMemory(chunked): %v", err)
+	}
+	gotHash, _ := domain.MemoryDigestHash(got)
+	if gotHash != hash {
+		t.Fatalf("roundtrip identity changed: %s != %s", gotHash, hash)
+	}
+
+	second := first
+	second.SnapshotID = domain.HashContent([]byte("snapshot-second"))
+	second.Summary += strings.Repeat("tail", 40<<10)
+	if _, err := st.PutMemory(ctx, repo, second); err != nil {
+		t.Fatal(err)
+	}
+	chunkDir := filepath.Join(st.repoDir(repo), "objects", "memory_chunks")
+	entries, err := os.ReadDir(chunkDir)
+	if err != nil || len(entries) < 2 {
+		t.Fatalf("component chunks=%d err=%v", len(entries), err)
+	}
+	raw, err := os.ReadFile(st.memPath(repo, hash))
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest, isManifest, err := domain.ParseMemoryChunkManifest(raw)
+	if err != nil || !isManifest || len(manifest.SummaryChunks) == 0 {
+		t.Fatalf("stored memory is not a manifest: %+v is=%v err=%v", manifest, isManifest, err)
+	}
+	if err := os.WriteFile(st.memoryChunkPath(repo, manifest.SummaryChunks[0]), docCompress([]byte("corrupt")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.GetMemory(ctx, repo, hash); !errors.Is(err, domain.ErrIntegrity) {
+		t.Fatalf("corrupt component was not rejected: %v", err)
+	}
+}
+
+func TestFSMemoryChunkReadValidatesInlineHashReferences(t *testing.T) {
+	ctx := context.Background()
+	st := NewFSStore(t.TempDir())
+	repo := rlHash('5')
+	digest := largeServerMemory("invalid-reference", 8<<10)
+	digest.SnapshotID = domain.ContentHash("invalid")
+	plan, ok, err := domain.PlanMemoryChunks(digest)
+	if err != nil || !ok {
+		t.Fatalf("PlanMemoryChunks: ok=%v err=%v", ok, err)
+	}
+	for hash, body := range plan.Bodies {
+		if err := writeAtomic(st.memoryChunkPath(repo, hash), docCompress(body)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	hash, _ := domain.MemoryDigestHash(digest)
+	manifest, _ := json.Marshal(plan.Manifest)
+	if err := writeAtomic(st.memPath(repo, hash), manifest); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.GetMemory(ctx, repo, hash); err == nil {
+		t.Fatal("chunked memory accepted an invalid snapshot reference")
+	}
+}
+
+func TestFSRepackMemoriesRemovesOnlyPointerBackedMeta(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	st := NewFSStore(root)
+	repo := rlHash('4')
+	digests := []domain.MemoryDigest{largeServerMemory("legacy-a", 16<<10), largeServerMemory("legacy-b", 32<<10)}
+	var hashes []domain.ContentHash
+	for _, digest := range digests {
+		if err := st.PutSnapshot(ctx, domain.Snapshot{ID: digest.SnapshotID, RepoID: repo, DocHash: digest.SnapshotID}); err != nil {
+			t.Fatal(err)
+		}
+		data, err := json.Marshal(digest)
+		if err != nil {
+			t.Fatal(err)
+		}
+		hash, _ := domain.MemoryDigestHash(digest)
+		if err := writeAtomic(st.memPath(repo, hash), data); err != nil {
+			t.Fatal(err)
+		}
+		if err := st.PutMemoryMeta(ctx, repo, digest); err != nil {
+			t.Fatal(err)
+		}
+		if err := st.SetSnapshotMemory(ctx, repo, digest.SnapshotID, hash); err != nil {
+			t.Fatal(err)
+		}
+		hashes = append(hashes, hash)
+	}
+	legacyOnly := domain.MemoryDigest{SnapshotID: domain.HashContent([]byte("pointerless")), Summary: "legacy only", Provider: domain.ProviderClaude}
+	if err := st.PutSnapshot(ctx, domain.Snapshot{ID: legacyOnly.SnapshotID, RepoID: repo, DocHash: legacyOnly.SnapshotID}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.PutMemoryMeta(ctx, repo, legacyOnly); err != nil {
+		t.Fatal(err)
+	}
+
+	before := serverTreeSize(t, st.repoDir(repo))
+	converted, saved, err := st.RepackMemories()
+	if err != nil {
+		t.Fatalf("RepackMemories: %v", err)
+	}
+	if converted != len(digests) {
+		t.Fatalf("converted=%d want %d", converted, len(digests))
+	}
+	after := serverTreeSize(t, st.repoDir(repo))
+	if after >= before || saved != before-after {
+		t.Fatalf("repack accounting before=%d after=%d saved=%d", before, after, saved)
+	}
+	for i, digest := range digests {
+		if _, err := st.GetMemoryMeta(ctx, repo, digest.SnapshotID); !errors.Is(err, domain.ErrNotFound) {
+			t.Fatalf("redundant memmeta %d was retained: %v", i, err)
+		}
+		got, err := st.GetMemory(ctx, repo, hashes[i])
+		if err != nil || got.Summary != digest.Summary {
+			t.Fatalf("repacked memory %d: err=%v", i, err)
+		}
+	}
+	if got, err := st.GetMemoryMeta(ctx, repo, legacyOnly.SnapshotID); err != nil || got.Summary != legacyOnly.Summary {
+		t.Fatalf("pointerless legacy metadata was removed: %+v err=%v", got, err)
+	}
+	if converted, _, err := st.RepackMemories(); err != nil || converted != 0 {
+		t.Fatalf("second repack converted=%d err=%v", converted, err)
+	}
+}

--- a/backend/internal/adapters/store/postgres_smoke_test.go
+++ b/backend/internal/adapters/store/postgres_smoke_test.go
@@ -151,6 +151,114 @@ func TestPGSmoke(t *testing.T) {
 		t.Fatalf("repo2 snapshot: repo=%s err=%v", got.RepoID, err)
 	}
 
+	// Large legacy memory migration keeps MemoryDigestHash stable while replacing
+	// the global raw JSON with a component manifest. Every existing memory owner
+	// must receive all memory_chunk grants before the shared representation flips.
+	legacyMemory := domain.MemoryDigest{
+		SnapshotID: snapID,
+		Summary:    strings.Repeat("shared-memory-prefix-", 12<<10),
+		KeyFacts:   []string{"identity remains the complete digest hash"},
+		OpenTasks:  []string{},
+		Provider:   domain.ProviderCodex,
+		Fragments: []domain.MemoryFragment{{
+			SourceSnapshot: snapID,
+			Summary:        strings.Repeat("memory-fragment-", 8<<10),
+		}},
+	}
+	legacyMemoryHash, _ := domain.MemoryDigestHash(legacyMemory)
+	legacyMemoryJSON, _ := json.Marshal(legacyMemory)
+	if _, err := st.pool.Exec(ctx, `INSERT INTO blobs (hash,bytes) VALUES ($1,$2)`, string(legacyMemoryHash), legacyMemoryJSON); err != nil {
+		t.Fatalf("legacy memory blob fixture: %v", err)
+	}
+	if _, err := st.pool.Exec(ctx, `INSERT INTO repo_blobs (repo_id,kind,hash) VALUES ($1,'memory',$2)`, string(repoID), string(legacyMemoryHash)); err != nil {
+		t.Fatalf("legacy memory owner fixture: %v", err)
+	}
+	if gotHash, err := st.PutMemory(ctx, repo2, legacyMemory); err != nil || gotHash != legacyMemoryHash {
+		t.Fatalf("memory component migration: hash=%s err=%v", gotHash, err)
+	}
+	var storedMemory []byte
+	if err := st.pool.QueryRow(ctx, `SELECT bytes FROM blobs WHERE hash=$1`, string(legacyMemoryHash)).Scan(&storedMemory); err != nil {
+		t.Fatalf("read migrated memory manifest: %v", err)
+	}
+	storedMemory, err = docDecompress(storedMemory)
+	if err != nil {
+		t.Fatalf("decode migrated memory manifest: %v", err)
+	}
+	memoryManifest, isMemoryManifest, err := domain.ParseMemoryChunkManifest(storedMemory)
+	if err != nil || !isMemoryManifest || memoryManifest.Format != domain.MemoryChunkFormatV1 {
+		t.Fatalf("memory manifest=%+v is=%v err=%v", memoryManifest, isMemoryManifest, err)
+	}
+	allMemoryChunks := append(append([]domain.ContentHash{}, memoryManifest.SummaryChunks...), memoryManifest.FragmentChunks...)
+	for _, owner := range []domain.ContentHash{repoID, repo2} {
+		got, err := st.GetMemory(ctx, owner, legacyMemoryHash)
+		if err != nil || got.Summary != legacyMemory.Summary {
+			t.Fatalf("memory owner %s lost migrated body: %v", owner, err)
+		}
+		for _, chunkHash := range allMemoryChunks {
+			var count int
+			if err := st.pool.QueryRow(ctx,
+				`SELECT count(*) FROM repo_blobs WHERE repo_id=$1 AND kind='memory_chunk' AND hash=$2`,
+				string(owner), string(chunkHash)).Scan(&count); err != nil || count != 1 {
+				t.Fatalf("memory owner %s lacks component %s: count=%d err=%v", owner, chunkHash, count, err)
+			}
+		}
+	}
+
+	// Concurrent writers lock the top-level memory before components. Both a
+	// legacy migrator and a deduplicating owner must finish without deadlock.
+	raceMemory := legacyMemory
+	raceMemory.Summary = strings.Repeat("memory-lock-order-", 10<<10)
+	raceMemoryHash, _ := domain.MemoryDigestHash(raceMemory)
+	raceMemoryJSON, _ := json.Marshal(raceMemory)
+	if _, err := st.pool.Exec(ctx, `INSERT INTO blobs (hash,bytes) VALUES ($1,$2)`, string(raceMemoryHash), raceMemoryJSON); err != nil {
+		t.Fatalf("memory lock-order blob fixture: %v", err)
+	}
+	if _, err := st.pool.Exec(ctx, `INSERT INTO repo_blobs (repo_id,kind,hash) VALUES ($1,'memory',$2)`, string(repoID), string(raceMemoryHash)); err != nil {
+		t.Fatalf("memory lock-order owner fixture: %v", err)
+	}
+	memoryRaceCtx, cancelMemoryRace := context.WithTimeout(ctx, 10*time.Second)
+	defer cancelMemoryRace()
+	startMemoryRace := make(chan struct{})
+	memoryRaceErrs := make(chan error, 2)
+	for _, owner := range []domain.ContentHash{repoID, repo2} {
+		owner := owner
+		go func() {
+			<-startMemoryRace
+			_, err := st.PutMemory(memoryRaceCtx, owner, raceMemory)
+			memoryRaceErrs <- err
+		}()
+	}
+	close(startMemoryRace)
+	for i := 0; i < 2; i++ {
+		if err := <-memoryRaceErrs; err != nil {
+			t.Fatalf("concurrent memory/component lock ordering: %v", err)
+		}
+	}
+
+	// A corrupt globally deduplicated memory component aborts the complete
+	// transaction, including the newly inserted top-level memory object.
+	corruptMemory := domain.MemoryDigest{
+		SnapshotID: snapID,
+		Summary:    strings.Repeat("corrupt-memory-component-", 8<<10),
+		Provider:   domain.ProviderClaude,
+	}
+	corruptMemoryHash, _ := domain.MemoryDigestHash(corruptMemory)
+	corruptMemoryPlan, ok, err := domain.PlanMemoryChunks(corruptMemory)
+	if err != nil || !ok {
+		t.Fatalf("corrupt memory plan: ok=%v err=%v", ok, err)
+	}
+	badMemoryChunk := corruptMemoryPlan.Order[0]
+	if _, err := st.pool.Exec(ctx, `INSERT INTO blobs (hash,bytes) VALUES ($1,$2)`, string(badMemoryChunk), docCompress([]byte("corrupt memory body"))); err != nil {
+		t.Fatalf("corrupt memory component fixture: %v", err)
+	}
+	if _, err := st.PutMemory(ctx, repoID, corruptMemory); !errors.Is(err, domain.ErrIntegrity) {
+		t.Fatalf("corrupt component PutMemory err=%v, want ErrIntegrity", err)
+	}
+	var failedMemoryCount int
+	if err := st.pool.QueryRow(ctx, `SELECT count(*) FROM blobs WHERE hash=$1`, string(corruptMemoryHash)).Scan(&failedMemoryCount); err != nil || failedMemoryCount != 0 {
+		t.Fatalf("failed PutMemory left top-level blob: count=%d err=%v", failedMemoryCount, err)
+	}
+
 	// Rolling v1→v2 dedup: a v2 writer must migrate the global manifest and grant
 	// every old/new doc owner the v2 chunks instead of retaining two representations.
 	v1CIR := domain.CIRDocument{

--- a/backend/internal/adapters/store/postgres_store.go
+++ b/backend/internal/adapters/store/postgres_store.go
@@ -1174,7 +1174,7 @@ func (s *PostgresStore) PutMemory(ctx context.Context, repoID domain.ContentHash
 	if err := validateHash(repoID); err != nil {
 		return "", err
 	}
-	if err := domain.ValidateOptionalContentHash(digest.SnapshotID); err != nil {
+	if err := validateMemoryDigestRefs(digest); err != nil {
 		return "", err
 	}
 	data, err := json.Marshal(digest)
@@ -1190,15 +1190,110 @@ func (s *PostgresStore) PutMemory(ctx context.Context, repoID domain.ContentHash
 		return "", err
 	}
 	defer tx.Rollback(ctx)
-	if _, err := tx.Exec(ctx, `INSERT INTO blobs (hash, bytes) VALUES ($1,$2) ON CONFLICT (hash) DO NOTHING`, string(h), data); err != nil {
+	// Lock order is memory object → memory components. A newly inserted manifest
+	// is invisible until every component and ownership grant commits with it.
+	plan, chunked, err := domain.PlanMemoryChunks(digest)
+	if err != nil {
 		return "", err
 	}
+	payload := data
+	if chunked {
+		payload, err = json.Marshal(plan.Manifest)
+		if err != nil {
+			return "", err
+		}
+	}
+	createdTag, err := tx.Exec(ctx, `INSERT INTO blobs (hash, bytes) VALUES ($1,$2) ON CONFLICT (hash) DO NOTHING`, string(h), payload)
+	if err != nil {
+		return "", err
+	}
+	created := createdTag.RowsAffected() > 0
 	var stored []byte
-	if err := tx.QueryRow(ctx, `SELECT bytes FROM blobs WHERE hash=$1`, string(h)).Scan(&stored); err != nil {
+	if err := tx.QueryRow(ctx, `SELECT bytes FROM blobs WHERE hash=$1 FOR UPDATE`, string(h)).Scan(&stored); err != nil {
 		return "", err
 	}
-	if !bytes.Equal(stored, data) {
-		return "", fmt.Errorf("%w: stored blob disagrees with memory hash %s", domain.ErrIntegrity, h)
+	stored, err = docDecompress(stored)
+	if err != nil {
+		return "", fmt.Errorf("%w: stored blob undecodable for memory %s", domain.ErrIntegrity, h)
+	}
+	storedManifest, isManifest, parseErr := domain.ParseMemoryChunkManifest(stored)
+	if parseErr != nil {
+		return "", fmt.Errorf("%w: invalid memory manifest %s", domain.ErrIntegrity, h)
+	}
+	if !created {
+		var existing domain.MemoryDigest
+		if isManifest {
+			existing, _, err = s.reassembleMemoryManifestTx(ctx, tx, stored)
+		} else {
+			err = json.Unmarshal(stored, &existing)
+		}
+		if err != nil {
+			return "", fmt.Errorf("%w: stored blob disagrees with memory hash %s", domain.ErrIntegrity, h)
+		}
+		got, hashErr := domain.MemoryDigestHash(existing)
+		if hashErr != nil || got != h {
+			return "", fmt.Errorf("%w: stored blob disagrees with memory hash %s", domain.ErrIntegrity, h)
+		}
+	}
+	if chunked {
+		for _, chunkHash := range plan.Order {
+			body := plan.Bodies[chunkHash]
+			if _, err := tx.Exec(ctx, `INSERT INTO blobs (hash, bytes) VALUES ($1,$2) ON CONFLICT (hash) DO NOTHING`,
+				string(chunkHash), docCompress(body)); err != nil {
+				return "", err
+			}
+			var existing []byte
+			if err := tx.QueryRow(ctx, `SELECT bytes FROM blobs WHERE hash=$1`, string(chunkHash)).Scan(&existing); err != nil {
+				return "", err
+			}
+			existing, err = docDecompress(existing)
+			if err != nil || !bytes.Equal(existing, body) {
+				return "", domain.ErrIntegrity
+			}
+			if _, err := tx.Exec(ctx,
+				`INSERT INTO repo_blobs (repo_id, kind, hash) VALUES ($1,'memory_chunk',$2) ON CONFLICT DO NOTHING`,
+				string(repoID), string(chunkHash)); err != nil {
+				return "", err
+			}
+		}
+	}
+	if !created && chunked && !isManifest {
+		// The blob is global but readability is repo-scoped. Before replacing a
+		// shared legacy memory with its manifest, grant every current memory owner
+		// every component so rolling multi-repo dedup cannot revoke access.
+		for _, chunkHash := range plan.Order {
+			if _, err := tx.Exec(ctx,
+				`INSERT INTO repo_blobs (repo_id, kind, hash)
+				 SELECT repo_id, 'memory_chunk', $2 FROM repo_blobs WHERE kind='memory' AND hash=$1
+				 ON CONFLICT DO NOTHING`, string(h), string(chunkHash)); err != nil {
+				return "", err
+			}
+		}
+		manifest, err := json.Marshal(plan.Manifest)
+		if err != nil {
+			return "", err
+		}
+		if _, err := tx.Exec(ctx, `UPDATE blobs SET bytes=$1 WHERE hash=$2`, manifest, string(h)); err != nil {
+			return "", err
+		}
+	} else if isManifest {
+		// A repo deduplicating against an already-manifested global memory must
+		// own the components referenced by the stored representation. Re-grant
+		// every current owner too, healing any interrupted/older migration.
+		all := append(append([]domain.ContentHash{}, storedManifest.SummaryChunks...), storedManifest.FragmentChunks...)
+		for _, chunkHash := range all {
+			if _, err := tx.Exec(ctx,
+				`INSERT INTO repo_blobs (repo_id, kind, hash) VALUES ($1,'memory_chunk',$2) ON CONFLICT DO NOTHING`,
+				string(repoID), string(chunkHash)); err != nil {
+				return "", err
+			}
+			if _, err := tx.Exec(ctx,
+				`INSERT INTO repo_blobs (repo_id, kind, hash)
+				 SELECT repo_id, 'memory_chunk', $2 FROM repo_blobs WHERE kind='memory' AND hash=$1
+				 ON CONFLICT DO NOTHING`, string(h), string(chunkHash)); err != nil {
+				return "", err
+			}
+		}
 	}
 	if _, err := tx.Exec(ctx,
 		`INSERT INTO repo_blobs (repo_id, kind, hash) VALUES ($1,'memory',$2) ON CONFLICT DO NOTHING`,
@@ -1209,6 +1304,31 @@ func (s *PostgresStore) PutMemory(ctx context.Context, repoID domain.ContentHash
 		return "", err
 	}
 	return h, nil
+}
+
+func (s *PostgresStore) reassembleMemoryManifestTx(ctx context.Context, tx pgx.Tx, data []byte) (domain.MemoryDigest, bool, error) {
+	manifest, isManifest, err := domain.ParseMemoryChunkManifest(data)
+	if !isManifest || err != nil {
+		return domain.MemoryDigest{}, isManifest, err
+	}
+	bodies := make(map[domain.ContentHash][]byte, len(manifest.SummaryChunks)+len(manifest.FragmentChunks))
+	all := append(append([]domain.ContentHash{}, manifest.SummaryChunks...), manifest.FragmentChunks...)
+	for _, chunkHash := range all {
+		if _, loaded := bodies[chunkHash]; loaded {
+			continue
+		}
+		var raw []byte
+		if err := tx.QueryRow(ctx, `SELECT bytes FROM blobs WHERE hash=$1`, string(chunkHash)).Scan(&raw); err != nil {
+			return domain.MemoryDigest{}, true, err
+		}
+		body, err := docDecompress(raw)
+		if err != nil {
+			return domain.MemoryDigest{}, true, err
+		}
+		bodies[chunkHash] = body
+	}
+	digest, err := domain.AssembleMemoryChunks(manifest, bodies)
+	return digest, true, err
 }
 
 func (s *PostgresStore) GetMemory(ctx context.Context, repoID, hash domain.ContentHash) (domain.MemoryDigest, error) {
@@ -1222,6 +1342,49 @@ func (s *PostgresStore) GetMemory(ctx context.Context, repoID, hash domain.Conte
 		string(repoID), string(hash)).Scan(&b); err != nil {
 		return domain.MemoryDigest{}, mapNoRows(err)
 	}
+	b, err := docDecompress(b)
+	if err != nil {
+		return domain.MemoryDigest{}, domain.ErrIntegrity
+	}
+	if manifest, isManifest, parseErr := domain.ParseMemoryChunkManifest(b); isManifest {
+		if parseErr != nil {
+			return domain.MemoryDigest{}, domain.ErrIntegrity
+		}
+		bodies := make(map[domain.ContentHash][]byte, len(manifest.SummaryChunks)+len(manifest.FragmentChunks))
+		all := append(append([]domain.ContentHash{}, manifest.SummaryChunks...), manifest.FragmentChunks...)
+		for _, chunkHash := range all {
+			if _, loaded := bodies[chunkHash]; loaded {
+				continue
+			}
+			var raw []byte
+			if err := s.pool.QueryRow(ctx,
+				`SELECT b.bytes FROM repo_blobs rb JOIN blobs b ON b.hash=rb.hash
+				 WHERE rb.repo_id=$1 AND rb.kind='memory_chunk' AND rb.hash=$2`,
+				string(repoID), string(chunkHash)).Scan(&raw); err != nil {
+				if errors.Is(err, pgx.ErrNoRows) {
+					return domain.MemoryDigest{}, fmt.Errorf("%w: memory %s missing component %s", domain.ErrIntegrity, hash, chunkHash)
+				}
+				return domain.MemoryDigest{}, err
+			}
+			body, err := docDecompress(raw)
+			if err != nil {
+				return domain.MemoryDigest{}, domain.ErrIntegrity
+			}
+			bodies[chunkHash] = body
+		}
+		digest, err := domain.AssembleMemoryChunks(manifest, bodies)
+		if err != nil {
+			return domain.MemoryDigest{}, err
+		}
+		if err := validateMemoryDigestRefs(digest); err != nil {
+			return domain.MemoryDigest{}, err
+		}
+		got, err := domain.MemoryDigestHash(digest)
+		if err != nil || got != hash {
+			return domain.MemoryDigest{}, fmt.Errorf("%w: memory hash mismatch: got %s want %s", domain.ErrIntegrity, got, hash)
+		}
+		return digest, nil
+	}
 	var d domain.MemoryDigest
 	if err := json.Unmarshal(b, &d); err != nil {
 		return domain.MemoryDigest{}, err
@@ -1232,6 +1395,9 @@ func (s *PostgresStore) GetMemory(ctx context.Context, repoID, hash domain.Conte
 	}
 	if got != hash {
 		return domain.MemoryDigest{}, fmt.Errorf("%w: memory hash mismatch: got %s want %s", domain.ErrIntegrity, got, hash)
+	}
+	if err := validateMemoryDigestRefs(d); err != nil {
+		return domain.MemoryDigest{}, err
 	}
 	return d, nil
 }

--- a/backend/internal/app/memory_storage_test.go
+++ b/backend/internal/app/memory_storage_test.go
@@ -1,0 +1,84 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/wnsdy95/cxthub/backend/internal/adapters/auth"
+	"github.com/wnsdy95/cxthub/backend/internal/adapters/gitengine"
+	"github.com/wnsdy95/cxthub/backend/internal/adapters/store"
+	"github.com/wnsdy95/cxthub/backend/internal/domain"
+)
+
+func TestMemoryDigestUsesSnapshotPointerWithoutMetaDoubleWrite(t *testing.T) {
+	svc, st := newFsckSvc(t)
+	ctx := context.Background()
+	repo := hh("memory-pointer-repo")
+	snapshotID := hh("memory-pointer-snapshot")
+	if err := st.PutSnapshot(ctx, domain.Snapshot{ID: snapshotID, RepoID: repo, DocHash: snapshotID}); err != nil {
+		t.Fatal(err)
+	}
+	digest := domain.MemoryDigest{
+		SnapshotID: snapshotID,
+		Summary:    "authoritative blob",
+		KeyFacts:   []string{"snapshot.memory_hash resolves the body"},
+		OpenTasks:  []string{},
+		Provider:   domain.ProviderCodex,
+	}
+	hash, err := svc.PutMemoryDigest(ctx, repo, digest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.GetMemoryMeta(ctx, repo, snapshotID); !errors.Is(err, domain.ErrNotFound) {
+		t.Fatalf("service still wrote a full memmeta copy: %v", err)
+	}
+	snapshot, err := st.GetSnapshot(ctx, repo, snapshotID)
+	if err != nil || snapshot.MemoryHash != hash {
+		t.Fatalf("memory pointer=%s want=%s err=%v", snapshot.MemoryHash, hash, err)
+	}
+	got, err := svc.GetMemoryDigest(ctx, repo, snapshotID)
+	if err != nil || got.Summary != digest.Summary {
+		t.Fatalf("pointer-backed GetMemoryDigest: %+v err=%v", got, err)
+	}
+}
+
+func TestMemoryDigestFallsBackOnlyForPointerlessLegacySnapshot(t *testing.T) {
+	ctx := context.Background()
+	repo := hh("legacy-memory-repo")
+	snapshotID := hh("legacy-memory-snapshot")
+	base := store.NewFSStore(t.TempDir())
+	if err := base.PutSnapshot(ctx, domain.Snapshot{ID: snapshotID, RepoID: repo, DocHash: snapshotID}); err != nil {
+		t.Fatal(err)
+	}
+	legacy := domain.MemoryDigest{SnapshotID: snapshotID, Summary: "legacy metadata", Provider: domain.ProviderClaude}
+	if err := base.PutMemoryMeta(ctx, repo, legacy); err != nil {
+		t.Fatal(err)
+	}
+	svc := NewService(base, base, auth.NewTeamTokenAuth(), gitengine.NewEngine(base), base)
+	got, err := svc.GetMemoryDigest(ctx, repo, snapshotID)
+	if err != nil || got.Summary != legacy.Summary {
+		t.Fatalf("pointerless fallback: %+v err=%v", got, err)
+	}
+
+	hash, err := base.PutMemory(ctx, repo, legacy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := base.SetSnapshotMemory(ctx, repo, snapshotID, hash); err != nil {
+		t.Fatal(err)
+	}
+	failing := &missingMemoryBlob{FSStore: base}
+	svc = NewService(base, failing, auth.NewTeamTokenAuth(), gitengine.NewEngine(base), base)
+	if _, err := svc.GetMemoryDigest(ctx, repo, snapshotID); !errors.Is(err, domain.ErrNotFound) {
+		t.Fatalf("pointer-backed corruption was hidden by legacy fallback: %v", err)
+	}
+}
+
+type missingMemoryBlob struct {
+	*store.FSStore
+}
+
+func (s *missingMemoryBlob) GetMemory(context.Context, domain.ContentHash, domain.ContentHash) (domain.MemoryDigest, error) {
+	return domain.MemoryDigest{}, domain.ErrNotFound
+}

--- a/backend/internal/app/service.go
+++ b/backend/internal/app/service.go
@@ -1044,7 +1044,10 @@ func gitOriginLabel(raw string) string {
 	return raw
 }
 
-// PutMemoryDigest stores snapshot derivative memory (blob + meta, idempotent).
+// PutMemoryDigest stores snapshot derivative memory as one authoritative blob
+// and attaches its hash to the snapshot. Older releases also wrote the entire
+// digest to MemoryMeta, doubling every large summary; pointerless metadata is
+// now read-only legacy fallback.
 // The target snapshot must exist first (design: 404/422 if not).
 func (s *Service) PutMemoryDigest(ctx context.Context, repoID domain.ContentHash, d domain.MemoryDigest) (domain.ContentHash, error) {
 	if err := validateHashes(repoID, d.SnapshotID); err != nil {
@@ -1062,9 +1065,6 @@ func (s *Service) PutMemoryDigest(ctx context.Context, repoID domain.ContentHash
 	if err != nil {
 		return "", err
 	}
-	if err := s.meta.PutMemoryMeta(ctx, repoID, d); err != nil {
-		return "", err
-	}
 	// Attaches a derivative pointer to the snapshot metadata — after push, the memorize also holds raw+memory (E clause).
 	// Without this, pull/web cannot recognize memory existence.
 	if err := s.meta.SetSnapshotMemory(ctx, repoID, d.SnapshotID, hash); err != nil {
@@ -1073,12 +1073,29 @@ func (s *Service) PutMemoryDigest(ctx context.Context, repoID domain.ContentHash
 	return hash, nil
 }
 
-// GetMemoryDigest retrieves the compressed memory of a snapshot.
+// GetMemoryDigest resolves the authoritative MemoryHash pointer. Metadata-only
+// fallback is intentionally limited to legacy snapshots with no pointer: once
+// a pointer exists, hiding a missing/corrupt blob behind stale metadata would
+// turn an integrity failure into a silent rollback.
 func (s *Service) GetMemoryDigest(ctx context.Context, repoID, snapshotID domain.ContentHash) (domain.MemoryDigest, error) {
 	if err := validateHashes(repoID, snapshotID); err != nil {
 		return domain.MemoryDigest{}, err
 	}
-	return s.meta.GetMemoryMeta(ctx, repoID, snapshotID)
+	snapshot, err := s.meta.GetSnapshot(ctx, repoID, snapshotID)
+	if err != nil {
+		return domain.MemoryDigest{}, err
+	}
+	if snapshot.MemoryHash == "" {
+		return s.meta.GetMemoryMeta(ctx, repoID, snapshotID)
+	}
+	digest, err := s.blobs.GetMemory(ctx, repoID, snapshot.MemoryHash)
+	if err != nil {
+		return domain.MemoryDigest{}, err
+	}
+	if digest.SnapshotID != snapshotID {
+		return domain.MemoryDigest{}, fmt.Errorf("%w: memory %s targets snapshot %s, want %s", domain.ErrIntegrity, snapshot.MemoryHash, digest.SnapshotID, snapshotID)
+	}
+	return digest, nil
 }
 
 // UpdateAbout updates the repo About (web-only — membership check at call site).

--- a/backend/internal/domain/memory_chunks.go
+++ b/backend/internal/domain/memory_chunks.go
@@ -1,0 +1,157 @@
+package domain
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+const MemoryChunkTarget = 64 << 10
+
+const MemoryChunkFormatV1 = "cxt-memory-chunks-v1"
+
+// MemoryChunkManifest is an at-rest representation. MemoryDigestHash remains
+// the hash of complete wire JSON; storage chunking never changes identity.
+type MemoryChunkManifest struct {
+	Format         string        `json:"format"`
+	SnapshotID     ContentHash   `json:"snapshot_id"`
+	SummaryChunks  []ContentHash `json:"summary_chunks,omitempty"`
+	KeyFacts       []string      `json:"key_facts"`
+	OpenTasks      []string      `json:"open_tasks"`
+	Provider       ProviderKind  `json:"provider"`
+	FragmentChunks []ContentHash `json:"fragment_chunks,omitempty"`
+}
+
+type MemoryChunkPlan struct {
+	Manifest MemoryChunkManifest
+	Bodies   map[ContentHash][]byte
+	Order    []ContentHash
+}
+
+func PlanMemoryChunks(d MemoryDigest) (plan MemoryChunkPlan, ok bool, err error) {
+	var fragments []byte
+	if len(d.Fragments) > 0 {
+		fragments, err = json.Marshal(d.Fragments)
+		if err != nil {
+			return MemoryChunkPlan{}, false, err
+		}
+	}
+	if len([]byte(d.Summary))+len(fragments) <= MemoryChunkTarget {
+		return MemoryChunkPlan{}, false, nil
+	}
+	plan = MemoryChunkPlan{
+		Manifest: MemoryChunkManifest{
+			Format:     MemoryChunkFormatV1,
+			SnapshotID: d.SnapshotID,
+			KeyFacts:   d.KeyFacts,
+			OpenTasks:  d.OpenTasks,
+			Provider:   d.Provider,
+		},
+		Bodies: map[ContentHash][]byte{},
+	}
+	plan.Manifest.SummaryChunks = plan.addComponent([]byte(d.Summary))
+	plan.Manifest.FragmentChunks = plan.addComponent(fragments)
+	reassembled, err := AssembleMemoryChunks(plan.Manifest, plan.Bodies)
+	if err != nil {
+		return MemoryChunkPlan{}, false, err
+	}
+	want, err := MemoryDigestHash(d)
+	if err != nil {
+		return MemoryChunkPlan{}, false, err
+	}
+	got, err := MemoryDigestHash(reassembled)
+	if err != nil || got != want {
+		return MemoryChunkPlan{}, false, ErrIntegrity
+	}
+	return plan, true, nil
+}
+
+func (p *MemoryChunkPlan) addComponent(data []byte) []ContentHash {
+	if len(data) == 0 {
+		return nil
+	}
+	hashes := make([]ContentHash, 0, (len(data)+MemoryChunkTarget-1)/MemoryChunkTarget)
+	for len(data) > 0 {
+		n := MemoryChunkTarget
+		if len(data) < n {
+			n = len(data)
+		}
+		body := append([]byte(nil), data[:n]...)
+		hash := HashContent(body)
+		p.Bodies[hash] = body
+		p.Order = append(p.Order, hash)
+		hashes = append(hashes, hash)
+		data = data[n:]
+	}
+	return hashes
+}
+
+func ParseMemoryChunkManifest(data []byte) (MemoryChunkManifest, bool, error) {
+	var probe struct {
+		Format string `json:"format"`
+	}
+	if err := json.Unmarshal(data, &probe); err != nil {
+		limit := len(data)
+		if limit > 128 {
+			limit = 128
+		}
+		if bytes.Contains(data[:limit], []byte("cxt-memory-chunks-")) {
+			return MemoryChunkManifest{}, true, err
+		}
+		return MemoryChunkManifest{}, false, nil
+	}
+	if !strings.HasPrefix(probe.Format, "cxt-memory-chunks-") {
+		return MemoryChunkManifest{}, false, nil
+	}
+	if probe.Format != MemoryChunkFormatV1 {
+		return MemoryChunkManifest{}, true, fmt.Errorf("unsupported memory manifest format %q", probe.Format)
+	}
+	var man MemoryChunkManifest
+	if err := json.Unmarshal(data, &man); err != nil {
+		return MemoryChunkManifest{}, true, err
+	}
+	if len(man.SummaryChunks) == 0 && len(man.FragmentChunks) == 0 {
+		return MemoryChunkManifest{}, true, fmt.Errorf("empty memory manifest")
+	}
+	return man, true, nil
+}
+
+func AssembleMemoryChunks(man MemoryChunkManifest, bodies map[ContentHash][]byte) (MemoryDigest, error) {
+	join := func(hashes []ContentHash) ([]byte, error) {
+		var out bytes.Buffer
+		for _, hash := range hashes {
+			if err := ValidateContentHash(hash); err != nil {
+				return nil, err
+			}
+			body, exists := bodies[hash]
+			if !exists || HashContent(body) != hash {
+				return nil, ErrIntegrity
+			}
+			out.Write(body)
+		}
+		return out.Bytes(), nil
+	}
+	summary, err := join(man.SummaryChunks)
+	if err != nil {
+		return MemoryDigest{}, err
+	}
+	fragmentBytes, err := join(man.FragmentChunks)
+	if err != nil {
+		return MemoryDigest{}, err
+	}
+	var fragments []MemoryFragment
+	if len(fragmentBytes) > 0 {
+		if err := json.Unmarshal(fragmentBytes, &fragments); err != nil {
+			return MemoryDigest{}, err
+		}
+	}
+	return MemoryDigest{
+		SnapshotID: man.SnapshotID,
+		Summary:    string(summary),
+		KeyFacts:   man.KeyFacts,
+		OpenTasks:  man.OpenTasks,
+		Provider:   man.Provider,
+		Fragments:  fragments,
+	}, nil
+}

--- a/backend/internal/domain/memory_chunks_test.go
+++ b/backend/internal/domain/memory_chunks_test.go
@@ -1,0 +1,69 @@
+package domain
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestMemoryComponentPlanRoundtripAndPrefixDedup(t *testing.T) {
+	base := strings.Repeat("résumé-memory-", 40<<10)
+	first := MemoryDigest{
+		SnapshotID: HashContent([]byte("memory-first")),
+		Summary:    base,
+		KeyFacts:   []string{"immutable identity"},
+		OpenTasks:  []string{},
+		Provider:   ProviderCodex,
+		Fragments: []MemoryFragment{{
+			SourceSnapshot: HashContent([]byte("memory-source")),
+			Summary:        strings.Repeat("fragment", 12<<10),
+		}},
+	}
+	second := first
+	second.SnapshotID = HashContent([]byte("memory-second"))
+	second.Summary += strings.Repeat("tail", 32<<10)
+
+	p1, ok, err := PlanMemoryChunks(first)
+	if err != nil || !ok {
+		t.Fatalf("PlanMemoryChunks(first): ok=%v err=%v", ok, err)
+	}
+	p2, ok, err := PlanMemoryChunks(second)
+	if err != nil || !ok {
+		t.Fatalf("PlanMemoryChunks(second): ok=%v err=%v", ok, err)
+	}
+	if p1.Manifest.Format != MemoryChunkFormatV1 {
+		t.Fatalf("format=%q", p1.Manifest.Format)
+	}
+	for hash, body := range p2.Bodies {
+		if len(body) > MemoryChunkTarget {
+			t.Fatalf("chunk %s exceeds target: %d", hash, len(body))
+		}
+		if HashContent(body) != hash {
+			t.Fatalf("chunk body/hash mismatch: %s", hash)
+		}
+	}
+	shared := 0
+	for hash := range p1.Bodies {
+		if _, exists := p2.Bodies[hash]; exists {
+			shared++
+		}
+	}
+	if shared == 0 {
+		t.Fatal("growing memory did not reuse any component chunk")
+	}
+	got, err := AssembleMemoryChunks(p1.Manifest, p1.Bodies)
+	if err != nil {
+		t.Fatalf("AssembleMemoryChunks: %v", err)
+	}
+	wantHash, _ := MemoryDigestHash(first)
+	gotHash, _ := MemoryDigestHash(got)
+	if gotHash != wantHash {
+		t.Fatalf("identity changed: got %s want %s", gotHash, wantHash)
+	}
+}
+
+func TestMemoryComponentPlanKeepsSmallDigestMonolithic(t *testing.T) {
+	_, ok, err := PlanMemoryChunks(MemoryDigest{Summary: "small", Provider: ProviderClaude})
+	if err != nil || ok {
+		t.Fatalf("small digest should stay monolithic: ok=%v err=%v", ok, err)
+	}
+}

--- a/backend/internal/ports/outbound/outbound.go
+++ b/backend/internal/ports/outbound/outbound.go
@@ -83,7 +83,9 @@ type MetadataStore interface {
 	ReadReflog(ctx context.Context, repoID domain.ContentHash) ([]domain.RefLogEntry, error)
 	GetManifest(ctx context.Context, repoID domain.ContentHash) (domain.Manifest, error)
 
-	// Memory meta (derivative; body is BlobStore). Target snapshot must exist (sync protocol).
+	// Legacy MemoryDigest metadata fallback for snapshots created before
+	// Snapshot.MemoryHash became authoritative. New writes attach only the blob
+	// hash; adapters keep these methods to read and safely retire old records.
 	GetMemoryMeta(ctx context.Context, repoID, snapshotID domain.ContentHash) (domain.MemoryDigest, error)
 	PutMemoryMeta(ctx context.Context, repoID domain.ContentHash, digest domain.MemoryDigest) error
 }
@@ -115,7 +117,7 @@ type JoinMutation struct {
 //
 // Implementation (impl step): v1 = Postgres BYTEA — blobs(hash PK, bytes BYTEA). hash deduplication (if same hash, existing, skip re-recording = idempotent put). Later replace with S3/MinIO adapter without downtime. Current is stdlib only stub.
 //
-// Storage units: SessionDoc (CIR body) and MemoryDigest body. Both have sha256:<hex> keys. Integrity: Recalculate hash on Get to verify key (sync protocol, verification is in impl).
+// Storage units: SessionDoc (CIR body) and MemoryDigest body. Both have sha256:<hex> keys. Their at-rest bodies may be storage-only chunk manifests, while Get always reconstructs and verifies the complete identity.
 type BlobStore interface {
 	// PutDoc: Store SessionDoc body. content-hash deduplication (Stored=false means already exists).
 	PutDoc(ctx context.Context, repoID domain.ContentHash, doc domain.SessionDoc) (stored bool, err error)

--- a/cli/cmd/cxt/main.go
+++ b/cli/cmd/cxt/main.go
@@ -255,7 +255,7 @@ func buildContainer(cfg config) container {
 		PRMerges:        gitctx.NewGitHubPRMergeResolver(),
 		Settings:        remote,
 		SettingsObjects: store,
-		Repack:          store.RepackDocs,
+		Repack:          store.RepackObjects,
 		Identity:        cfg.Identity,
 	}
 

--- a/cli/internal/adapters/chunkcas/memory.go
+++ b/cli/internal/adapters/chunkcas/memory.go
@@ -1,0 +1,175 @@
+package chunkcas
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/wnsdy95/cxthub/cli/internal/domain"
+)
+
+// MemoryChunkTarget is deliberately smaller than the transcript chunk target.
+// Memory summaries are copied between generations and commonly share long
+// prefixes, so 64 KiB keeps the rewritten tail bounded without creating a
+// large number of tiny files.
+const MemoryChunkTarget = 64 << 10
+
+const MemoryFormatV1 = "cxt-memory-chunks-v1"
+
+// MemoryManifest is an at-rest representation only. The wire protocol keeps
+// sending a complete MemoryDigest, and MemoryDigestHash remains the identity.
+// Potentially large, prefix-sharing components are chunked independently;
+// small structured fields stay inline.
+type MemoryManifest struct {
+	Format         string               `json:"format"`
+	SnapshotID     domain.ContentHash   `json:"snapshot_id"`
+	SummaryChunks  []domain.ContentHash `json:"summary_chunks,omitempty"`
+	KeyFacts       []string             `json:"key_facts"`
+	OpenTasks      []string             `json:"open_tasks"`
+	Provider       domain.ProviderKind  `json:"provider"`
+	FragmentChunks []domain.ContentHash `json:"fragment_chunks,omitempty"`
+}
+
+type MemoryPlan struct {
+	Manifest MemoryManifest
+	Bodies   map[domain.ContentHash][]byte
+	Order    []domain.ContentHash
+}
+
+// PlanMemory returns ok=false for small digests, which stay as one legacy JSON
+// object. For larger digests it creates fixed-offset component chunks and
+// verifies that reconstruction preserves the original content identity.
+func PlanMemory(d domain.MemoryDigest) (plan MemoryPlan, ok bool, err error) {
+	var fragments []byte
+	if len(d.Fragments) > 0 {
+		fragments, err = json.Marshal(d.Fragments)
+		if err != nil {
+			return MemoryPlan{}, false, err
+		}
+	}
+	if len([]byte(d.Summary))+len(fragments) <= MemoryChunkTarget {
+		return MemoryPlan{}, false, nil
+	}
+	plan = MemoryPlan{
+		Manifest: MemoryManifest{
+			Format:     MemoryFormatV1,
+			SnapshotID: d.SnapshotID,
+			KeyFacts:   d.KeyFacts,
+			OpenTasks:  d.OpenTasks,
+			Provider:   d.Provider,
+		},
+		Bodies: map[domain.ContentHash][]byte{},
+	}
+	plan.Manifest.SummaryChunks = plan.addComponent([]byte(d.Summary))
+	plan.Manifest.FragmentChunks = plan.addComponent(fragments)
+
+	reassembled, err := AssembleMemory(plan.Manifest, plan.Bodies)
+	if err != nil {
+		return MemoryPlan{}, false, err
+	}
+	want, err := domain.MemoryDigestHash(d)
+	if err != nil {
+		return MemoryPlan{}, false, err
+	}
+	got, err := domain.MemoryDigestHash(reassembled)
+	if err != nil || got != want {
+		return MemoryPlan{}, false, domain.ErrHashMismatch
+	}
+	return plan, true, nil
+}
+
+func (p *MemoryPlan) addComponent(data []byte) []domain.ContentHash {
+	if len(data) == 0 {
+		return nil
+	}
+	hashes := make([]domain.ContentHash, 0, (len(data)+MemoryChunkTarget-1)/MemoryChunkTarget)
+	for len(data) > 0 {
+		n := MemoryChunkTarget
+		if len(data) < n {
+			n = len(data)
+		}
+		body := append([]byte(nil), data[:n]...)
+		hash := domain.HashContent(body)
+		p.Bodies[hash] = body
+		p.Order = append(p.Order, hash)
+		hashes = append(hashes, hash)
+		data = data[n:]
+	}
+	return hashes
+}
+
+// ParseMemoryManifest distinguishes legacy full JSON from a chunk manifest.
+// A recognized/future manifest with malformed or unsupported contents is
+// reported as a manifest error instead of being silently parsed as a digest.
+func ParseMemoryManifest(data []byte) (MemoryManifest, bool, error) {
+	var probe struct {
+		Format string `json:"format"`
+	}
+	if err := json.Unmarshal(data, &probe); err != nil {
+		limit := len(data)
+		if limit > 128 {
+			limit = 128
+		}
+		if bytes.Contains(data[:limit], []byte("cxt-memory-chunks-")) {
+			return MemoryManifest{}, true, err
+		}
+		return MemoryManifest{}, false, nil
+	}
+	if !strings.HasPrefix(probe.Format, "cxt-memory-chunks-") {
+		return MemoryManifest{}, false, nil
+	}
+	if probe.Format != MemoryFormatV1 {
+		return MemoryManifest{}, true, fmt.Errorf("unsupported memory manifest format %q", probe.Format)
+	}
+	var man MemoryManifest
+	if err := json.Unmarshal(data, &man); err != nil {
+		return MemoryManifest{}, true, err
+	}
+	if len(man.SummaryChunks) == 0 && len(man.FragmentChunks) == 0 {
+		return MemoryManifest{}, true, fmt.Errorf("empty memory manifest")
+	}
+	return man, true, nil
+}
+
+// AssembleMemory rebuilds a digest and validates every component's own CAS
+// identity. The caller additionally compares the digest hash with its object
+// path, which protects the inline manifest fields.
+func AssembleMemory(man MemoryManifest, bodies map[domain.ContentHash][]byte) (domain.MemoryDigest, error) {
+	join := func(hashes []domain.ContentHash) ([]byte, error) {
+		var out bytes.Buffer
+		for _, hash := range hashes {
+			if err := domain.ValidateContentHash(hash); err != nil {
+				return nil, err
+			}
+			body, exists := bodies[hash]
+			if !exists || domain.HashContent(body) != hash {
+				return nil, domain.ErrHashMismatch
+			}
+			out.Write(body)
+		}
+		return out.Bytes(), nil
+	}
+	summary, err := join(man.SummaryChunks)
+	if err != nil {
+		return domain.MemoryDigest{}, err
+	}
+	fragmentBytes, err := join(man.FragmentChunks)
+	if err != nil {
+		return domain.MemoryDigest{}, err
+	}
+	var fragments []domain.MemoryFragment
+	if len(fragmentBytes) > 0 {
+		if err := json.Unmarshal(fragmentBytes, &fragments); err != nil {
+			return domain.MemoryDigest{}, err
+		}
+	}
+	return domain.MemoryDigest{
+		SnapshotID: man.SnapshotID,
+		Summary:    string(summary),
+		KeyFacts:   man.KeyFacts,
+		OpenTasks:  man.OpenTasks,
+		Provider:   man.Provider,
+		Fragments:  fragments,
+	}, nil
+}

--- a/cli/internal/adapters/chunkcas/memory_test.go
+++ b/cli/internal/adapters/chunkcas/memory_test.go
@@ -1,0 +1,71 @@
+package chunkcas
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/wnsdy95/cxthub/cli/internal/domain"
+)
+
+func TestMemoryComponentPlanRoundtripAndPrefixDedup(t *testing.T) {
+	base := strings.Repeat("résumé-memory-", 40<<10)
+	first := domain.MemoryDigest{
+		SnapshotID: domain.HashContent([]byte("memory-first")),
+		Summary:    base,
+		KeyFacts:   []string{"immutable identity"},
+		OpenTasks:  []string{},
+		Provider:   domain.ProviderCodex,
+		Fragments: []domain.MemoryFragment{{
+			SourceSnapshot: domain.HashContent([]byte("memory-source")),
+			Summary:        strings.Repeat("fragment", 12<<10),
+		}},
+	}
+	second := first
+	second.SnapshotID = domain.HashContent([]byte("memory-second"))
+	second.Summary += strings.Repeat("tail", 32<<10)
+
+	p1, ok, err := PlanMemory(first)
+	if err != nil || !ok {
+		t.Fatalf("PlanMemory(first): ok=%v err=%v", ok, err)
+	}
+	p2, ok, err := PlanMemory(second)
+	if err != nil || !ok {
+		t.Fatalf("PlanMemory(second): ok=%v err=%v", ok, err)
+	}
+	if p1.Manifest.Format != MemoryFormatV1 {
+		t.Fatalf("format=%q", p1.Manifest.Format)
+	}
+	for hash, body := range p2.Bodies {
+		if len(body) > MemoryChunkTarget {
+			t.Fatalf("chunk %s exceeds target: %d", hash, len(body))
+		}
+		if domain.HashContent(body) != hash {
+			t.Fatalf("chunk body/hash mismatch: %s", hash)
+		}
+	}
+	shared := 0
+	for hash := range p1.Bodies {
+		if _, exists := p2.Bodies[hash]; exists {
+			shared++
+		}
+	}
+	if shared == 0 {
+		t.Fatal("growing memory did not reuse any component chunk")
+	}
+	got, err := AssembleMemory(p1.Manifest, p1.Bodies)
+	if err != nil {
+		t.Fatalf("AssembleMemory: %v", err)
+	}
+	wantHash, _ := domain.MemoryDigestHash(first)
+	gotHash, _ := domain.MemoryDigestHash(got)
+	if gotHash != wantHash {
+		t.Fatalf("identity changed: got %s want %s", gotHash, wantHash)
+	}
+}
+
+func TestMemoryComponentPlanKeepsSmallDigestMonolithic(t *testing.T) {
+	_, ok, err := PlanMemory(domain.MemoryDigest{Summary: "small", Provider: domain.ProviderClaude})
+	if err != nil || ok {
+		t.Fatalf("small digest should stay monolithic: ok=%v err=%v", ok, err)
+	}
+}

--- a/cli/internal/adapters/delivery/cli/root.go
+++ b/cli/internal/adapters/delivery/cli/root.go
@@ -131,7 +131,8 @@ func Run(c *Container, args []string) error {
 		return runRemote(ctx, c, cwd, rest)
 
 	case "repack":
-		// Local .cxt doc storage repacked in chunk CAS — recovers duplicate prefixes (prefix) from legacy docs captured each time. Integrity hash invariant and lossless (reassembly verification and replacement).
+		// Repack large transcript and memory objects into their storage-only chunk
+		// CAS forms. Content identities and the wire protocol remain unchanged.
 		if c.Repack == nil {
 			return fmt.Errorf("repack unsupported build")
 		}
@@ -139,7 +140,7 @@ func Run(c *Container, args []string) error {
 		if err != nil {
 			return err
 		}
-		fmt.Printf("repacked %d doc(s), reclaimed %.1f MB\n", n, float64(saved)/1e6)
+		fmt.Printf("repacked %d object(s), reclaimed %.1f MB\n", n, float64(saved)/1e6)
 		return nil
 
 	case "add":

--- a/cli/internal/adapters/storage/file_store.go
+++ b/cli/internal/adapters/storage/file_store.go
@@ -653,13 +653,8 @@ func (s *FileStore) Manifest(ctx context.Context, repoID string) (domain.Manifes
 
 // PutMemory stores a MemoryDigest as a content-addressed blob. No-op if it already exists.
 func (s *FileStore) PutMemory(_ context.Context, digest domain.MemoryDigest) (domain.ContentHash, error) {
-	if err := domain.ValidateOptionalContentHash(digest.SnapshotID); err != nil {
+	if err := validateMemoryDigestRefs(digest); err != nil {
 		return "", err
-	}
-	for _, fragment := range digest.Fragments {
-		if err := domain.ValidateContentHash(fragment.SourceSnapshot); err != nil {
-			return "", err
-		}
 	}
 	data, err := json.Marshal(digest)
 	if err != nil {
@@ -672,8 +667,14 @@ func (s *FileStore) PutMemory(_ context.Context, digest domain.MemoryDigest) (do
 			return "", err
 		}
 	} else {
-		if err := writeAtomic(p, data); err != nil {
+		chunked, _, err := s.putMemoryChunked(h, digest)
+		if err != nil {
 			return "", err
+		}
+		if !chunked {
+			if err := writeAtomic(p, data); err != nil {
+				return "", err
+			}
 		}
 	}
 	return h, nil
@@ -691,6 +692,12 @@ func (s *FileStore) GetMemory(_ context.Context, hash domain.ContentHash) (domai
 		}
 		return domain.MemoryDigest{}, err
 	}
+	if chunked, isManifest, chunkErr := s.getMemoryChunked(hash, data); isManifest {
+		if chunkErr != nil {
+			return domain.MemoryDigest{}, chunkErr
+		}
+		return chunked, nil
+	}
 	var d domain.MemoryDigest
 	if err := json.Unmarshal(data, &d); err != nil {
 		return domain.MemoryDigest{}, err
@@ -702,7 +709,7 @@ func (s *FileStore) GetMemory(_ context.Context, hash domain.ContentHash) (domai
 	if got != hash {
 		return domain.MemoryDigest{}, domain.ErrHashMismatch
 	}
-	if err := domain.ValidateOptionalContentHash(d.SnapshotID); err != nil {
+	if err := validateMemoryDigestRefs(d); err != nil {
 		return domain.MemoryDigest{}, err
 	}
 	return d, nil

--- a/cli/internal/adapters/storage/memory_chunks.go
+++ b/cli/internal/adapters/storage/memory_chunks.go
@@ -1,0 +1,220 @@
+package storage
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/wnsdy95/cxthub/cli/internal/adapters/chunkcas"
+	"github.com/wnsdy95/cxthub/cli/internal/domain"
+)
+
+func validateMemoryDigestRefs(digest domain.MemoryDigest) error {
+	if err := domain.ValidateOptionalContentHash(digest.SnapshotID); err != nil {
+		return err
+	}
+	for _, fragment := range digest.Fragments {
+		if err := domain.ValidateContentHash(fragment.SourceSnapshot); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *FileStore) putMemoryChunked(hash domain.ContentHash, digest domain.MemoryDigest) (bool, int64, error) {
+	plan, ok, err := chunkcas.PlanMemory(digest)
+	if err != nil || !ok {
+		return false, 0, err
+	}
+	var added int64
+	for _, chunkHash := range plan.Order {
+		path := s.objectPath("memory_chunks", chunkHash)
+		body := plan.Bodies[chunkHash]
+		if fileExists(path) {
+			raw, err := readCxtFile(path)
+			if err != nil {
+				return false, added, err
+			}
+			existing, err := docDecompress(raw)
+			if err != nil || !bytes.Equal(existing, body) {
+				return false, added, domain.ErrHashMismatch
+			}
+			continue
+		}
+		compressed := docCompress(body)
+		if err := writeAtomic(path, compressed); err != nil {
+			return false, added, err
+		}
+		added += int64(len(compressed))
+	}
+	manifest, err := json.Marshal(plan.Manifest)
+	if err != nil {
+		return false, added, err
+	}
+	if err := writeAtomic(s.objectPath("memories", hash), manifest); err != nil {
+		return false, added, err
+	}
+	return true, added, nil
+}
+
+func (s *FileStore) getMemoryChunked(hash domain.ContentHash, data []byte) (domain.MemoryDigest, bool, error) {
+	manifest, isManifest, err := chunkcas.ParseMemoryManifest(data)
+	if !isManifest {
+		return domain.MemoryDigest{}, false, nil
+	}
+	if err != nil {
+		return domain.MemoryDigest{}, true, err
+	}
+	bodies := make(map[domain.ContentHash][]byte, len(manifest.SummaryChunks)+len(manifest.FragmentChunks))
+	all := append(append([]domain.ContentHash{}, manifest.SummaryChunks...), manifest.FragmentChunks...)
+	for _, chunkHash := range all {
+		if _, loaded := bodies[chunkHash]; loaded {
+			continue
+		}
+		if err := domain.ValidateContentHash(chunkHash); err != nil {
+			return domain.MemoryDigest{}, true, err
+		}
+		raw, err := readCxtFile(s.objectPath("memory_chunks", chunkHash))
+		if err != nil {
+			if os.IsNotExist(err) {
+				return domain.MemoryDigest{}, true, fmt.Errorf("%w: memory %s missing component %s", domain.ErrHashMismatch, hash, chunkHash)
+			}
+			return domain.MemoryDigest{}, true, err
+		}
+		body, err := docDecompress(raw)
+		if err != nil {
+			return domain.MemoryDigest{}, true, domain.ErrHashMismatch
+		}
+		bodies[chunkHash] = body
+	}
+	digest, err := chunkcas.AssembleMemory(manifest, bodies)
+	if err != nil {
+		return domain.MemoryDigest{}, true, err
+	}
+	if err := validateMemoryDigestRefs(digest); err != nil {
+		return domain.MemoryDigest{}, true, err
+	}
+	got, err := domain.MemoryDigestHash(digest)
+	if err != nil || got != hash {
+		return domain.MemoryDigest{}, true, domain.ErrHashMismatch
+	}
+	return digest, true, nil
+}
+
+// RepackMemories converts large legacy MemoryDigest JSON objects into 64 KiB
+// component CAS manifests. MemoryDigestHash remains unchanged. Existing and
+// corrupt manifests are never rewritten by maintenance, and a grace window
+// protects chunks concurrently created during mark-and-sweep.
+func (s *FileStore) RepackMemories() (converted int, saved int64, err error) {
+	memoriesDir := filepath.Join(s.storeDir(), "objects", "memories")
+	entries, err := os.ReadDir(memoriesDir)
+	if os.IsNotExist(err) {
+		return 0, 0, nil
+	}
+	if err != nil {
+		return 0, 0, err
+	}
+	live := map[domain.ContentHash]bool{}
+	sweepSafe := true
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		hash, ok := hashFromObjectName(entry.Name())
+		if !ok {
+			continue
+		}
+		path := filepath.Join(memoriesDir, entry.Name())
+		data, readErr := readCxtFile(path)
+		if readErr != nil {
+			continue
+		}
+		if _, isManifest, manifestErr := s.getMemoryChunked(hash, data); isManifest {
+			var manifest chunkcas.MemoryManifest
+			if json.Unmarshal(data, &manifest) == nil {
+				for _, chunkHash := range append(manifest.SummaryChunks, manifest.FragmentChunks...) {
+					live[chunkHash] = true
+				}
+				if manifest.Format != chunkcas.MemoryFormatV1 {
+					sweepSafe = false
+				}
+			} else {
+				sweepSafe = false
+			}
+			if manifestErr != nil {
+				continue
+			}
+			continue
+		}
+		var digest domain.MemoryDigest
+		if json.Unmarshal(data, &digest) != nil {
+			continue
+		}
+		got, hashErr := domain.MemoryDigestHash(digest)
+		if hashErr != nil || got != hash {
+			continue
+		}
+		before := int64(len(data))
+		chunked, added, putErr := s.putMemoryChunked(hash, digest)
+		if putErr != nil {
+			return converted, saved, putErr
+		}
+		if !chunked {
+			continue
+		}
+		manifestData, readErr := readCxtFile(path)
+		if readErr != nil {
+			return converted, saved, readErr
+		}
+		manifest, isManifest, parseErr := chunkcas.ParseMemoryManifest(manifestData)
+		if parseErr != nil || !isManifest {
+			return converted, saved, domain.ErrHashMismatch
+		}
+		for _, chunkHash := range append(manifest.SummaryChunks, manifest.FragmentChunks...) {
+			live[chunkHash] = true
+		}
+		saved += before - int64(len(manifestData)) - added
+		converted++
+	}
+
+	if !sweepSafe {
+		return converted, saved, nil
+	}
+	chunksDir := filepath.Join(s.storeDir(), "objects", "memory_chunks")
+	chunkEntries, chunkErr := os.ReadDir(chunksDir)
+	if os.IsNotExist(chunkErr) {
+		return converted, saved, nil
+	}
+	if chunkErr != nil {
+		return converted, saved, chunkErr
+	}
+	for _, entry := range chunkEntries {
+		if entry.IsDir() {
+			continue
+		}
+		chunkHash, ok := hashFromObjectName(entry.Name())
+		if !ok || live[chunkHash] {
+			continue
+		}
+		info, infoErr := entry.Info()
+		if infoErr != nil || time.Since(info.ModTime()) < 10*time.Minute {
+			continue
+		}
+		saved += info.Size()
+		_ = os.Remove(filepath.Join(chunksDir, entry.Name()))
+	}
+	return converted, saved, nil
+}
+
+// RepackObjects upgrades every chunkable local object type.
+func (s *FileStore) RepackObjects() (converted int, saved int64, err error) {
+	docs, docSaved, err := s.RepackDocs()
+	if err != nil {
+		return docs, docSaved, err
+	}
+	memories, memorySaved, err := s.RepackMemories()
+	return docs + memories, docSaved + memorySaved, err
+}

--- a/cli/internal/adapters/storage/memory_chunks_test.go
+++ b/cli/internal/adapters/storage/memory_chunks_test.go
@@ -1,0 +1,176 @@
+package storage
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/wnsdy95/cxthub/cli/internal/adapters/chunkcas"
+	"github.com/wnsdy95/cxthub/cli/internal/domain"
+)
+
+func largeMemory(label string, extra int) domain.MemoryDigest {
+	return domain.MemoryDigest{
+		SnapshotID: domain.HashContent([]byte("snapshot-" + label)),
+		Summary:    strings.Repeat("shared-memory-prefix-", 12<<10) + strings.Repeat(label, extra),
+		KeyFacts:   []string{"memory identity is immutable"},
+		OpenTasks:  []string{},
+		Provider:   domain.ProviderCodex,
+		Fragments: []domain.MemoryFragment{{
+			SourceSnapshot: domain.HashContent([]byte("source-" + label)),
+			Summary:        strings.Repeat("fragment-", 10<<10),
+		}},
+	}
+}
+
+func memoryChunkFiles(t *testing.T, root string) map[string]int64 {
+	t.Helper()
+	out := map[string]int64{}
+	dir := filepath.Join(root, ".cxt", "objects", "memory_chunks")
+	entries, err := os.ReadDir(dir)
+	if os.IsNotExist(err) {
+		return out
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range entries {
+		info, err := entry.Info()
+		if err != nil {
+			t.Fatal(err)
+		}
+		out[entry.Name()] = info.Size()
+	}
+	return out
+}
+
+func TestMemoryChunkRoundtripPrefixDedupAndCorruption(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	st := NewFileStore(root)
+
+	first := largeMemory("first", 8<<10)
+	firstHash, err := st.PutMemory(ctx, first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := st.GetMemory(ctx, firstHash)
+	if err != nil {
+		t.Fatalf("GetMemory(chunked): %v", err)
+	}
+	gotHash, _ := domain.MemoryDigestHash(got)
+	if gotHash != firstHash {
+		t.Fatalf("roundtrip identity changed: %s != %s", gotHash, firstHash)
+	}
+	before := memoryChunkFiles(t, root)
+	if len(before) < 2 {
+		t.Fatalf("expected component chunks, got %d", len(before))
+	}
+
+	second := first
+	second.SnapshotID = domain.HashContent([]byte("snapshot-second"))
+	second.Summary += strings.Repeat("tail", 40<<10)
+	secondHash, err := st.PutMemory(ctx, second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	after := memoryChunkFiles(t, root)
+	shared := 0
+	for name := range before {
+		if _, ok := after[name]; ok {
+			shared++
+		}
+	}
+	if shared == 0 {
+		t.Fatal("memory growth did not reuse prefix chunks")
+	}
+	if got, err := st.GetMemory(ctx, secondHash); err != nil || got.Summary != second.Summary {
+		t.Fatalf("second memory roundtrip: err=%v", err)
+	}
+
+	raw, err := readCxtFile(st.objectPath("memories", firstHash))
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest, isManifest, err := chunkcas.ParseMemoryManifest(raw)
+	if err != nil || !isManifest || len(manifest.SummaryChunks) == 0 {
+		t.Fatalf("stored memory is not a manifest: %+v is=%v err=%v", manifest, isManifest, err)
+	}
+	victim := st.objectPath("memory_chunks", manifest.SummaryChunks[0])
+	if err := os.WriteFile(victim, docCompress([]byte("corrupt")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.GetMemory(ctx, firstHash); !errors.Is(err, domain.ErrHashMismatch) {
+		t.Fatalf("corrupt component was not rejected: %v", err)
+	}
+}
+
+func TestMemoryChunkReadValidatesInlineHashReferences(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	st := NewFileStore(root)
+	digest := largeMemory("invalid-reference", 8<<10)
+	digest.SnapshotID = domain.ContentHash("invalid")
+	plan, ok, err := chunkcas.PlanMemory(digest)
+	if err != nil || !ok {
+		t.Fatalf("PlanMemory: ok=%v err=%v", ok, err)
+	}
+	for hash, body := range plan.Bodies {
+		if err := writeAtomic(st.objectPath("memory_chunks", hash), docCompress(body)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	hash, _ := domain.MemoryDigestHash(digest)
+	manifest, _ := json.Marshal(plan.Manifest)
+	if err := writeAtomic(st.objectPath("memories", hash), manifest); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.GetMemory(ctx, hash); err == nil {
+		t.Fatal("chunked memory accepted an invalid snapshot reference")
+	}
+}
+
+func TestRepackMemoriesLegacyLosslessAndIdempotent(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	st := NewFileStore(root)
+	digests := []domain.MemoryDigest{largeMemory("legacy-a", 16<<10), largeMemory("legacy-b", 32<<10)}
+	var hashes []domain.ContentHash
+	for _, digest := range digests {
+		data, err := json.Marshal(digest)
+		if err != nil {
+			t.Fatal(err)
+		}
+		hash, _ := domain.MemoryDigestHash(digest)
+		if err := writeAtomic(st.objectPath("memories", hash), data); err != nil {
+			t.Fatal(err)
+		}
+		hashes = append(hashes, hash)
+	}
+	objects := filepath.Join(root, ".cxt", "objects")
+	before := dirSize(t, objects)
+	converted, saved, err := st.RepackMemories()
+	if err != nil {
+		t.Fatalf("RepackMemories: %v", err)
+	}
+	if converted != len(digests) {
+		t.Fatalf("converted=%d want %d", converted, len(digests))
+	}
+	after := dirSize(t, objects)
+	if after >= before || saved != before-after {
+		t.Fatalf("repack accounting before=%d after=%d saved=%d", before, after, saved)
+	}
+	for i, hash := range hashes {
+		got, err := st.GetMemory(ctx, hash)
+		if err != nil || got.Summary != digests[i].Summary {
+			t.Fatalf("repacked memory %d: err=%v", i, err)
+		}
+	}
+	if converted, _, err := st.RepackMemories(); err != nil || converted != 0 {
+		t.Fatalf("second repack converted=%d err=%v", converted, err)
+	}
+}

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -9,7 +9,7 @@ cxt keeps `cli/` and `backend/` in separate Go modules with independent domain t
 | `cir.schema.json` | CIR v1, the provider-independent canonical intermediate representation decoded from raw Claude and Codex JSONL. Changes require compatibility review. |
 | `manifest.schema.json` | Manifest v1: repository refs plus the `snapshot_index` catalog used for push/pull have-want negotiation. Changes require compatibility review. |
 | `openapi.yaml` | OpenAPI 3.1 REST contract shared by CLI, backend, and frontend. Route and field drift tests keep it aligned with the server. |
-| `db/migrations/*.sql` | Ordered PostgreSQL migrations through 0035, covering repository objects, identity/workspaces, pending state, reflog, compaction, graft overlays, chunk storage, and scoped session refs. |
+| `db/migrations/*.sql` | Ordered PostgreSQL migrations through 0036, covering repository objects, identity/workspaces, pending state, reflog, compaction, graft overlays, transcript/memory chunk storage, and scoped session refs. |
 
 ## DB Schema (ERDiagram)
 

--- a/schemas/db/migrations/0036_memory_chunks.sql
+++ b/schemas/db/migrations/0036_memory_chunks.sql
@@ -1,0 +1,12 @@
+-- 0036: Memory component CAS ownership.
+--
+-- A large MemoryDigest remains identified by the hash of its complete wire
+-- JSON, while the at-rest blob may be a manifest whose summary and fragment
+-- streams live in 64 KiB component chunks. Keep memory chunks distinct from
+-- transcript chunks so each object type's mark-and-sweep cannot delete the
+-- other's bodies. Ownership remains repo-scoped.
+ALTER TABLE repo_blobs DROP CONSTRAINT IF EXISTS repo_blobs_kind_check;
+ALTER TABLE repo_blobs ADD CONSTRAINT repo_blobs_kind_check CHECK (kind IN ('doc', 'memory', 'chunk', 'memory_chunk'));
+
+COMMENT ON COLUMN snapshots.memory_hash IS 'Authoritative pointer to the complete MemoryDigest identity in blobs. The blob may be a storage-only component manifest.';
+COMMENT ON TABLE memories IS 'Legacy structured MemoryDigest metadata retained for pointerless snapshots and rolling compatibility; new reads resolve snapshots.memory_hash.';


### PR DESCRIPTION
Closes #58

## What changed
- preserve MemoryDigestHash and the complete JSON wire contract while storing large summaries/fragments as fixed 64 KiB component chunks
- use separate memory chunk namespaces and repo-scoped PostgreSQL ownership
- make Snapshot.memory_hash authoritative; retain metadata only as pointerless legacy fallback
- add lossless/idempotent local and server repack, with pointer/blob-proven FS memmeta cleanup
- add migration 0036 and transactional PostgreSQL multi-owner migration/corruption rollback

## Evidence
- full backend/CLI tests, vet, and race pass
- sync E2E and public full preflight pass
- real PostgreSQL smoke passes, including concurrent migration and corrupt component rollback
- production image builds and health endpoint returns 200
- real backup copy: local memories 53,596 KiB to 748 KiB manifests + 1,492 KiB chunks; server memories 50,808 KiB to 776 KiB + 1,480 KiB, memmeta 113 to 0
- object filename sets unchanged; second repack reports 0 objects / 0 MB on both stores

## Compatibility
Old clients still upload/download complete MemoryDigest JSON. Existing raw blobs and pointerless metadata remain readable. PostgreSQL legacy metadata rows are retained for rolling compatibility.