### PR TITLE
fix(memory): deduplicate extractive fallback projection

### DIFF
--- a/cli/internal/adapters/memory/distiller.go
+++ b/cli/internal/adapters/memory/distiller.go
@@ -135,11 +135,7 @@ func extractiveConversationDigest(events []domain.Event) string {
 	if len(users) == 0 && len(assistants) == 0 {
 		return ""
 	}
-	var b strings.Builder
-	b.WriteString("Conversation digest (extractive fallback; provider compaction summary unavailable):\n")
-	writeExtractiveSection(&b, "Recent user intent", users)
-	writeExtractiveSection(&b, "Recent assistant outcomes", assistants)
-	return truncate(strings.TrimSpace(b.String()), extractiveDigestMaxRunes-1)
+	return truncate(domain.RenderExtractiveFallbackSummary(users, assistants), extractiveDigestMaxRunes-1)
 }
 
 func messageText(blocks []domain.ContentBlock) string {
@@ -188,20 +184,6 @@ func appendRecentDistinct(items []string, text string, limit int) []string {
 		items = items[len(items)-limit:]
 	}
 	return items
-}
-
-func writeExtractiveSection(b *strings.Builder, title string, items []string) {
-	if len(items) == 0 {
-		return
-	}
-	b.WriteString("\n\n")
-	b.WriteString(title)
-	b.WriteString(":\n")
-	for _, item := range items {
-		b.WriteString("- ")
-		b.WriteString(item)
-		b.WriteByte('\n')
-	}
 }
 
 // extractSummarySections extracts the top-level bullets from the KeyFacts ("Key Technical Concepts") and OpenTasks ("Pending Tasks") sections of a compression summary. It accumulates summaries, so it writes the last occurrence of each section. For unstructured text, it returns an empty result (fallback for the caller). Deterministic.

--- a/cli/internal/domain/entities.go
+++ b/cli/internal/domain/entities.go
@@ -251,10 +251,21 @@ func memoryFragmentKey(fragment MemoryFragment) string {
 
 func renderMemoryFragments(out *MemoryDigest) {
 	var summaries []string
+	fallbackInsertAt := -1
+	var fallbackUsers, fallbackAssistants []string
 	var facts, tasks []string
 	for _, fragment := range out.Fragments {
-		if summary := strings.TrimSpace(fragment.Summary); summary != "" && !containsString(summaries, summary) {
-			summaries = append(summaries, summary)
+		if summary := strings.TrimSpace(fragment.Summary); summary != "" {
+			if users, assistants, ok := parseExtractiveFallbackSummary(summary); ok {
+				// Keep the combined projection at the position of the newest
+				// fallback fragment. renderSeedDigest retains the newest tail, so
+				// placing it at the first fallback could evict newer unique items.
+				fallbackInsertAt = len(summaries)
+				fallbackUsers = dedupStrings(fallbackUsers, users)
+				fallbackAssistants = dedupStrings(fallbackAssistants, assistants)
+			} else if !containsString(summaries, summary) {
+				summaries = append(summaries, summary)
+			}
 		}
 		facts = dedupStrings(facts, fragment.KeyFacts)
 		if fragment.TasksAuthoritative {
@@ -263,9 +274,99 @@ func renderMemoryFragments(out *MemoryDigest) {
 			tasks = dedupStrings(tasks, fragment.OpenTasks)
 		}
 	}
+	if fallbackInsertAt >= 0 {
+		summaries = append(summaries, "")
+		copy(summaries[fallbackInsertAt+1:], summaries[fallbackInsertAt:])
+		summaries[fallbackInsertAt] = RenderExtractiveFallbackSummary(fallbackUsers, fallbackAssistants)
+	}
 	out.Summary = strings.Join(summaries, "\n\n")
 	out.KeyFacts = facts
 	out.OpenTasks = tasks
+}
+
+const (
+	extractiveFallbackHeader           = "Conversation digest (extractive fallback; provider compaction summary unavailable):"
+	extractiveFallbackUsersHeader      = "Recent user intent:"
+	extractiveFallbackAssistantsHeader = "Recent assistant outcomes:"
+)
+
+// RenderExtractiveFallbackSummary is the canonical text representation of the
+// deterministic conversation fallback. Keeping the format in the domain lets
+// provenance rendering recognize and combine exact items without fuzzy or
+// model-dependent comparison.
+func RenderExtractiveFallbackSummary(users, assistants []string) string {
+	var b strings.Builder
+	b.WriteString(extractiveFallbackHeader)
+	// Preserve the established storage wire format: the header already carried
+	// one newline before writeExtractiveSection added two more.
+	b.WriteByte('\n')
+	writeExtractiveFallbackSection(&b, extractiveFallbackUsersHeader, users)
+	writeExtractiveFallbackSection(&b, extractiveFallbackAssistantsHeader, assistants)
+	return strings.TrimSpace(b.String())
+}
+
+func writeExtractiveFallbackSection(b *strings.Builder, header string, items []string) {
+	if len(items) == 0 {
+		return
+	}
+	b.WriteString("\n\n")
+	b.WriteString(header)
+	b.WriteByte('\n')
+	for _, item := range items {
+		if item = strings.TrimSpace(item); item != "" {
+			b.WriteString("- ")
+			b.WriteString(item)
+			b.WriteByte('\n')
+		}
+	}
+}
+
+// parseExtractiveFallbackSummary accepts only the exact deterministic format
+// emitted by RenderExtractiveFallbackSummary. Any unexpected prose or section
+// order is classified as an unstructured/agent-written summary and remains
+// byte-for-byte on the legacy rendering path.
+func parseExtractiveFallbackSummary(summary string) (users, assistants []string, ok bool) {
+	lines := strings.Split(strings.TrimSpace(summary), "\n")
+	if len(lines) == 0 || strings.TrimSpace(lines[0]) != extractiveFallbackHeader {
+		return nil, nil, false
+	}
+	section := 0
+	seenUsers, seenAssistants := false, false
+	for _, raw := range lines[1:] {
+		line := strings.TrimSpace(raw)
+		if line == "" {
+			continue
+		}
+		switch line {
+		case extractiveFallbackUsersHeader:
+			if seenUsers || seenAssistants {
+				return nil, nil, false
+			}
+			seenUsers, section = true, 1
+		case extractiveFallbackAssistantsHeader:
+			if seenAssistants {
+				return nil, nil, false
+			}
+			seenAssistants, section = true, 2
+		default:
+			if section == 0 || !strings.HasPrefix(line, "- ") {
+				return nil, nil, false
+			}
+			item := strings.TrimSpace(strings.TrimPrefix(line, "- "))
+			if item == "" {
+				return nil, nil, false
+			}
+			if section == 1 {
+				users = append(users, item)
+			} else {
+				assistants = append(assistants, item)
+			}
+		}
+	}
+	if len(users) == 0 && len(assistants) == 0 {
+		return nil, nil, false
+	}
+	return users, assistants, true
 }
 
 func containsString(items []string, want string) bool {

--- a/cli/internal/domain/merge_digests_test.go
+++ b/cli/internal/domain/merge_digests_test.go
@@ -2,6 +2,7 @@ package domain
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -28,4 +29,160 @@ func TestMergeDigestsOpenTasksAuthority(t *testing.T) {
 	if !reflect.DeepEqual(got.OpenTasks, want) {
 		t.Fatalf("Non-struct merge = %v, want %v", got.OpenTasks, want)
 	}
+}
+
+func TestRenderExtractiveFallbackSummaryPreservesWireFormat(t *testing.T) {
+	want := "Conversation digest (extractive fallback; provider compaction summary unavailable):\n\n\n" +
+		"Recent user intent:\n- Keep the existing hash contract.\n\n\n" +
+		"Recent assistant outcomes:\n- Verified the canonical whitespace."
+	got := RenderExtractiveFallbackSummary(
+		[]string{"Keep the existing hash contract."},
+		[]string{"Verified the canonical whitespace."},
+	)
+	if got != want {
+		t.Fatalf("extractive fallback wire format changed:\n got %q\nwant %q", got, want)
+	}
+}
+
+func TestMergeDigestsDeduplicatesExtractiveFallbackItems(t *testing.T) {
+	prior := MemoryDigest{
+		SnapshotID: ContentHash("sha256:" + strings.Repeat("a", 64)),
+		Summary: extractiveFallbackSummary(
+			[]string{"Inspect pull context boundaries.", "Fix every confirmed defect."},
+			[]string{"Measured the restart seed."},
+		),
+	}
+	fresh := MemoryDigest{
+		SnapshotID: ContentHash("sha256:" + strings.Repeat("b", 64)),
+		Summary: extractiveFallbackSummary(
+			[]string{"Inspect pull context boundaries.", "Fix every confirmed defect."},
+			[]string{"Measured the restart seed.", "Scoped pull briefings by terminal."},
+		),
+	}
+
+	got := MergeDigests(prior, fresh)
+	if len(got.Fragments) != 2 {
+		t.Fatalf("provenance fragments = %d, want 2", len(got.Fragments))
+	}
+	for _, item := range []string{
+		"Conversation digest (extractive fallback; provider compaction summary unavailable):",
+		"Inspect pull context boundaries.",
+		"Fix every confirmed defect.",
+		"Measured the restart seed.",
+	} {
+		if count := strings.Count(got.Summary, item); count != 1 {
+			t.Fatalf("rendered summary count(%q) = %d, want 1:\n%s", item, count, got.Summary)
+		}
+	}
+	if !strings.Contains(got.Summary, "Scoped pull briefings by terminal.") {
+		t.Fatalf("new unique outcome was lost:\n%s", got.Summary)
+	}
+}
+
+func TestMergeDigestsPreservesUniqueSiblingFallbackItems(t *testing.T) {
+	left := MemoryDigest{
+		SnapshotID: ContentHash("sha256:" + strings.Repeat("c", 64)),
+		Summary: extractiveFallbackSummary(
+			[]string{"Review the left branch."},
+			[]string{"Verified the left branch migration."},
+		),
+	}
+	right := MemoryDigest{
+		SnapshotID: ContentHash("sha256:" + strings.Repeat("d", 64)),
+		Summary: extractiveFallbackSummary(
+			[]string{"Review the right branch."},
+			[]string{"Verified the right branch migration."},
+		),
+	}
+
+	got := MergeDigests(left, right)
+	for _, item := range []string{
+		"Review the left branch.",
+		"Review the right branch.",
+		"Verified the left branch migration.",
+		"Verified the right branch migration.",
+	} {
+		if !strings.Contains(got.Summary, item) {
+			t.Fatalf("sibling item %q was lost:\n%s", item, got.Summary)
+		}
+	}
+	if strings.Index(got.Summary, "Review the left branch.") > strings.Index(got.Summary, "Review the right branch.") ||
+		strings.Index(got.Summary, "Verified the left branch migration.") > strings.Index(got.Summary, "Verified the right branch migration.") {
+		t.Fatalf("sibling chronology changed:\n%s", got.Summary)
+	}
+}
+
+func TestMergeDigestsKeepsUnstructuredSummariesOrdered(t *testing.T) {
+	leftFallback := MemoryFragment{
+		SourceSnapshot: ContentHash("sha256:" + strings.Repeat("e", 64)),
+		Summary:        extractiveFallbackSummary([]string{"Shared request."}, []string{"Left outcome."}),
+	}
+	leftAgent := MemoryFragment{
+		SourceSnapshot: ContentHash("sha256:" + strings.Repeat("f", 64)),
+		Summary:        "Agent-written summary A\nwith deliberate formatting.",
+	}
+	rightFallback := MemoryFragment{
+		SourceSnapshot: ContentHash("sha256:" + strings.Repeat("1", 64)),
+		Summary:        extractiveFallbackSummary([]string{"Shared request."}, []string{"Right outcome."}),
+	}
+	rightAgent := MemoryFragment{
+		SourceSnapshot: ContentHash("sha256:" + strings.Repeat("2", 64)),
+		Summary:        "Agent-written summary B\nwith different formatting.",
+	}
+
+	got := MergeDigests(
+		MemoryDigest{Fragments: []MemoryFragment{leftFallback, leftAgent}},
+		MemoryDigest{Fragments: []MemoryFragment{rightFallback, rightAgent}},
+	)
+	if strings.Count(got.Summary, "Shared request.") != 1 ||
+		!strings.Contains(got.Summary, "Left outcome.") || !strings.Contains(got.Summary, "Right outcome.") {
+		t.Fatalf("fallback projection was not normalized:\n%s", got.Summary)
+	}
+	leftAt := strings.Index(got.Summary, leftAgent.Summary)
+	fallbackAt := strings.Index(got.Summary, "Conversation digest (extractive fallback; provider compaction summary unavailable):")
+	rightAt := strings.Index(got.Summary, rightAgent.Summary)
+	if leftAt < 0 || fallbackAt < 0 || rightAt < 0 || !(leftAt < fallbackAt && fallbackAt < rightAt) {
+		t.Fatalf("unstructured summaries changed or reordered:\n%s", got.Summary)
+	}
+	if len(got.Fragments) != 4 {
+		t.Fatalf("mixed provenance fragments = %d, want 4", len(got.Fragments))
+	}
+}
+
+func TestMergeDigestsDoesNotParseFallbackLookalike(t *testing.T) {
+	lookalike := extractiveFallbackSummary([]string{"Valid-looking item."}, nil) +
+		"\nAgent commentary outside the deterministic sections."
+	valid := extractiveFallbackSummary([]string{"Actual deterministic item."}, nil)
+	got := MergeDigests(
+		MemoryDigest{SnapshotID: ContentHash("sha256:" + strings.Repeat("3", 64)), Summary: lookalike},
+		MemoryDigest{SnapshotID: ContentHash("sha256:" + strings.Repeat("4", 64)), Summary: valid},
+	)
+	if !strings.Contains(got.Summary, lookalike) {
+		t.Fatalf("fallback lookalike was rewritten:\n%s", got.Summary)
+	}
+	if !strings.Contains(got.Summary, valid) {
+		t.Fatalf("valid fallback was lost beside lookalike:\n%s", got.Summary)
+	}
+}
+
+func extractiveFallbackSummary(users, assistants []string) string {
+	var b strings.Builder
+	b.WriteString("Conversation digest (extractive fallback; provider compaction summary unavailable):\n")
+	if len(users) > 0 {
+		b.WriteString("\n\nRecent user intent:\n")
+		for _, item := range users {
+			b.WriteString("- ")
+			b.WriteString(item)
+			b.WriteByte('\n')
+		}
+	}
+	if len(assistants) > 0 {
+		b.WriteString("\n\nRecent assistant outcomes:\n")
+		for _, item := range assistants {
+			b.WriteString("- ")
+			b.WriteString(item)
+			b.WriteByte('\n')
+		}
+	}
+	return strings.TrimSpace(b.String())
 }


### PR DESCRIPTION
## Summary

- centralize the deterministic extractive fallback wire format without changing its bytes
- keep immutable provenance fragments while rendering repeated fallback sections as one exact-item union
- deduplicate repeated user intent and assistant outcome lines across linear and graft/sibling memory projections
- place the combined fallback at the newest fallback position so bounded tail rendering retains recent unique context
- fail closed to the existing unstructured path when a summary contains any unexpected prose or section order

## Dogfood evidence

The current main memory at snapshot `78af28c9ef` contains 7 provenance fragments and 3 cumulative fallback generations. The same user-intent items appear in every generation. Re-rendering the unchanged fragments with this patch changes the active compatibility summary from 8,970 to 7,493 bytes and fallback headers from 3 to 1, while preserving every unique outcome.

A read-only restart rehearsal separately confirmed the source 6.5 MB Codex session already materializes to a bounded 39,155-byte seed with one cxt seed marker; this PR addresses semantic working-set duplication, not an unbounded seed or immediate-compaction claim.

## Invariants

- historical memory objects and fragment provenance are not rewritten or deleted
- no fuzzy or model-dependent deduplication
- agent-written/unstructured summaries retain their bytes and relative order
- key-fact/open-task authority is unchanged
- the existing fresh fallback text wire format is byte-for-byte stable

## Verification

- focused linear, sibling, mixed, malformed-lookalike, chronology, and wire-format tests
- CLI full test, vet, and race suites
- sync E2E
- full API E2E
- public tree/history preflight
- deploy static/Terraform/web checks

Closes #62
