### PR TITLE
fix(memory): preserve graft lineage past stale memory boundaries

### DIFF
--- a/backend/internal/adapters/store/memory_chunks.go
+++ b/backend/internal/adapters/store/memory_chunks.go
@@ -22,6 +22,29 @@ func validateMemoryDigestRefs(digest domain.MemoryDigest) error {
 			return err
 		}
 	}
+	if coverage := digest.GraftCoverage; coverage != nil {
+		if coverage.ProjectionVersion == 0 || coverage.GraftSeq > domain.MaxGraftSeq {
+			return domain.ErrIntegrity
+		}
+		if coverage.ProjectionComplete && coverage.LineageFingerprint == "" {
+			return domain.ErrIntegrity
+		}
+		if coverage.LineageFingerprint != "" {
+			if err := validateHash(coverage.LineageFingerprint); err != nil {
+				return err
+			}
+		}
+		for _, parent := range coverage.GraftParents {
+			if err := validateHash(parent); err != nil {
+				return err
+			}
+		}
+		for _, source := range coverage.PinnedSources {
+			if err := validateHash(source); err != nil {
+				return err
+			}
+		}
+	}
 	return nil
 }
 
@@ -166,7 +189,7 @@ func (s *FSStore) repackMemoryRepo(repoID domain.ContentHash) (converted int, sa
 				for _, chunkHash := range append(manifest.SummaryChunks, manifest.FragmentChunks...) {
 					live[chunkHash] = true
 				}
-				if manifest.Format != domain.MemoryChunkFormatV1 {
+				if !domain.SupportedMemoryChunkFormat(manifest.Format) {
 					sweepSafe = false
 				}
 			} else {

--- a/backend/internal/adapters/store/memory_chunks_test.go
+++ b/backend/internal/adapters/store/memory_chunks_test.go
@@ -23,6 +23,14 @@ func largeServerMemory(label string, extra int) domain.MemoryDigest {
 			SourceSnapshot: domain.HashContent([]byte("source-" + label)),
 			Summary:        strings.Repeat("fragment-", 10<<10),
 		}},
+		GraftCoverage: &domain.MemoryGraftCoverage{
+			ProjectionVersion:  domain.MemoryProjectionVersion,
+			ProjectionComplete: true,
+			LineageFingerprint: domain.HashContent([]byte("lineage-" + label)),
+			GraftSeq:           3,
+			GraftParents:       []domain.ContentHash{domain.HashContent([]byte("graft-" + label))},
+			PinnedSources:      []domain.ContentHash{domain.HashContent([]byte("pinned-" + label))},
+		},
 	}
 }
 

--- a/backend/internal/app/memory_storage_test.go
+++ b/backend/internal/app/memory_storage_test.go
@@ -25,6 +25,14 @@ func TestMemoryDigestUsesSnapshotPointerWithoutMetaDoubleWrite(t *testing.T) {
 		KeyFacts:   []string{"snapshot.memory_hash resolves the body"},
 		OpenTasks:  []string{},
 		Provider:   domain.ProviderCodex,
+		GraftCoverage: &domain.MemoryGraftCoverage{
+			ProjectionVersion:  domain.MemoryProjectionVersion,
+			ProjectionComplete: true,
+			LineageFingerprint: hh("memory-lineage-state"),
+			GraftSeq:           4,
+			GraftParents:       []domain.ContentHash{hh("memory-graft-parent")},
+			PinnedSources:      []domain.ContentHash{hh("memory-pinned-source")},
+		},
 	}
 	hash, err := svc.PutMemoryDigest(ctx, repo, digest)
 	if err != nil {
@@ -38,8 +46,58 @@ func TestMemoryDigestUsesSnapshotPointerWithoutMetaDoubleWrite(t *testing.T) {
 		t.Fatalf("memory pointer=%s want=%s err=%v", snapshot.MemoryHash, hash, err)
 	}
 	got, err := svc.GetMemoryDigest(ctx, repo, snapshotID)
-	if err != nil || got.Summary != digest.Summary {
+	if err != nil || got.Summary != digest.Summary || got.GraftCoverage == nil ||
+		!got.GraftCoverage.ProjectionComplete ||
+		got.GraftCoverage.GraftSeq != digest.GraftCoverage.GraftSeq ||
+		len(got.GraftCoverage.GraftParents) != 1 || got.GraftCoverage.GraftParents[0] != digest.GraftCoverage.GraftParents[0] ||
+		len(got.GraftCoverage.PinnedSources) != 1 || got.GraftCoverage.PinnedSources[0] != digest.GraftCoverage.PinnedSources[0] {
 		t.Fatalf("pointer-backed GetMemoryDigest: %+v err=%v", got, err)
+	}
+}
+
+func TestMemoryDigestAcceptsExplicitIncompleteProjectionWithoutFingerprint(t *testing.T) {
+	svc, st := newFsckSvc(t)
+	ctx := context.Background()
+	repo := hh("incomplete-memory-coverage-repo")
+	snapshotID := hh("incomplete-memory-coverage-snapshot")
+	if err := st.PutSnapshot(ctx, domain.Snapshot{ID: snapshotID, RepoID: repo, DocHash: snapshotID}); err != nil {
+		t.Fatal(err)
+	}
+	digest := domain.MemoryDigest{
+		SnapshotID: snapshotID, Summary: "available partial projection", Provider: domain.ProviderCodex,
+		GraftCoverage: &domain.MemoryGraftCoverage{
+			ProjectionVersion: domain.MemoryProjectionVersion,
+			GraftSeq:          1,
+		},
+	}
+	if _, err := svc.PutMemoryDigest(ctx, repo, digest); err != nil {
+		t.Fatalf("explicit incomplete coverage was rejected: %v", err)
+	}
+}
+
+func TestMemoryDigestRejectsInvalidGraftCoverageBeforeStorage(t *testing.T) {
+	svc, st := newFsckSvc(t)
+	ctx := context.Background()
+	repo := hh("invalid-memory-coverage-repo")
+	snapshotID := hh("invalid-memory-coverage-snapshot")
+	if err := st.PutSnapshot(ctx, domain.Snapshot{ID: snapshotID, RepoID: repo, DocHash: snapshotID}); err != nil {
+		t.Fatal(err)
+	}
+	for name, coverage := range map[string]*domain.MemoryGraftCoverage{
+		"missing version":       {LineageFingerprint: hh("lineage"), GraftSeq: 1},
+		"missing fingerprint":   {ProjectionVersion: 1, ProjectionComplete: true, GraftSeq: 1},
+		"sequence overflow":     {ProjectionVersion: 1, LineageFingerprint: hh("lineage"), GraftSeq: domain.MaxGraftSeq + 1},
+		"invalid parent":        {ProjectionVersion: 1, LineageFingerprint: hh("lineage"), GraftParents: []domain.ContentHash{"not-a-hash"}},
+		"invalid pinned source": {ProjectionVersion: 1, LineageFingerprint: hh("lineage"), PinnedSources: []domain.ContentHash{"not-a-hash"}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := svc.PutMemoryDigest(ctx, repo, domain.MemoryDigest{
+				SnapshotID: snapshotID, Summary: "invalid", Provider: domain.ProviderCodex, GraftCoverage: coverage,
+			})
+			if err == nil {
+				t.Fatal("invalid graft coverage was accepted")
+			}
+		})
 	}
 }
 

--- a/backend/internal/app/service.go
+++ b/backend/internal/app/service.go
@@ -1058,6 +1058,29 @@ func (s *Service) PutMemoryDigest(ctx context.Context, repoID domain.ContentHash
 			return "", err
 		}
 	}
+	if coverage := d.GraftCoverage; coverage != nil {
+		if coverage.ProjectionVersion == 0 || coverage.GraftSeq > domain.MaxGraftSeq {
+			return "", fmt.Errorf("%w: invalid memory graft coverage version or sequence", domain.ErrIntegrity)
+		}
+		if coverage.ProjectionComplete && coverage.LineageFingerprint == "" {
+			return "", fmt.Errorf("%w: complete memory projection is missing its lineage fingerprint", domain.ErrIntegrity)
+		}
+		if coverage.LineageFingerprint != "" {
+			if err := domain.ValidateContentHash(coverage.LineageFingerprint); err != nil {
+				return "", err
+			}
+		}
+		for _, parent := range coverage.GraftParents {
+			if err := domain.ValidateContentHash(parent); err != nil {
+				return "", err
+			}
+		}
+		for _, source := range coverage.PinnedSources {
+			if err := domain.ValidateContentHash(source); err != nil {
+				return "", err
+			}
+		}
+	}
 	if _, err := s.meta.GetSnapshot(ctx, repoID, d.SnapshotID); err != nil {
 		return "", err // ErrNotFound → 404
 	}

--- a/backend/internal/domain/entities.go
+++ b/backend/internal/domain/entities.go
@@ -5,6 +5,8 @@ import "time"
 // MaxGraftSeq is the upper bound of the graft Lamport version that PostgreSQL BIGINT and FS/CLI JSON replicas can share. Wrapping around at the upper bound could cause removed edges to revive as legacy seq=0, so mutations are fail-closed.
 const MaxGraftSeq uint64 = 1<<63 - 1
 
+const MemoryProjectionVersion uint32 = 1
+
 // Repo is the root of the session storage space (data model, sync protocol).
 //
 // One per detected code repository. Namespace root for all branch/snapshot/ref names.
@@ -237,12 +239,26 @@ type Manifest struct {
 //
 // The backend stores only CIR-neutral digests and does not know provider-native formats.
 type MemoryDigest struct {
-	SnapshotID ContentHash      `json:"snapshot_id"`
-	Summary    string           `json:"summary"`
-	KeyFacts   []string         `json:"key_facts"`
-	OpenTasks  []string         `json:"open_tasks"`
-	Provider   ProviderKind     `json:"provider"`
-	Fragments  []MemoryFragment `json:"fragments,omitempty"`
+	SnapshotID    ContentHash          `json:"snapshot_id"`
+	Summary       string               `json:"summary"`
+	KeyFacts      []string             `json:"key_facts"`
+	OpenTasks     []string             `json:"open_tasks"`
+	Provider      ProviderKind         `json:"provider"`
+	Fragments     []MemoryFragment     `json:"fragments,omitempty"`
+	GraftCoverage *MemoryGraftCoverage `json:"graft_coverage,omitempty"`
+}
+
+// MemoryGraftCoverage is the root graft register and transitive lineage state
+// observed when a client projected and attached a digest. ProjectionComplete
+// distinguishes a trusted fingerprint from retained partial data. Nil means
+// legacy/unknown.
+type MemoryGraftCoverage struct {
+	ProjectionVersion  uint32        `json:"projection_version"`
+	ProjectionComplete bool          `json:"projection_complete"`
+	LineageFingerprint ContentHash   `json:"lineage_fingerprint,omitempty"`
+	GraftSeq           uint64        `json:"graft_seq"`
+	GraftParents       []ContentHash `json:"graft_parents,omitempty"`
+	PinnedSources      []ContentHash `json:"pinned_sources,omitempty"`
 }
 
 // MemoryFragment is one snapshot-scoped memory contribution. The backend

--- a/backend/internal/domain/hash_test.go
+++ b/backend/internal/domain/hash_test.go
@@ -3,6 +3,7 @@ package domain
 import (
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 )
 
@@ -19,6 +20,26 @@ func TestValidateSessionDocHash(t *testing.T) {
 	doc.Hash = HashContent([]byte("different"))
 	if err := ValidateSessionDocHash(doc); !errors.Is(err, ErrIntegrity) {
 		t.Fatalf("mismatched doc error = %v, want ErrIntegrity", err)
+	}
+}
+
+func TestMemoryDigestCoverageWireHashParity(t *testing.T) {
+	h := func(c string) ContentHash { return ContentHash("sha256:" + strings.Repeat(c, 64)) }
+	digest := MemoryDigest{
+		SnapshotID: h("a"), Summary: "summary", KeyFacts: []string{"fact"}, OpenTasks: []string{}, Provider: ProviderCodex,
+		Fragments: []MemoryFragment{{SourceSnapshot: h("b"), Summary: "fragment"}},
+		GraftCoverage: &MemoryGraftCoverage{
+			ProjectionVersion: MemoryProjectionVersion, ProjectionComplete: true, LineageFingerprint: h("c"), GraftSeq: 2,
+			GraftParents: []ContentHash{h("d")}, PinnedSources: []ContentHash{h("e")},
+		},
+	}
+	wire := `{"snapshot_id":"` + string(h("a")) + `","summary":"summary","key_facts":["fact"],"open_tasks":[],"provider":"codex","fragments":[{"source_snapshot":"` + string(h("b")) + `","summary":"fragment"}],"graft_coverage":{"projection_version":1,"projection_complete":true,"lineage_fingerprint":"` + string(h("c")) + `","graft_seq":2,"graft_parents":["` + string(h("d")) + `"],"pinned_sources":["` + string(h("e")) + `"]}}`
+	got, err := MemoryDigestHash(digest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := HashContent([]byte(wire)); got != want {
+		t.Fatalf("coverage wire hash = %s, want %s", got, want)
 	}
 }
 

--- a/backend/internal/domain/memory_chunks.go
+++ b/backend/internal/domain/memory_chunks.go
@@ -9,18 +9,22 @@ import (
 
 const MemoryChunkTarget = 64 << 10
 
-const MemoryChunkFormatV1 = "cxt-memory-chunks-v1"
+const (
+	MemoryChunkFormatV1 = "cxt-memory-chunks-v1"
+	MemoryChunkFormatV2 = "cxt-memory-chunks-v2"
+)
 
 // MemoryChunkManifest is an at-rest representation. MemoryDigestHash remains
 // the hash of complete wire JSON; storage chunking never changes identity.
 type MemoryChunkManifest struct {
-	Format         string        `json:"format"`
-	SnapshotID     ContentHash   `json:"snapshot_id"`
-	SummaryChunks  []ContentHash `json:"summary_chunks,omitempty"`
-	KeyFacts       []string      `json:"key_facts"`
-	OpenTasks      []string      `json:"open_tasks"`
-	Provider       ProviderKind  `json:"provider"`
-	FragmentChunks []ContentHash `json:"fragment_chunks,omitempty"`
+	Format         string               `json:"format"`
+	SnapshotID     ContentHash          `json:"snapshot_id"`
+	SummaryChunks  []ContentHash        `json:"summary_chunks,omitempty"`
+	KeyFacts       []string             `json:"key_facts"`
+	OpenTasks      []string             `json:"open_tasks"`
+	Provider       ProviderKind         `json:"provider"`
+	FragmentChunks []ContentHash        `json:"fragment_chunks,omitempty"`
+	GraftCoverage  *MemoryGraftCoverage `json:"graft_coverage,omitempty"`
 }
 
 type MemoryChunkPlan struct {
@@ -42,11 +46,12 @@ func PlanMemoryChunks(d MemoryDigest) (plan MemoryChunkPlan, ok bool, err error)
 	}
 	plan = MemoryChunkPlan{
 		Manifest: MemoryChunkManifest{
-			Format:     MemoryChunkFormatV1,
-			SnapshotID: d.SnapshotID,
-			KeyFacts:   d.KeyFacts,
-			OpenTasks:  d.OpenTasks,
-			Provider:   d.Provider,
+			Format:        memoryChunkFormatFor(d),
+			SnapshotID:    d.SnapshotID,
+			KeyFacts:      d.KeyFacts,
+			OpenTasks:     d.OpenTasks,
+			Provider:      d.Provider,
+			GraftCoverage: d.GraftCoverage,
 		},
 		Bodies: map[ContentHash][]byte{},
 	}
@@ -65,6 +70,17 @@ func PlanMemoryChunks(d MemoryDigest) (plan MemoryChunkPlan, ok bool, err error)
 		return MemoryChunkPlan{}, false, ErrIntegrity
 	}
 	return plan, true, nil
+}
+
+func memoryChunkFormatFor(d MemoryDigest) string {
+	if d.GraftCoverage != nil {
+		return MemoryChunkFormatV2
+	}
+	return MemoryChunkFormatV1
+}
+
+func SupportedMemoryChunkFormat(format string) bool {
+	return format == MemoryChunkFormatV1 || format == MemoryChunkFormatV2
 }
 
 func (p *MemoryChunkPlan) addComponent(data []byte) []ContentHash {
@@ -104,7 +120,7 @@ func ParseMemoryChunkManifest(data []byte) (MemoryChunkManifest, bool, error) {
 	if !strings.HasPrefix(probe.Format, "cxt-memory-chunks-") {
 		return MemoryChunkManifest{}, false, nil
 	}
-	if probe.Format != MemoryChunkFormatV1 {
+	if !SupportedMemoryChunkFormat(probe.Format) {
 		return MemoryChunkManifest{}, true, fmt.Errorf("unsupported memory manifest format %q", probe.Format)
 	}
 	var man MemoryChunkManifest
@@ -147,11 +163,12 @@ func AssembleMemoryChunks(man MemoryChunkManifest, bodies map[ContentHash][]byte
 		}
 	}
 	return MemoryDigest{
-		SnapshotID: man.SnapshotID,
-		Summary:    string(summary),
-		KeyFacts:   man.KeyFacts,
-		OpenTasks:  man.OpenTasks,
-		Provider:   man.Provider,
-		Fragments:  fragments,
+		SnapshotID:    man.SnapshotID,
+		Summary:       string(summary),
+		KeyFacts:      man.KeyFacts,
+		OpenTasks:     man.OpenTasks,
+		Provider:      man.Provider,
+		Fragments:     fragments,
+		GraftCoverage: man.GraftCoverage,
 	}, nil
 }

--- a/backend/internal/domain/memory_chunks_test.go
+++ b/backend/internal/domain/memory_chunks_test.go
@@ -17,6 +17,14 @@ func TestMemoryComponentPlanRoundtripAndPrefixDedup(t *testing.T) {
 			SourceSnapshot: HashContent([]byte("memory-source")),
 			Summary:        strings.Repeat("fragment", 12<<10),
 		}},
+		GraftCoverage: &MemoryGraftCoverage{
+			ProjectionVersion:  MemoryProjectionVersion,
+			ProjectionComplete: true,
+			LineageFingerprint: HashContent([]byte("lineage-state")),
+			GraftSeq:           2,
+			GraftParents:       []ContentHash{HashContent([]byte("graft-parent"))},
+			PinnedSources:      []ContentHash{HashContent([]byte("pinned-source"))},
+		},
 	}
 	second := first
 	second.SnapshotID = HashContent([]byte("memory-second"))
@@ -30,7 +38,7 @@ func TestMemoryComponentPlanRoundtripAndPrefixDedup(t *testing.T) {
 	if err != nil || !ok {
 		t.Fatalf("PlanMemoryChunks(second): ok=%v err=%v", ok, err)
 	}
-	if p1.Manifest.Format != MemoryChunkFormatV1 {
+	if p1.Manifest.Format != MemoryChunkFormatV2 {
 		t.Fatalf("format=%q", p1.Manifest.Format)
 	}
 	for hash, body := range p2.Bodies {
@@ -58,6 +66,18 @@ func TestMemoryComponentPlanRoundtripAndPrefixDedup(t *testing.T) {
 	gotHash, _ := MemoryDigestHash(got)
 	if gotHash != wantHash {
 		t.Fatalf("identity changed: got %s want %s", gotHash, wantHash)
+	}
+}
+
+func TestMemoryComponentPlanKeepsLegacyManifestVersionWithoutCoverage(t *testing.T) {
+	digest := MemoryDigest{
+		SnapshotID: HashContent([]byte("legacy-format")),
+		Summary:    strings.Repeat("legacy", 16<<10),
+		Provider:   ProviderCodex,
+	}
+	plan, ok, err := PlanMemoryChunks(digest)
+	if err != nil || !ok || plan.Manifest.Format != MemoryChunkFormatV1 {
+		t.Fatalf("legacy plan: format=%q ok=%v err=%v", plan.Manifest.Format, ok, err)
 	}
 }
 

--- a/cli/internal/adapters/chunkcas/memory.go
+++ b/cli/internal/adapters/chunkcas/memory.go
@@ -15,20 +15,27 @@ import (
 // large number of tiny files.
 const MemoryChunkTarget = 64 << 10
 
-const MemoryFormatV1 = "cxt-memory-chunks-v1"
+const (
+	MemoryFormatV1 = "cxt-memory-chunks-v1"
+	// V2 adds the inline graft-coverage proof. Old readers must reject it as an
+	// unsupported format instead of dropping the proof and reporting a false
+	// content-hash corruption after reassembly.
+	MemoryFormatV2 = "cxt-memory-chunks-v2"
+)
 
 // MemoryManifest is an at-rest representation only. The wire protocol keeps
 // sending a complete MemoryDigest, and MemoryDigestHash remains the identity.
 // Potentially large, prefix-sharing components are chunked independently;
 // small structured fields stay inline.
 type MemoryManifest struct {
-	Format         string               `json:"format"`
-	SnapshotID     domain.ContentHash   `json:"snapshot_id"`
-	SummaryChunks  []domain.ContentHash `json:"summary_chunks,omitempty"`
-	KeyFacts       []string             `json:"key_facts"`
-	OpenTasks      []string             `json:"open_tasks"`
-	Provider       domain.ProviderKind  `json:"provider"`
-	FragmentChunks []domain.ContentHash `json:"fragment_chunks,omitempty"`
+	Format         string                      `json:"format"`
+	SnapshotID     domain.ContentHash          `json:"snapshot_id"`
+	SummaryChunks  []domain.ContentHash        `json:"summary_chunks,omitempty"`
+	KeyFacts       []string                    `json:"key_facts"`
+	OpenTasks      []string                    `json:"open_tasks"`
+	Provider       domain.ProviderKind         `json:"provider"`
+	FragmentChunks []domain.ContentHash        `json:"fragment_chunks,omitempty"`
+	GraftCoverage  *domain.MemoryGraftCoverage `json:"graft_coverage,omitempty"`
 }
 
 type MemoryPlan struct {
@@ -53,11 +60,12 @@ func PlanMemory(d domain.MemoryDigest) (plan MemoryPlan, ok bool, err error) {
 	}
 	plan = MemoryPlan{
 		Manifest: MemoryManifest{
-			Format:     MemoryFormatV1,
-			SnapshotID: d.SnapshotID,
-			KeyFacts:   d.KeyFacts,
-			OpenTasks:  d.OpenTasks,
-			Provider:   d.Provider,
+			Format:        memoryFormatFor(d),
+			SnapshotID:    d.SnapshotID,
+			KeyFacts:      d.KeyFacts,
+			OpenTasks:     d.OpenTasks,
+			Provider:      d.Provider,
+			GraftCoverage: d.GraftCoverage,
 		},
 		Bodies: map[domain.ContentHash][]byte{},
 	}
@@ -77,6 +85,17 @@ func PlanMemory(d domain.MemoryDigest) (plan MemoryPlan, ok bool, err error) {
 		return MemoryPlan{}, false, domain.ErrHashMismatch
 	}
 	return plan, true, nil
+}
+
+func memoryFormatFor(d domain.MemoryDigest) string {
+	if d.GraftCoverage != nil {
+		return MemoryFormatV2
+	}
+	return MemoryFormatV1
+}
+
+func SupportedMemoryFormat(format string) bool {
+	return format == MemoryFormatV1 || format == MemoryFormatV2
 }
 
 func (p *MemoryPlan) addComponent(data []byte) []domain.ContentHash {
@@ -119,7 +138,7 @@ func ParseMemoryManifest(data []byte) (MemoryManifest, bool, error) {
 	if !strings.HasPrefix(probe.Format, "cxt-memory-chunks-") {
 		return MemoryManifest{}, false, nil
 	}
-	if probe.Format != MemoryFormatV1 {
+	if !SupportedMemoryFormat(probe.Format) {
 		return MemoryManifest{}, true, fmt.Errorf("unsupported memory manifest format %q", probe.Format)
 	}
 	var man MemoryManifest
@@ -165,11 +184,12 @@ func AssembleMemory(man MemoryManifest, bodies map[domain.ContentHash][]byte) (d
 		}
 	}
 	return domain.MemoryDigest{
-		SnapshotID: man.SnapshotID,
-		Summary:    string(summary),
-		KeyFacts:   man.KeyFacts,
-		OpenTasks:  man.OpenTasks,
-		Provider:   man.Provider,
-		Fragments:  fragments,
+		SnapshotID:    man.SnapshotID,
+		Summary:       string(summary),
+		KeyFacts:      man.KeyFacts,
+		OpenTasks:     man.OpenTasks,
+		Provider:      man.Provider,
+		Fragments:     fragments,
+		GraftCoverage: man.GraftCoverage,
 	}, nil
 }

--- a/cli/internal/adapters/chunkcas/memory_test.go
+++ b/cli/internal/adapters/chunkcas/memory_test.go
@@ -19,6 +19,14 @@ func TestMemoryComponentPlanRoundtripAndPrefixDedup(t *testing.T) {
 			SourceSnapshot: domain.HashContent([]byte("memory-source")),
 			Summary:        strings.Repeat("fragment", 12<<10),
 		}},
+		GraftCoverage: &domain.MemoryGraftCoverage{
+			ProjectionVersion:  domain.MemoryProjectionVersion,
+			ProjectionComplete: true,
+			LineageFingerprint: domain.HashContent([]byte("lineage-state")),
+			GraftSeq:           2,
+			GraftParents:       []domain.ContentHash{domain.HashContent([]byte("graft-parent"))},
+			PinnedSources:      []domain.ContentHash{domain.HashContent([]byte("pinned-source"))},
+		},
 	}
 	second := first
 	second.SnapshotID = domain.HashContent([]byte("memory-second"))
@@ -32,7 +40,7 @@ func TestMemoryComponentPlanRoundtripAndPrefixDedup(t *testing.T) {
 	if err != nil || !ok {
 		t.Fatalf("PlanMemory(second): ok=%v err=%v", ok, err)
 	}
-	if p1.Manifest.Format != MemoryFormatV1 {
+	if p1.Manifest.Format != MemoryFormatV2 {
 		t.Fatalf("format=%q", p1.Manifest.Format)
 	}
 	for hash, body := range p2.Bodies {
@@ -60,6 +68,18 @@ func TestMemoryComponentPlanRoundtripAndPrefixDedup(t *testing.T) {
 	gotHash, _ := domain.MemoryDigestHash(got)
 	if gotHash != wantHash {
 		t.Fatalf("identity changed: got %s want %s", gotHash, wantHash)
+	}
+}
+
+func TestMemoryComponentPlanKeepsLegacyManifestVersionWithoutCoverage(t *testing.T) {
+	digest := domain.MemoryDigest{
+		SnapshotID: domain.HashContent([]byte("legacy-format")),
+		Summary:    strings.Repeat("legacy", 16<<10),
+		Provider:   domain.ProviderCodex,
+	}
+	plan, ok, err := PlanMemory(digest)
+	if err != nil || !ok || plan.Manifest.Format != MemoryFormatV1 {
+		t.Fatalf("legacy plan: format=%q ok=%v err=%v", plan.Manifest.Format, ok, err)
 	}
 }
 

--- a/cli/internal/adapters/storage/memory_chunks.go
+++ b/cli/internal/adapters/storage/memory_chunks.go
@@ -21,6 +21,29 @@ func validateMemoryDigestRefs(digest domain.MemoryDigest) error {
 			return err
 		}
 	}
+	if coverage := digest.GraftCoverage; coverage != nil {
+		if coverage.ProjectionVersion == 0 || coverage.GraftSeq > domain.MaxGraftSeq {
+			return domain.ErrHashMismatch
+		}
+		if coverage.ProjectionComplete && coverage.LineageFingerprint == "" {
+			return domain.ErrHashMismatch
+		}
+		if coverage.LineageFingerprint != "" {
+			if err := domain.ValidateContentHash(coverage.LineageFingerprint); err != nil {
+				return err
+			}
+		}
+		for _, parent := range coverage.GraftParents {
+			if err := domain.ValidateContentHash(parent); err != nil {
+				return err
+			}
+		}
+		for _, source := range coverage.PinnedSources {
+			if err := domain.ValidateContentHash(source); err != nil {
+				return err
+			}
+		}
+	}
 	return nil
 }
 
@@ -138,7 +161,7 @@ func (s *FileStore) RepackMemories() (converted int, saved int64, err error) {
 				for _, chunkHash := range append(manifest.SummaryChunks, manifest.FragmentChunks...) {
 					live[chunkHash] = true
 				}
-				if manifest.Format != chunkcas.MemoryFormatV1 {
+				if !chunkcas.SupportedMemoryFormat(manifest.Format) {
 					sweepSafe = false
 				}
 			} else {

--- a/cli/internal/adapters/storage/memory_chunks_test.go
+++ b/cli/internal/adapters/storage/memory_chunks_test.go
@@ -24,6 +24,14 @@ func largeMemory(label string, extra int) domain.MemoryDigest {
 			SourceSnapshot: domain.HashContent([]byte("source-" + label)),
 			Summary:        strings.Repeat("fragment-", 10<<10),
 		}},
+		GraftCoverage: &domain.MemoryGraftCoverage{
+			ProjectionVersion:  domain.MemoryProjectionVersion,
+			ProjectionComplete: true,
+			LineageFingerprint: domain.HashContent([]byte("lineage-" + label)),
+			GraftSeq:           3,
+			GraftParents:       []domain.ContentHash{domain.HashContent([]byte("graft-" + label))},
+			PinnedSources:      []domain.ContentHash{domain.HashContent([]byte("pinned-" + label))},
+		},
 	}
 }
 

--- a/cli/internal/app/branch_seed.go
+++ b/cli/internal/app/branch_seed.go
@@ -91,14 +91,14 @@ func (s *BranchSeedService) Seed(ctx context.Context, in inbound.SeedInput) (inb
 	}
 	if mainSnap.ID != "" {
 		if mainSnap.MemoryHash != "" {
-			if d, derr := s.store.GetMemory(ctx, mainSnap.MemoryHash); derr == nil {
+			if d, ok := snapshotMemoryProjection(ctx, s.store, mainSnap); ok {
 				mainMem = &d
 			}
 		}
 		if mainMem == nil && mainDocAvailable {
 			if d, derr := s.distiller.Distill(ctx, mainDoc.CIR, nil); derr == nil {
 				d.SnapshotID = mainSnap.ID
-				if prior, ok := ancestorMemoryProjection(ctx, s.store, mainSnap); ok {
+				if prior, ok := priorMemoryProjection(ctx, s.store, mainSnap); ok {
 					prior = boundCarriedDigest(prior)
 					d = domain.MergeDigests(prior, d)
 				}
@@ -113,10 +113,19 @@ func (s *BranchSeedService) Seed(ctx context.Context, in inbound.SeedInput) (inb
 		return inbound.SeedOutput{}, err
 	}
 	branchMem.SnapshotID = fromSnap.ID
-	if prior, ok := ancestorMemoryProjection(ctx, s.store, fromSnap); ok {
+	branchState, prior, hasBranchPrior, branchProjectionComplete, err := stablePriorMemoryProjection(ctx, s.store, fromSnap.ID)
+	if err != nil {
+		return inbound.SeedOutput{}, err
+	}
+	fromSnap = branchState.snap
+	if hasBranchPrior {
 		prior = boundCarriedDigest(prior)
 		branchMem = domain.MergeDigests(prior, branchMem)
 	}
+	// Preserve the departure snapshot as provenance even when it had no prior
+	// digest. The seed changes SnapshotID below, but inherited fragments must
+	// keep identifying their actual source for future stale-lineage repair.
+	branchMem = domain.MergeDigests(domain.MemoryDigest{}, branchMem)
 
 	// Seed CIR synthesis: [Layer1⊕Layer2 summary message] + [Layer3 bounded
 	// full session]. The summary has a fixed maximum, and the exact encoded
@@ -160,6 +169,16 @@ func (s *BranchSeedService) Seed(ctx context.Context, in inbound.SeedInput) (inb
 	if err != nil {
 		return inbound.SeedOutput{}, err
 	}
+	snap := domain.Snapshot{
+		ID: docHash, RepoID: repo.ID, Branch: in.NewBranch,
+		Parents: []domain.ContentHash{fromRef.Target}, DocHash: docHash,
+		Provider: provider, Fidelity: domain.FidelityReconstructed,
+		Message:   fmt.Sprintf("seed: %s → %s", in.FromBranch, in.NewBranch),
+		Author:    in.Author,
+		CreatedAt: time.Now().UTC(),
+		SessionID: seedSession,
+		Models:    fromDoc.CIR.Envelope.OrderedModels(),
+	}
 	// The materialized prompt is intentionally bounded, but the branch must not
 	// lose the inherited digest. Attach the merged main + departure-lineage
 	// memory to the seed snapshot so the next memorize/seed operation inherits
@@ -171,6 +190,8 @@ func (s *BranchSeedService) Seed(ctx context.Context, in inbound.SeedInput) (inb
 		seedMemory = domain.MergeDigests(boundCarriedDigest(*mainMem), branchMem)
 	}
 	seedMemory.SnapshotID = docHash
+	seedState := childMemoryProjectionState(snap, branchState)
+	seedMemory.GraftCoverage = memoryGraftCoverageFromState(ctx, s.store, seedState, seedMemory.Fragments, branchProjectionComplete)
 	if seedMemory.Provider == "" {
 		seedMemory.Provider = provider
 	}
@@ -178,16 +199,7 @@ func (s *BranchSeedService) Seed(ctx context.Context, in inbound.SeedInput) (inb
 	if err != nil {
 		return inbound.SeedOutput{}, err
 	}
-	snap := domain.Snapshot{
-		ID: docHash, RepoID: repo.ID, Branch: in.NewBranch,
-		Parents: []domain.ContentHash{fromRef.Target}, DocHash: docHash,
-		MemoryHash: memoryHash, Provider: provider, Fidelity: domain.FidelityReconstructed,
-		Message:   fmt.Sprintf("seed: %s → %s", in.FromBranch, in.NewBranch),
-		Author:    in.Author,
-		CreatedAt: time.Now().UTC(),
-		SessionID: seedSession,
-		Models:    fromDoc.CIR.Envelope.OrderedModels(),
-	}
+	snap.MemoryHash = memoryHash
 	if err := s.store.PutSnapshot(ctx, snap); err != nil {
 		return inbound.SeedOutput{}, err
 	}

--- a/cli/internal/app/branch_seed_inheritance_test.go
+++ b/cli/internal/app/branch_seed_inheritance_test.go
@@ -130,6 +130,18 @@ func TestBranchSeedFromMainIncludesStoredMemoryAndFullSession(t *testing.T) {
 			t.Fatalf("main conversation event %d = %+v, want %+v", i, got, want)
 		}
 	}
+	seedSnapshot, err := store.GetSnapshot(ctx, out.SnapshotID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	seedMemory, err := store.GetMemory(ctx, seedSnapshot.MemoryHash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	walker := memoryProjectionWalker{fingerprinter: newMemoryProjectionFingerprinter(ctx, store)}
+	if !walker.memoryDigestCoversLineage(seedMemory, seedSnapshot) {
+		t.Fatal("seed coverage omitted the departure parent's attached memory pointer")
+	}
 }
 
 func TestBranchSeedFromMainDistillsMemoryWhenHeadHasNoStoredDigest(t *testing.T) {
@@ -211,6 +223,91 @@ func TestBranchSeedFromOtherLineageIncludesMainMemoryAndLineageSession(t *testin
 	for i, want := range featureEvents {
 		if got := seed.CIR.Events[i+1].Blocks[0].Text; got != want.Blocks[0].Text {
 			t.Fatalf("feature conversation event %d = %q, want %q", i, got, want.Blocks[0].Text)
+		}
+	}
+
+	seedSnapshot, err := store.GetSnapshot(ctx, out.SnapshotID)
+	if err != nil {
+		t.Fatalf("get seed snapshot: %v", err)
+	}
+	seedMemory, err := store.GetMemory(ctx, seedSnapshot.MemoryHash)
+	if err != nil {
+		t.Fatalf("get seed memory: %v", err)
+	}
+	if seedMemory.GraftCoverage == nil || !seedMemory.GraftCoverage.ProjectionComplete {
+		t.Fatal("cross-lineage seed did not record memory coverage")
+	}
+	pinned := map[domain.ContentHash]bool{}
+	for _, source := range seedMemory.GraftCoverage.PinnedSources {
+		pinned[source] = true
+	}
+	if !pinned[mainHead] || !pinned[featureHead] || len(pinned) != 2 {
+		t.Fatalf("seed pinned sources = %v, want main %s and memoryless departure %s", seedMemory.GraftCoverage.PinnedSources, mainHead, featureHead)
+	}
+	walker := memoryProjectionWalker{fingerprinter: newMemoryProjectionFingerprinter(ctx, store)}
+	if !walker.memoryDigestCoversLineage(seedMemory, seedSnapshot) {
+		t.Fatal("synthetic seed coverage does not match its stored parent lineage")
+	}
+
+	// The seed coverage is now stale: a graft appears below its natural parent
+	// after the seed memory was attached. Reprojection must add that late branch
+	// without dropping the explicitly imported main memory or the departure
+	// snapshot's on-the-fly distillation.
+	lateGraft := putBranchSeedSnapshot(t, ctx, store, repo.ID, "feature/late", []domain.Event{
+		seedMessage("user", "late graft conversation", 0),
+	}, nil, &domain.MemoryDigest{Summary: "LATE GRAFT MEMORY", Provider: domain.ProviderCodex})
+	featureSnapshot, err := store.GetSnapshot(ctx, featureHead)
+	if err != nil {
+		t.Fatalf("get feature snapshot: %v", err)
+	}
+	featureSnapshot.Grafted = true
+	featureSnapshot.GraftSeq = 1
+	featureSnapshot.GraftParents = []domain.ContentHash{lateGraft}
+	if err := store.PutSnapshot(ctx, featureSnapshot); err != nil {
+		t.Fatalf("add late graft: %v", err)
+	}
+	seedSnapshot, err = store.GetSnapshot(ctx, out.SnapshotID)
+	if err != nil {
+		t.Fatalf("reload seed snapshot: %v", err)
+	}
+	projected, ok := snapshotMemoryProjection(ctx, store, seedSnapshot)
+	if !ok {
+		t.Fatal("stale cross-lineage seed memory was not reprojected")
+	}
+	for _, want := range []string{
+		"MAIN PROJECT MEMORY FOR EVERY NEW BRANCH",
+		"feature lineage digest",
+		"LATE GRAFT MEMORY",
+	} {
+		if count := strings.Count(projected.Summary, want); count != 1 {
+			t.Fatalf("reprojected seed summary contains %q %d times, want exactly once: %q", want, count, projected.Summary)
+		}
+	}
+
+	// Memorizing the seed snapshot itself replaces its fresh own contribution,
+	// but must not replace the imported memory owned only by that seed digest.
+	memorizer := NewMemorizeService(
+		branchSeedGit{repo: repo}, nil, nil, nil,
+		stubDistiller{d: domain.MemoryDigest{Summary: "RE-MEMORIZED SEED OWN MEMORY"}}, store,
+	)
+	memorized, err := memorizer.Memorize(ctx, inbound.MemorizeInput{
+		Cwd: repo.LocalPath, Provider: domain.ProviderCodex, Ref: string(out.SnapshotID),
+	})
+	if err != nil {
+		t.Fatalf("re-memorize seed: %v", err)
+	}
+	rememorized, err := store.GetMemory(ctx, memorized.MemoryHash)
+	if err != nil {
+		t.Fatalf("get re-memorized seed: %v", err)
+	}
+	for _, want := range []string{
+		"MAIN PROJECT MEMORY FOR EVERY NEW BRANCH",
+		"feature lineage digest",
+		"LATE GRAFT MEMORY",
+		"RE-MEMORIZED SEED OWN MEMORY",
+	} {
+		if count := strings.Count(rememorized.Summary, want); count != 1 {
+			t.Fatalf("re-memorized seed contains %q %d times, want exactly once: %q", want, count, rememorized.Summary)
 		}
 	}
 }
@@ -334,6 +431,10 @@ func TestBranchSeedMainMemoryAndConversationStayWithinBudget(t *testing.T) {
 	}
 	if seedMemory.SnapshotID != out.SnapshotID {
 		t.Fatalf("seed memory snapshot = %s, want %s", seedMemory.SnapshotID, out.SnapshotID)
+	}
+	if seedMemory.GraftCoverage == nil || seedMemory.GraftCoverage.ProjectionVersion != domain.MemoryProjectionVersion || !seedMemory.GraftCoverage.ProjectionComplete ||
+		seedMemory.GraftCoverage.LineageFingerprint == "" || seedMemory.GraftCoverage.GraftSeq != 0 || len(seedMemory.GraftCoverage.GraftParents) != 0 {
+		t.Fatalf("seed memory graft coverage = %+v, want explicit empty register", seedMemory.GraftCoverage)
 	}
 	if !strings.Contains(seedMemory.Summary, fullMainSummary) {
 		t.Fatalf("attached seed memory lost full main digest: got %d bytes, want at least %d", len(seedMemory.Summary), len(fullMainSummary))

--- a/cli/internal/app/load_session.go
+++ b/cli/internal/app/load_session.go
@@ -461,7 +461,7 @@ func (s *LoadSessionService) prependTrimDigest(ctx context.Context, omitted, see
 	// Prioritize the stored memorize digest (self-snapshot → parent projection).
 	stored, hasStored := domain.MemoryDigest{}, false
 	if snap.MemoryHash != "" {
-		if d, gerr := s.store.GetMemory(ctx, snap.MemoryHash); gerr == nil {
+		if d, ok := snapshotMemoryProjection(ctx, s.store, snap); ok {
 			stored, hasStored = d, true
 		}
 	}
@@ -535,7 +535,7 @@ func (s *LoadSessionService) loadMemory(ctx context.Context, cir domain.CIRDocum
 	digest.SnapshotID = snap.ID
 	// Heritage continuation (same logic as memorize): merge project memory from
 	// every parent lineage, including overlay grafts.
-	if prior, ok := ancestorMemoryProjection(ctx, s.store, snap); ok {
+	if prior, ok := priorMemoryProjection(ctx, s.store, snap); ok {
 		prior = boundCarriedDigest(prior)
 		digest = domain.MergeDigests(prior, digest)
 	}

--- a/cli/internal/app/memorize.go
+++ b/cli/internal/app/memorize.go
@@ -2,6 +2,8 @@ package app
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"strings"
 
 	"github.com/wnsdy95/cxthub/cli/internal/domain"
@@ -105,21 +107,42 @@ func (s *MemorizeService) Memorize(ctx context.Context, in inbound.MemorizeInput
 		return inbound.MemorizeOutput{}, err
 	}
 	digest.SnapshotID = snap.ID
+	// Every coverage-bearing digest needs snapshot-scoped provenance even when
+	// it has no inherited memory. Otherwise a future lineage mutation cannot
+	// separate this snapshot's own contribution from opaque inherited content.
+	digest = domain.MergeDigests(domain.MemoryDigest{}, digest)
 	// Project memory follows every natural/graft lineage and unions provenance
 	// fragments; choosing one globally closest digest loses sibling PR memory.
 	// Filter noisy prior KeyFacts so tool names and ingestion markers do not propagate forever across generations. Keep only sentence-form facts, using the same rules as the seed filter.
-	if prior, ok := ancestorMemoryProjection(ctx, s.store, snap); ok {
+	projectionState, prior, hasPrior, priorComplete, err := stablePriorMemoryProjection(ctx, s.store, snap.ID)
+	if err != nil {
+		return inbound.MemorizeOutput{}, err
+	}
+	snap = projectionState.snap
+	if hasPrior {
 		prior.KeyFacts = seedWorthyFacts(prior.KeyFacts)
 		prior = boundCarriedDigest(prior)
 		digest = domain.MergeDigests(prior, digest)
 	}
+	// Coverage is derived after the final fragment union. This records imports
+	// such as branch-seed main memory that current graph parents cannot replay;
+	// computing it before the merge would make those fragments disappear on the
+	// first later graft mutation.
+	digest.GraftCoverage = memoryGraftCoverageFromState(ctx, s.store, projectionState, digest.Fragments, priorComplete)
 	memHash, err := s.store.PutMemory(ctx, digest)
 	if err != nil {
 		return inbound.MemorizeOutput{}, err
 	}
 	// Attach to current branch HEAD snapshot (derivative pointer — ID/body immutable).
-	snap.MemoryHash = memHash
-	if err := s.store.PutSnapshot(ctx, snap); err != nil {
+	attachment := snap
+	attachment.MemoryHash = memHash
+	// A concurrent sync may have advanced the mutable graft register since the
+	// stable projection read. Memory attachment must never replay this stale
+	// register; PutSnapshot treats seq=0/no edges as a derivative-only update.
+	attachment.Grafted = false
+	attachment.GraftSeq = 0
+	attachment.GraftParents = nil
+	if err := s.store.PutSnapshot(ctx, attachment); err != nil {
 		return inbound.MemorizeOutput{}, err
 	}
 	return inbound.MemorizeOutput{SnapshotID: snap.ID, MemoryHash: memHash, Attached: true}, nil
@@ -128,49 +151,581 @@ func (s *MemorizeService) Memorize(ctx context.Context, in inbound.MemorizeInput
 // Ensure MemorizeService implements inbound.Memorize.
 var _ inbound.Memorize = (*MemorizeService)(nil)
 
-// ancestorMemoryProjection merges the nearest digest from every immediate
-// natural/graft lineage. A single global BFS winner loses memory from sibling
-// PRs. Fragment provenance makes common ancestors idempotent across branches.
+// ancestorMemoryProjection projects every nearest memory frontier behind the
+// snapshot. A digest is a valid traversal stop only when it proves coverage of
+// the memory-bearing snapshot's current mutable graft register.
 func ancestorMemoryProjection(ctx context.Context, store outbound.SessionStore, snap domain.Snapshot) (domain.MemoryDigest, bool) {
-	var projection domain.MemoryDigest
-	found := false
-	for _, parent := range snap.ReachabilityParents() {
-		digest, ok := nearestDigestFrom(ctx, store, parent)
-		if !ok {
-			continue
-		}
-		if !found {
-			projection = digest
-			found = true
-		} else {
-			projection = domain.MergeDigests(projection, digest)
+	digest, found, _ := ancestorMemoryProjectionDetailed(ctx, store, snap)
+	return digest, found
+}
+
+func ancestorMemoryProjectionDetailed(ctx context.Context, store outbound.SessionStore, snap domain.Snapshot) (domain.MemoryDigest, bool, bool) {
+	return memoryProjectionFromDetailed(ctx, store, snap.ReachabilityParents()...)
+}
+
+// snapshotMemoryProjection resolves a snapshot's own digest together with any
+// graft lineages added or superseded after that digest was attached.
+func snapshotMemoryProjection(ctx context.Context, store outbound.SessionStore, snap domain.Snapshot) (domain.MemoryDigest, bool) {
+	digest, found, _ := snapshotMemoryProjectionDetailed(ctx, store, snap)
+	return digest, found
+}
+
+func snapshotMemoryProjectionDetailed(ctx context.Context, store outbound.SessionStore, snap domain.Snapshot) (domain.MemoryDigest, bool, bool) {
+	return memoryProjectionFromDetailed(ctx, store, snap.ID)
+}
+
+// priorMemoryProjection returns everything a fresh distillation of snap must
+// inherit while replacing that snapshot's previous own contribution. Modern
+// digests can also own pinned imports that are not reachable from parents, so
+// reading ancestors alone is lossy when the same seed/head is memorized again.
+// Legacy cumulative digests have no provenance to separate own from inherited
+// content and retain the historical ancestor-only behavior.
+func priorMemoryProjection(ctx context.Context, store outbound.SessionStore, snap domain.Snapshot) (domain.MemoryDigest, bool) {
+	digest, found, _ := priorMemoryProjectionDetailed(ctx, store, snap)
+	return digest, found
+}
+
+func priorMemoryProjectionDetailed(ctx context.Context, store outbound.SessionStore, snap domain.Snapshot) (domain.MemoryDigest, bool, bool) {
+	if snap.MemoryHash == "" {
+		return ancestorMemoryProjectionDetailed(ctx, store, snap)
+	}
+	current, err := store.GetMemory(ctx, snap.MemoryHash)
+	if err != nil {
+		digest, found, _ := ancestorMemoryProjectionDetailed(ctx, store, snap)
+		return digest, found, false
+	}
+	if len(current.Fragments) == 0 {
+		return ancestorMemoryProjectionDetailed(ctx, store, snap)
+	}
+	projected, ok, complete := snapshotMemoryProjectionDetailed(ctx, store, snap)
+	if !ok {
+		return domain.MemoryDigest{}, false, complete
+	}
+	fragments := make([]domain.MemoryFragment, 0, len(projected.Fragments))
+	for _, fragment := range projected.Fragments {
+		if fragment.SourceSnapshot != snap.ID {
+			fragments = append(fragments, fragment)
 		}
 	}
-	return projection, found
+	if len(fragments) == 0 {
+		return domain.MemoryDigest{}, false, complete
+	}
+	prior := domain.MemoryDigest{SnapshotID: snap.ID, Provider: projected.Provider, Fragments: fragments}
+	return domain.MergeDigests(domain.MemoryDigest{}, prior), true, complete
 }
 
 func nearestDigestFrom(ctx context.Context, store outbound.SessionStore, start domain.ContentHash) (domain.MemoryDigest, bool) {
-	seen := map[domain.ContentHash]bool{}
-	queue := []domain.ContentHash{start}
-	for len(queue) > 0 {
-		id := queue[0]
-		queue = queue[1:]
-		if id == "" || seen[id] {
+	return memoryProjectionFrom(ctx, store, start)
+}
+
+type memoryProjectionWalker struct {
+	ctx            context.Context
+	store          outbound.SessionStore
+	seen           map[domain.ContentHash]bool
+	supplementSeen map[domain.ContentHash]bool
+	fingerprinter  *memoryProjectionFingerprinter
+	projection     domain.MemoryDigest
+	found          bool
+	complete       bool
+}
+
+func memoryProjectionFrom(ctx context.Context, store outbound.SessionStore, starts ...domain.ContentHash) (domain.MemoryDigest, bool) {
+	digest, found, _ := memoryProjectionFromDetailed(ctx, store, starts...)
+	return digest, found
+}
+
+func memoryProjectionFromDetailed(ctx context.Context, store outbound.SessionStore, starts ...domain.ContentHash) (domain.MemoryDigest, bool, bool) {
+	walker := memoryProjectionWalker{
+		ctx: ctx, store: store,
+		seen: map[domain.ContentHash]bool{}, supplementSeen: map[domain.ContentHash]bool{},
+		fingerprinter: newMemoryProjectionFingerprinter(ctx, store), complete: true,
+	}
+	for _, start := range starts {
+		walker.walk(start)
+	}
+	return walker.projection, walker.found, walker.complete
+}
+
+func (w *memoryProjectionWalker) walk(id domain.ContentHash) {
+	if id == "" || w.seen[id] {
+		return
+	}
+	w.seen[id] = true // Cycle guard: graft is mutable even though cycles are rejected at write time.
+	snap, err := w.store.GetSnapshot(w.ctx, id)
+	if err != nil {
+		w.complete = false
+		return // Partial local lineage: keep every available frontier.
+	}
+
+	digest, hasDigest := domain.MemoryDigest{}, false
+	if snap.MemoryHash != "" {
+		if loaded, loadErr := w.store.GetMemory(w.ctx, snap.MemoryHash); loadErr == nil {
+			digest, hasDigest = loaded, true
+		} else {
+			w.complete = false
+		}
+	}
+	if hasDigest && w.memoryDigestCoversLineage(digest, snap) {
+		w.merge(digest)
+		return
+	}
+
+	if hasDigest && len(digest.Fragments) == 0 {
+		// A legacy cumulative digest already contains its natural lineage, but it
+		// may have been produced by the old first-BFS-winner algorithm and silently
+		// skipped a graft below that lineage. Scan natural ancestors only for such
+		// hidden graft supplements, project this snapshot's current grafts, then
+		// keep the nearest opaque digest once. This repairs old descendants without
+		// concatenating every historical cumulative summary again.
+		for _, parent := range snap.Parents {
+			w.scanLegacySupplements(parent)
+		}
+		for _, parent := range snap.GraftParents {
+			w.walk(parent)
+		}
+		w.mergeLegacyOpaque(digest)
+		return
+	}
+
+	// No digest, or a modern fragment digest created against a stale/unknown
+	// graft register: reconstruct all current parent frontiers first. Fragment
+	// provenance then lets us append only this snapshot's own contribution, so
+	// superseded grafts are not retained.
+	for _, parent := range snap.ReachabilityParents() {
+		w.walk(parent)
+	}
+	if hasDigest {
+		if own, ok := w.retainedMemoryContribution(digest, snap); ok {
+			w.merge(own)
+		}
+	}
+}
+
+// scanLegacySupplements follows the natural chain assumed to be embedded in a
+// nearest opaque legacy digest and adds only graft branches that the old
+// single-winner projection could have skipped. This scan cannot stop at a
+// descendant digest's coverage: the outer opaque digest may predate a later
+// memory/graft update on that ancestor.
+func (w *memoryProjectionWalker) scanLegacySupplements(id domain.ContentHash) {
+	if id == "" || w.seen[id] || w.supplementSeen[id] {
+		return
+	}
+	w.supplementSeen[id] = true
+	snap, err := w.store.GetSnapshot(w.ctx, id)
+	if err != nil {
+		w.complete = false
+		return
+	}
+	for _, parent := range snap.Parents {
+		w.scanLegacySupplements(parent)
+	}
+	for _, parent := range snap.GraftParents {
+		w.walk(parent)
+	}
+}
+
+func (w *memoryProjectionWalker) merge(digest domain.MemoryDigest) {
+	if !w.found {
+		w.projection = digest
+		w.found = true
+		return
+	}
+	w.projection = domain.MergeDigests(w.projection, digest)
+}
+
+// mergeLegacyOpaque avoids recreating the historical cumulative-summary
+// explosion while repairing old grafts. Narrative replacement is allowed only
+// when the later opaque digest byte-for-byte contains every projected fragment
+// summary. Structured facts/tasks are still unioned explicitly, so narrative
+// containment cannot discard them. No fuzzy or semantic match is inferred.
+func (w *memoryProjectionWalker) mergeLegacyOpaque(digest domain.MemoryDigest) {
+	if w.found && legacyDigestContainsProjectionNarrative(digest, w.projection) {
+		digest.KeyFacts = mergeExactStrings(w.projection.KeyFacts, digest.KeyFacts)
+		digest.OpenTasks = mergeExactStrings(w.projection.OpenTasks, digest.OpenTasks)
+		w.projection = digest
+		return
+	}
+	w.merge(digest)
+}
+
+func legacyDigestContainsProjectionNarrative(legacy, projection domain.MemoryDigest) bool {
+	if len(projection.Fragments) == 0 {
+		return projection.Summary == "" || strings.Contains(legacy.Summary, projection.Summary)
+	}
+	for _, fragment := range projection.Fragments {
+		if fragment.Summary != "" && !strings.Contains(legacy.Summary, fragment.Summary) {
+			return false
+		}
+	}
+	return true
+}
+
+func mergeExactStrings(groups ...[]string) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, group := range groups {
+		for _, item := range group {
+			if item == "" || seen[item] {
+				continue
+			}
+			seen[item] = true
+			out = append(out, item)
+		}
+	}
+	return out
+}
+
+func (w *memoryProjectionWalker) memoryDigestCoversLineage(digest domain.MemoryDigest, snap domain.Snapshot) bool {
+	coverage := digest.GraftCoverage
+	if coverage == nil || coverage.ProjectionVersion != domain.MemoryProjectionVersion || !coverage.ProjectionComplete {
+		// Presence is also the migration proof that the corrected transitive
+		// frontier algorithm produced this digest. A no-graft legacy descendant
+		// can still have inherited an older hidden graft loss.
+		return false
+	}
+	if coverage.GraftSeq != snap.GraftSeq || len(coverage.GraftParents) != len(snap.GraftParents) {
+		return false
+	}
+	for i := range coverage.GraftParents {
+		if coverage.GraftParents[i] != snap.GraftParents[i] {
+			return false
+		}
+	}
+	fingerprint, complete := w.fingerprinter.root(snap)
+	return complete && coverage.LineageFingerprint == fingerprint
+}
+
+func memoryGraftCoverage(
+	ctx context.Context,
+	store outbound.SessionStore,
+	snap domain.Snapshot,
+	fragments []domain.MemoryFragment,
+	projectionComplete bool,
+) *domain.MemoryGraftCoverage {
+	fingerprinter := newMemoryProjectionFingerprinter(ctx, store)
+	fingerprint, lineageComplete := fingerprinter.root(snap)
+	state := memoryProjectionReadState{
+		snap: snap, fingerprint: fingerprint, lineageComplete: lineageComplete,
+		fingerprinter: fingerprinter,
+	}
+	return memoryGraftCoverageFromState(ctx, store, state, fragments, projectionComplete)
+}
+
+func memoryGraftCoverageFromState(
+	ctx context.Context,
+	store outbound.SessionStore,
+	state memoryProjectionReadState,
+	fragments []domain.MemoryFragment,
+	projectionComplete bool,
+) *domain.MemoryGraftCoverage {
+	seenSources := map[domain.ContentHash]bool{}
+	pinned := make([]domain.ContentHash, 0)
+	for _, fragment := range fragments {
+		source := fragment.SourceSnapshot
+		if source == "" || source == state.snap.ID || seenSources[source] {
 			continue
 		}
-		seen[id] = true
-		ps, err := store.GetSnapshot(ctx, id)
-		if err != nil {
-			continue // Skip local ancestors (partial lineage) — within the available range, the best option
+		seenSources[source] = true
+		// A source is reproducible only when it is in this root's current
+		// reachability graph and its currently attached memory is readable.
+		// Everything else is an intentional import or an available fallback from
+		// a partial projection, and remains owned by this digest.
+		reproducible := memorySourceReproducible(ctx, store, state.fingerprinter.reachable, source)
+		if !reproducible {
+			pinned = append(pinned, source)
 		}
-		if ps.MemoryHash != "" {
-			if d, derr := store.GetMemory(ctx, ps.MemoryHash); derr == nil {
-				return d, true
-			}
-		}
-		queue = append(queue, ps.ReachabilityParents()...)
 	}
-	return domain.MemoryDigest{}, false
+	return &domain.MemoryGraftCoverage{
+		ProjectionVersion:  domain.MemoryProjectionVersion,
+		ProjectionComplete: projectionComplete && state.lineageComplete,
+		LineageFingerprint: state.fingerprint,
+		GraftSeq:           state.snap.GraftSeq,
+		GraftParents:       append([]domain.ContentHash(nil), state.snap.GraftParents...),
+		PinnedSources:      pinned,
+	}
+}
+
+type memoryProjectionReadState struct {
+	snap            domain.Snapshot
+	fingerprint     domain.ContentHash
+	ancestorState   domain.ContentHash
+	lineageComplete bool
+	fingerprinter   *memoryProjectionFingerprinter
+}
+
+func readMemoryProjectionState(ctx context.Context, store outbound.SessionStore, id domain.ContentHash) (memoryProjectionReadState, error) {
+	snap, err := store.GetSnapshot(ctx, id)
+	if err != nil {
+		return memoryProjectionReadState{}, err
+	}
+	fingerprinter := newMemoryProjectionFingerprinter(ctx, store)
+	fingerprint, rootComplete := fingerprinter.root(snap)
+	fingerprinter.visiting[snap.ID] = true
+	ancestorState, ancestorComplete := fingerprinter.snapshot(snap, true)
+	delete(fingerprinter.visiting, snap.ID)
+	return memoryProjectionReadState{
+		snap: snap, fingerprint: fingerprint, ancestorState: ancestorState,
+		lineageComplete: rootComplete && ancestorComplete,
+		fingerprinter:   fingerprinter,
+	}, nil
+}
+
+func sameMemoryProjectionState(left, right memoryProjectionReadState) bool {
+	if left.snap.ID != right.snap.ID || left.snap.MemoryHash != right.snap.MemoryHash ||
+		left.snap.GraftSeq != right.snap.GraftSeq || left.lineageComplete != right.lineageComplete ||
+		left.fingerprint != right.fingerprint || left.ancestorState != right.ancestorState ||
+		len(left.snap.GraftParents) != len(right.snap.GraftParents) {
+		return false
+	}
+	for i := range left.snap.GraftParents {
+		if left.snap.GraftParents[i] != right.snap.GraftParents[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// childMemoryProjectionState derives a new single-parent seed's proof from the
+// exact stable parent state used to build its memory. The parent edge uses the
+// ancestor form (including the parent's MemoryHash); deriving it avoids a
+// second live traversal that could stamp the seed with a concurrent state.
+func childMemoryProjectionState(snap domain.Snapshot, parent memoryProjectionReadState) memoryProjectionReadState {
+	fingerprinter := &memoryProjectionFingerprinter{reachable: map[domain.ContentHash]bool{}}
+	for id := range parent.fingerprinter.reachable {
+		fingerprinter.reachable[id] = true
+	}
+	fingerprinter.reachable[snap.ID] = true
+	state := memoryProjectionReadState{snap: snap, fingerprinter: fingerprinter}
+	if len(snap.Parents) != 1 || snap.Parents[0] != parent.snap.ID || len(snap.GraftParents) != 0 ||
+		!parent.lineageComplete || parent.ancestorState == "" {
+		return state
+	}
+	wire := memoryProjectionFingerprintState{
+		SnapshotID:   snap.ID,
+		GraftParents: []memoryProjectionFingerprintEdge{},
+		Parents: []memoryProjectionFingerprintEdge{{
+			SnapshotID: parent.snap.ID,
+			State:      parent.ancestorState,
+		}},
+		GraftSeq: snap.GraftSeq,
+	}
+	data, err := json.Marshal(wire)
+	if err != nil {
+		return state
+	}
+	state.fingerprint = domain.HashContent(data)
+	state.ancestorState = state.fingerprint // synthetic root has no MemoryHash yet
+	state.lineageComplete = true
+	return state
+}
+
+const memoryProjectionReadAttempts = 3
+
+// stablePriorMemoryProjection prevents a projection from one graft/memory
+// state from being stamped with proof of another state. Multiple terminals can
+// update the same local .cxt store, so read the transitive state before and
+// after projection and retry optimistically on movement.
+func stablePriorMemoryProjection(
+	ctx context.Context,
+	store outbound.SessionStore,
+	id domain.ContentHash,
+) (memoryProjectionReadState, domain.MemoryDigest, bool, bool, error) {
+	for attempt := 0; attempt < memoryProjectionReadAttempts; attempt++ {
+		before, err := readMemoryProjectionState(ctx, store, id)
+		if err != nil {
+			return memoryProjectionReadState{}, domain.MemoryDigest{}, false, false, err
+		}
+		prior, found, projectionComplete := priorMemoryProjectionDetailed(ctx, store, before.snap)
+		after, err := readMemoryProjectionState(ctx, store, id)
+		if err != nil {
+			return memoryProjectionReadState{}, domain.MemoryDigest{}, false, false, err
+		}
+		if sameMemoryProjectionState(before, after) {
+			return after, prior, found, projectionComplete, nil
+		}
+	}
+	return memoryProjectionReadState{}, domain.MemoryDigest{}, false, false,
+		fmt.Errorf("%w: memory lineage changed during projection", domain.ErrSyncConflict)
+}
+
+type memoryProjectionFingerprintEdge struct {
+	SnapshotID domain.ContentHash `json:"snapshot_id"`
+	State      domain.ContentHash `json:"state"`
+}
+
+type memoryProjectionFingerprintState struct {
+	SnapshotID   domain.ContentHash                `json:"snapshot_id"`
+	Parents      []memoryProjectionFingerprintEdge `json:"parents"`
+	GraftParents []memoryProjectionFingerprintEdge `json:"graft_parents"`
+	GraftSeq     uint64                            `json:"graft_seq"`
+	MemoryHash   domain.ContentHash                `json:"memory_hash,omitempty"`
+}
+
+type memoryProjectionFingerprintResult struct {
+	hash domain.ContentHash
+	ok   bool
+}
+
+type memoryProjectionFingerprinter struct {
+	ctx       context.Context
+	store     outbound.SessionStore
+	memo      map[domain.ContentHash]memoryProjectionFingerprintResult
+	visiting  map[domain.ContentHash]bool
+	reachable map[domain.ContentHash]bool
+}
+
+func newMemoryProjectionFingerprinter(ctx context.Context, store outbound.SessionStore) *memoryProjectionFingerprinter {
+	return &memoryProjectionFingerprinter{
+		ctx: ctx, store: store,
+		memo:     map[domain.ContentHash]memoryProjectionFingerprintResult{},
+		visiting: map[domain.ContentHash]bool{}, reachable: map[domain.ContentHash]bool{},
+	}
+}
+
+// root fingerprints the complete reachable projection state while excluding
+// only the root's replaceable MemoryHash. Ancestor MemoryHash values are part
+// of the proof, so re-memorizing an ancestor invalidates descendants instead
+// of silently shadowing the updated memory.
+func (f *memoryProjectionFingerprinter) root(snap domain.Snapshot) (domain.ContentHash, bool) {
+	if snap.ID == "" || f.visiting[snap.ID] {
+		return "", false
+	}
+	f.reachable[snap.ID] = true
+	f.visiting[snap.ID] = true
+	hash, ok := f.snapshot(snap, false)
+	delete(f.visiting, snap.ID)
+	return hash, ok
+}
+
+func (f *memoryProjectionFingerprinter) byID(id domain.ContentHash) (domain.ContentHash, bool) {
+	if id != "" {
+		// Reachability is a topology fact even when this replica is missing the
+		// referenced snapshot body. Coverage remains incomplete, but stale-memory
+		// fallback can still distinguish a partial pull from a removed graft.
+		f.reachable[id] = true
+	}
+	if cached, ok := f.memo[id]; ok {
+		return cached.hash, cached.ok
+	}
+	if id == "" || f.visiting[id] {
+		return "", false
+	}
+	snap, err := f.store.GetSnapshot(f.ctx, id)
+	if err != nil {
+		f.memo[id] = memoryProjectionFingerprintResult{}
+		return "", false
+	}
+	f.reachable[id] = true
+	f.visiting[id] = true
+	hash, ok := f.snapshot(snap, true)
+	delete(f.visiting, id)
+	f.memo[id] = memoryProjectionFingerprintResult{hash: hash, ok: ok}
+	return hash, ok
+}
+
+func (f *memoryProjectionFingerprinter) snapshot(snap domain.Snapshot, includeMemory bool) (domain.ContentHash, bool) {
+	if err := domain.ValidateContentHash(snap.ID); err != nil {
+		return "", false
+	}
+	state := memoryProjectionFingerprintState{SnapshotID: snap.ID, GraftSeq: snap.GraftSeq}
+	if includeMemory && snap.MemoryHash != "" {
+		if err := domain.ValidateContentHash(snap.MemoryHash); err != nil {
+			return "", false
+		}
+		state.MemoryHash = snap.MemoryHash
+	}
+	appendEdges := func(ids []domain.ContentHash) ([]memoryProjectionFingerprintEdge, bool) {
+		edges := make([]memoryProjectionFingerprintEdge, 0, len(ids))
+		complete := true
+		for _, id := range ids {
+			if err := domain.ValidateContentHash(id); err != nil {
+				complete = false
+				continue
+			}
+			parentState, ok := f.byID(id)
+			if !ok {
+				complete = false
+				continue
+			}
+			edges = append(edges, memoryProjectionFingerprintEdge{SnapshotID: id, State: parentState})
+		}
+		return edges, complete
+	}
+	var ok bool
+	if state.Parents, ok = appendEdges(snap.Parents); !ok {
+		return "", false
+	}
+	if state.GraftParents, ok = appendEdges(snap.GraftParents); !ok {
+		return "", false
+	}
+	data, err := json.Marshal(state)
+	if err != nil {
+		return "", false
+	}
+	return domain.HashContent(data), true
+}
+
+func (w *memoryProjectionWalker) retainedMemoryContribution(digest domain.MemoryDigest, snap domain.Snapshot) (domain.MemoryDigest, bool) {
+	if len(digest.Fragments) == 0 {
+		return digest, true // Legacy cumulative digest: preserve the opaque value.
+	}
+	pinned := map[domain.ContentHash]bool{}
+	if coverage := digest.GraftCoverage; coverage != nil && coverage.ProjectionVersion == domain.MemoryProjectionVersion {
+		for _, source := range coverage.PinnedSources {
+			pinned[source] = true
+		}
+	}
+	// Recompute current root membership even when the cheap root-register check
+	// already rejected coverage. If a source is still in the graph but this
+	// replica cannot read its memory, retain the old fragment as a lossless
+	// partial-pull fallback. A source absent from the graph is retained only when
+	// it was explicitly imported/pinned; this is what lets graft removal work.
+	current := newMemoryProjectionFingerprinter(w.ctx, w.store)
+	_, lineageComplete := current.root(snap)
+	checkedReadable := map[domain.ContentHash]bool{}
+	readable := map[domain.ContentHash]bool{}
+	fragments := make([]domain.MemoryFragment, 0, len(digest.Fragments))
+	for _, fragment := range digest.Fragments {
+		source := fragment.SourceSnapshot
+		keep := source == snap.ID || pinned[source]
+		if !keep && !lineageComplete {
+			// A missing intermediate snapshot hides all of its deeper ancestors.
+			// Until the replica is complete we cannot prove that any inherited
+			// fragment was removed, so prefer a temporary stale value to data loss.
+			keep = true
+		} else if !keep && current.reachable[source] {
+			if !checkedReadable[source] {
+				checkedReadable[source] = true
+				readable[source] = memorySourceReproducible(w.ctx, w.store, current.reachable, source)
+			}
+			keep = !readable[source]
+		}
+		if keep {
+			fragments = append(fragments, fragment)
+		}
+	}
+	if len(fragments) == 0 {
+		return domain.MemoryDigest{}, false
+	}
+	own := domain.MemoryDigest{SnapshotID: snap.ID, Provider: digest.Provider, Fragments: fragments}
+	return domain.MergeDigests(domain.MemoryDigest{}, own), true
+}
+
+func memorySourceReproducible(
+	ctx context.Context,
+	store outbound.SessionStore,
+	reachable map[domain.ContentHash]bool,
+	source domain.ContentHash,
+) bool {
+	if !reachable[source] {
+		return false
+	}
+	sourceSnapshot, err := store.GetSnapshot(ctx, source)
+	if err != nil || sourceSnapshot.MemoryHash == "" {
+		return false
+	}
+	_, err = store.GetMemory(ctx, sourceSnapshot.MemoryHash)
+	return err == nil
 }
 
 // nearestAncestorDigest is retained for explicit legacy single-nearest callers

--- a/cli/internal/app/memory_lineage_test.go
+++ b/cli/internal/app/memory_lineage_test.go
@@ -2,12 +2,63 @@ package app
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
 	"github.com/wnsdy95/cxthub/cli/internal/adapters/storage"
 	"github.com/wnsdy95/cxthub/cli/internal/domain"
+	"github.com/wnsdy95/cxthub/cli/internal/ports/inbound"
 )
+
+type projectionMutationStore struct {
+	*storage.FileStore
+	target, graft domain.ContentHash
+	remaining     int // -1 mutates on every successful memory read.
+}
+
+func (s *projectionMutationStore) GetMemory(ctx context.Context, hash domain.ContentHash) (domain.MemoryDigest, error) {
+	digest, err := s.FileStore.GetMemory(ctx, hash)
+	if err == nil && s.remaining != 0 {
+		if s.remaining > 0 {
+			s.remaining--
+		}
+		s.mutateGraft(ctx)
+	}
+	return digest, err
+}
+
+func (s *projectionMutationStore) mutateGraft(ctx context.Context) {
+	snap, err := s.FileStore.GetSnapshot(ctx, s.target)
+	if err != nil {
+		return
+	}
+	snap.GraftSeq++
+	if len(snap.GraftParents) == 0 {
+		snap.Grafted = true
+		snap.GraftParents = []domain.ContentHash{s.graft}
+	} else {
+		snap.Grafted = false
+		snap.GraftParents = nil
+	}
+	_ = s.FileStore.PutSnapshot(ctx, snap)
+}
+
+type graftBeforeMemoryAttachStore struct {
+	*storage.FileStore
+	target, graft domain.ContentHash
+	mutated       bool
+}
+
+func (s *graftBeforeMemoryAttachStore) PutMemory(ctx context.Context, digest domain.MemoryDigest) (domain.ContentHash, error) {
+	hash, err := s.FileStore.PutMemory(ctx, digest)
+	if err == nil && !s.mutated {
+		s.mutated = true
+		mutator := projectionMutationStore{FileStore: s.FileStore, target: s.target, graft: s.graft}
+		mutator.mutateGraft(ctx)
+	}
+	return hash, err
+}
 
 // TestMergeDigests fixes the determinism rules for memory digest merges:
 // ancestor precedence + dedup, disallow duplicate links if summaries are contained.
@@ -89,6 +140,10 @@ func TestAncestorMemoryProjectionUnionsParallelGraftFragments(t *testing.T) {
 	base := domain.MemoryDigest{SnapshotID: h('a'), Summary: "shared base"}
 	left := domain.MergeDigests(base, domain.MemoryDigest{SnapshotID: h('b'), Summary: "left PR"})
 	right := domain.MergeDigests(base, domain.MemoryDigest{SnapshotID: h('c'), Summary: "right PR"})
+	baseHash, err := st.PutMemory(ctx, base)
+	if err != nil {
+		t.Fatal(err)
+	}
 	leftHash, err := st.PutMemory(ctx, left)
 	if err != nil {
 		t.Fatal(err)
@@ -98,8 +153,9 @@ func TestAncestorMemoryProjectionUnionsParallelGraftFragments(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, snap := range []domain.Snapshot{
-		{ID: h('b'), DocHash: h('b'), Branch: "main", MemoryHash: leftHash},
-		{ID: h('c'), DocHash: h('c'), Branch: "main", MemoryHash: rightHash},
+		{ID: h('a'), DocHash: h('a'), Branch: "main", MemoryHash: baseHash},
+		{ID: h('b'), DocHash: h('b'), Branch: "main", Parents: []domain.ContentHash{h('a')}, MemoryHash: leftHash},
+		{ID: h('c'), DocHash: h('c'), Branch: "main", Parents: []domain.ContentHash{h('a')}, MemoryHash: rightHash},
 		{ID: h('d'), DocHash: h('d'), Branch: "main", Parents: []domain.ContentHash{h('b')}, GraftParents: []domain.ContentHash{h('c')}, Grafted: true},
 	} {
 		if err := st.PutSnapshot(ctx, snap); err != nil {
@@ -116,6 +172,617 @@ func TestAncestorMemoryProjectionUnionsParallelGraftFragments(t *testing.T) {
 	}
 	if len(got.Fragments) != 3 {
 		t.Fatalf("fragment union = %d, want shared+left+right", len(got.Fragments))
+	}
+}
+
+// A server append can add a graft overlay after the boundary snapshot already
+// has memory. That digest only covers the pre-graft lineage, so a child must
+// not treat it as a complete projection of the boundary's current ancestry.
+func TestAncestorMemoryProjectionDoesNotShadowGraftBehindMemory(t *testing.T) {
+	ctx := context.Background()
+	st := storage.NewFileStore(t.TempDir())
+	h := func(c byte) domain.ContentHash {
+		return domain.ContentHash("sha256:" + strings.Repeat(string(c), 64))
+	}
+	putMemory := func(d domain.MemoryDigest) domain.ContentHash {
+		hash, err := st.PutMemory(ctx, d)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return hash
+	}
+	putSnapshot := func(s domain.Snapshot) {
+		if err := st.PutSnapshot(ctx, s); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	base := domain.MemoryDigest{SnapshotID: h('a'), Summary: "shared base"}
+	baseHash := putMemory(base)
+	teammate := domain.MergeDigests(base, domain.MemoryDigest{SnapshotID: h('b'), Summary: "teammate work"})
+	teammateHash := putMemory(teammate)
+	// This is the digest created before the server attached T as a graft.
+	// Legacy cumulative digest: no fragment provenance and no coverage marker.
+	local := domain.MemoryDigest{SnapshotID: h('d'), Summary: "local work"}
+	localHash := putMemory(local)
+	descendant := domain.MemoryDigest{SnapshotID: h('e'), Summary: "local work\n\ndescendant work"}
+	descendantHash := putMemory(descendant)
+
+	putSnapshot(domain.Snapshot{ID: h('a'), DocHash: h('a'), Branch: "main", MemoryHash: baseHash})
+	putSnapshot(domain.Snapshot{ID: h('b'), DocHash: h('b'), Branch: "main", Parents: []domain.ContentHash{h('a')}, MemoryHash: teammateHash})
+	putSnapshot(domain.Snapshot{
+		ID: h('d'), DocHash: h('d'), Branch: "main", Parents: []domain.ContentHash{h('a')},
+		GraftParents: []domain.ContentHash{h('b')}, Grafted: true, GraftSeq: 1, MemoryHash: localHash,
+	})
+	putSnapshot(domain.Snapshot{
+		ID: h('e'), DocHash: h('e'), Branch: "main", Parents: []domain.ContentHash{h('d')}, MemoryHash: descendantHash,
+	})
+
+	boundary, _ := st.GetSnapshot(ctx, h('d'))
+	direct, ok := snapshotMemoryProjection(ctx, st, boundary)
+	if !ok || !strings.Contains(direct.Summary, "local work") || !strings.Contains(direct.Summary, "teammate work") {
+		t.Fatalf("direct stale boundary projection = %q, want local + graft memory", direct.Summary)
+	}
+	child, _ := st.GetSnapshot(ctx, h('e'))
+	direct, ok = snapshotMemoryProjection(ctx, st, child)
+	if !ok || !strings.Contains(direct.Summary, "descendant work") || !strings.Contains(direct.Summary, "teammate work") {
+		t.Fatalf("legacy descendant projection = %q, want descendant + hidden graft memory", direct.Summary)
+	}
+	got, ok := ancestorMemoryProjection(ctx, st, child)
+	if !ok || !strings.Contains(got.Summary, "local work") || !strings.Contains(got.Summary, "teammate work") {
+		t.Fatalf("stale boundary projection = %q, want local + graft memory", got.Summary)
+	}
+}
+
+// A memoryless boundary is also not a single lineage. Its child must inherit
+// the nearest digest from every natural/graft parent instead of the first BFS
+// winner only.
+func TestAncestorMemoryProjectionUnionsThroughMemorylessBoundary(t *testing.T) {
+	ctx := context.Background()
+	st := storage.NewFileStore(t.TempDir())
+	h := func(c byte) domain.ContentHash {
+		return domain.ContentHash("sha256:" + strings.Repeat(string(c), 64))
+	}
+	put := func(s domain.Snapshot, summary string) {
+		if summary != "" {
+			memoryHash, err := st.PutMemory(ctx, domain.MemoryDigest{SnapshotID: s.ID, Summary: summary})
+			if err != nil {
+				t.Fatal(err)
+			}
+			s.MemoryHash = memoryHash
+		}
+		if err := st.PutSnapshot(ctx, s); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	put(domain.Snapshot{ID: h('b'), DocHash: h('b'), Branch: "main"}, "natural lineage")
+	put(domain.Snapshot{ID: h('c'), DocHash: h('c'), Branch: "main"}, "graft lineage")
+	put(domain.Snapshot{
+		ID: h('d'), DocHash: h('d'), Branch: "main", Parents: []domain.ContentHash{h('b')},
+		GraftParents: []domain.ContentHash{h('c')}, Grafted: true, GraftSeq: 1,
+	}, "")
+	put(domain.Snapshot{ID: h('e'), DocHash: h('e'), Branch: "main", Parents: []domain.ContentHash{h('d')}}, "")
+
+	child, _ := st.GetSnapshot(ctx, h('e'))
+	got, ok := ancestorMemoryProjection(ctx, st, child)
+	if !ok || !strings.Contains(got.Summary, "natural lineage") || !strings.Contains(got.Summary, "graft lineage") {
+		t.Fatalf("memoryless boundary projection = %q, want both lineages", got.Summary)
+	}
+}
+
+func TestMemoryProjectionStopsAtCurrentGraftCoverage(t *testing.T) {
+	ctx := context.Background()
+	st := storage.NewFileStore(t.TempDir())
+	h := func(c byte) domain.ContentHash {
+		return domain.ContentHash("sha256:" + strings.Repeat(string(c), 64))
+	}
+	digest := domain.MergeDigests(
+		domain.MemoryDigest{SnapshotID: h('b'), Summary: "covered teammate work"},
+		domain.MemoryDigest{SnapshotID: h('d'), Summary: "covered local work"},
+	)
+	teammateHash, err := st.PutMemory(ctx, domain.MemoryDigest{SnapshotID: h('b'), Summary: "covered teammate work"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.PutSnapshot(ctx, domain.Snapshot{ID: h('b'), DocHash: h('b'), Branch: "main", MemoryHash: teammateHash}); err != nil {
+		t.Fatal(err)
+	}
+	boundary := domain.Snapshot{
+		ID: h('d'), DocHash: h('d'), Branch: "main", Grafted: true, GraftSeq: 1,
+		GraftParents: []domain.ContentHash{h('b')},
+	}
+	if err := st.PutSnapshot(ctx, boundary); err != nil {
+		t.Fatal(err)
+	}
+	digest.GraftCoverage = memoryGraftCoverage(ctx, st, boundary, digest.Fragments, true)
+	if digest.GraftCoverage == nil {
+		t.Fatal("complete boundary did not produce coverage")
+	}
+	memoryHash, err := st.PutMemory(ctx, digest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	boundary.MemoryHash = memoryHash
+	if err := st.PutSnapshot(ctx, boundary); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.PutSnapshot(ctx, domain.Snapshot{ID: h('e'), DocHash: h('e'), Parents: []domain.ContentHash{h('d')}}); err != nil {
+		t.Fatal(err)
+	}
+	child, _ := st.GetSnapshot(ctx, h('e'))
+	got, ok := ancestorMemoryProjection(ctx, st, child)
+	if !ok || !strings.Contains(got.Summary, "covered teammate work") || !strings.Contains(got.Summary, "covered local work") {
+		t.Fatalf("current coverage projection = %q", got.Summary)
+	}
+}
+
+func TestPriorMemoryProjectionReplacesOwnContributionButKeepsPinnedImport(t *testing.T) {
+	ctx := context.Background()
+	st := storage.NewFileStore(t.TempDir())
+	h := func(c byte) domain.ContentHash {
+		return domain.ContentHash("sha256:" + strings.Repeat(string(c), 64))
+	}
+	base := domain.MergeDigests(domain.MemoryDigest{}, domain.MemoryDigest{SnapshotID: h('a'), Summary: "reachable prior"})
+	baseHash, err := st.PutMemory(ctx, base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rootDigest := domain.MergeDigests(base, domain.MemoryDigest{SnapshotID: h('c'), Summary: "external pinned import"})
+	rootDigest = domain.MergeDigests(rootDigest, domain.MemoryDigest{SnapshotID: h('d'), Summary: "old root contribution"})
+	root := domain.Snapshot{ID: h('d'), DocHash: h('d'), Branch: "main", Parents: []domain.ContentHash{h('a')}}
+	for _, snap := range []domain.Snapshot{
+		{ID: h('a'), DocHash: h('a'), Branch: "main", MemoryHash: baseHash},
+		root,
+	} {
+		if err := st.PutSnapshot(ctx, snap); err != nil {
+			t.Fatal(err)
+		}
+	}
+	rootDigest.GraftCoverage = memoryGraftCoverage(ctx, st, root, rootDigest.Fragments, true)
+	if rootDigest.GraftCoverage == nil || len(rootDigest.GraftCoverage.PinnedSources) != 1 || rootDigest.GraftCoverage.PinnedSources[0] != h('c') {
+		t.Fatalf("root pinned coverage = %+v", rootDigest.GraftCoverage)
+	}
+	rootHash, err := st.PutMemory(ctx, rootDigest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root.MemoryHash = rootHash
+	if err := st.PutSnapshot(ctx, root); err != nil {
+		t.Fatal(err)
+	}
+	prior, ok := priorMemoryProjection(ctx, st, root)
+	if !ok || !strings.Contains(prior.Summary, "reachable prior") || !strings.Contains(prior.Summary, "external pinned import") {
+		t.Fatalf("same-snapshot prior projection = %q", prior.Summary)
+	}
+	if strings.Contains(prior.Summary, "old root contribution") {
+		t.Fatalf("same-snapshot prior retained replaced own contribution: %q", prior.Summary)
+	}
+}
+
+func TestStableMemoryProjectionRetriesConcurrentGraftMovement(t *testing.T) {
+	ctx := context.Background()
+	baseStore := storage.NewFileStore(t.TempDir())
+	h := func(c byte) domain.ContentHash {
+		return domain.ContentHash("sha256:" + strings.Repeat(string(c), 64))
+	}
+	putMemory := func(id domain.ContentHash, summary string) domain.ContentHash {
+		hash, err := baseStore.PutMemory(ctx, domain.MemoryDigest{SnapshotID: id, Summary: summary})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return hash
+	}
+	for _, snap := range []domain.Snapshot{
+		{ID: h('a'), DocHash: h('a'), Branch: "main", MemoryHash: putMemory(h('a'), "natural memory")},
+		{ID: h('c'), DocHash: h('c'), Branch: "main", MemoryHash: putMemory(h('c'), "concurrent graft memory")},
+		{ID: h('d'), DocHash: h('d'), Branch: "main", Parents: []domain.ContentHash{h('a')}},
+	} {
+		if err := baseStore.PutSnapshot(ctx, snap); err != nil {
+			t.Fatal(err)
+		}
+	}
+	store := &projectionMutationStore{FileStore: baseStore, target: h('d'), graft: h('c'), remaining: 1}
+	state, prior, found, complete, err := stablePriorMemoryProjection(ctx, store, h('d'))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !found || !complete || state.snap.GraftSeq != 1 || len(state.snap.GraftParents) != 1 || state.snap.GraftParents[0] != h('c') {
+		t.Fatalf("stable retry state=%+v found=%v complete=%v", state.snap, found, complete)
+	}
+	if !strings.Contains(prior.Summary, "natural memory") || !strings.Contains(prior.Summary, "concurrent graft memory") {
+		t.Fatalf("stable retry projected stale state: %q", prior.Summary)
+	}
+
+	store = &projectionMutationStore{FileStore: baseStore, target: h('d'), graft: h('c'), remaining: -1}
+	if _, _, _, _, err := stablePriorMemoryProjection(ctx, store, h('d')); !errors.Is(err, domain.ErrSyncConflict) {
+		t.Fatalf("continuously moving lineage error = %v, want sync conflict", err)
+	}
+}
+
+func TestMemorizeAttachmentDoesNotReplayConcurrentGraftRegister(t *testing.T) {
+	ctx := context.Background()
+	baseStore := storage.NewFileStore(t.TempDir())
+	repo := domain.Repo{ID: "repo-memory-attach-race", DefaultBranch: "main", LocalPath: t.TempDir()}
+	docHash, err := baseStore.PutDoc(ctx, domain.SessionDoc{CIR: domain.CIRDocument{
+		Envelope: domain.Envelope{CIRVersion: "1", SourceProvider: domain.ProviderCodex},
+		Events:   []domain.Event{{Kind: domain.EventMessage, Role: "user", Seq: 0}},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	graftID := domain.HashContent([]byte("attachment-race-graft"))
+	graftMemory, err := baseStore.PutMemory(ctx, domain.MemoryDigest{SnapshotID: graftID, Summary: "concurrent graft survives attachment"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, snap := range []domain.Snapshot{
+		{ID: graftID, DocHash: graftID, RepoID: repo.ID, Branch: "main", MemoryHash: graftMemory},
+		{ID: docHash, DocHash: docHash, RepoID: repo.ID, Branch: "main"},
+	} {
+		if err := baseStore.PutSnapshot(ctx, snap); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := baseStore.PutRef(ctx, domain.Ref{Kind: domain.RefBranch, Name: "main", RepoID: repo.ID, Target: docHash}); err != nil {
+		t.Fatal(err)
+	}
+	store := &graftBeforeMemoryAttachStore{FileStore: baseStore, target: docHash, graft: graftID}
+	service := NewMemorizeService(
+		branchSeedGit{repo: repo}, nil, nil, nil,
+		stubDistiller{d: domain.MemoryDigest{Summary: "fresh root memory"}}, store,
+	)
+	out, err := service.Memorize(ctx, inbound.MemorizeInput{Cwd: repo.LocalPath, Provider: domain.ProviderCodex})
+	if err != nil {
+		t.Fatal(err)
+	}
+	root, err := baseStore.GetSnapshot(ctx, docHash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if root.MemoryHash != out.MemoryHash || root.GraftSeq != 1 || len(root.GraftParents) != 1 || root.GraftParents[0] != graftID {
+		t.Fatalf("memory attachment replayed stale graft state: %+v", root)
+	}
+	projected, ok := snapshotMemoryProjection(ctx, baseStore, root)
+	if !ok || !strings.Contains(projected.Summary, "fresh root memory") || !strings.Contains(projected.Summary, "concurrent graft survives attachment") {
+		t.Fatalf("post-race projection = %q", projected.Summary)
+	}
+}
+
+func TestMemoryProjectionRebuildsSupersededGraftFromCurrentParents(t *testing.T) {
+	ctx := context.Background()
+	st := storage.NewFileStore(t.TempDir())
+	h := func(c byte) domain.ContentHash {
+		return domain.ContentHash("sha256:" + strings.Repeat(string(c), 64))
+	}
+	base := domain.MemoryDigest{SnapshotID: h('a'), Summary: "current base"}
+	baseHash, err := st.PutMemory(ctx, base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stale := domain.MergeDigests(base, domain.MemoryDigest{SnapshotID: h('b'), Summary: "removed graft work"})
+	stale = domain.MergeDigests(stale, domain.MemoryDigest{SnapshotID: h('d'), Summary: "boundary own work"})
+	removedHash, err := st.PutMemory(ctx, domain.MemoryDigest{SnapshotID: h('b'), Summary: "removed graft work"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	boundary := domain.Snapshot{
+		ID: h('d'), DocHash: h('d'), Branch: "main", Parents: []domain.ContentHash{h('a')},
+		Grafted: true, GraftSeq: 1, GraftParents: []domain.ContentHash{h('b')},
+	}
+	for _, snap := range []domain.Snapshot{
+		{ID: h('a'), DocHash: h('a'), Branch: "main", MemoryHash: baseHash},
+		{ID: h('b'), DocHash: h('b'), Branch: "main", Parents: []domain.ContentHash{h('a')}, MemoryHash: removedHash},
+		boundary,
+	} {
+		if err := st.PutSnapshot(ctx, snap); err != nil {
+			t.Fatal(err)
+		}
+	}
+	stale.GraftCoverage = memoryGraftCoverage(ctx, st, boundary, stale.Fragments, true)
+	if stale.GraftCoverage == nil {
+		t.Fatal("complete stale boundary did not produce coverage")
+	}
+	staleHash, err := st.PutMemory(ctx, stale)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Current seq=2 removes the old graft parent. Only A + D remain reachable.
+	boundary.GraftSeq = 2
+	boundary.GraftParents = nil
+	boundary.Grafted = false
+	boundary.MemoryHash = staleHash
+	if err := st.PutSnapshot(ctx, boundary); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.PutSnapshot(ctx, domain.Snapshot{ID: h('e'), DocHash: h('e'), Branch: "main", Parents: []domain.ContentHash{h('d')}}); err != nil {
+		t.Fatal(err)
+	}
+	child, _ := st.GetSnapshot(ctx, h('e'))
+	got, ok := ancestorMemoryProjection(ctx, st, child)
+	if !ok || !strings.Contains(got.Summary, "current base") || !strings.Contains(got.Summary, "boundary own work") {
+		t.Fatalf("superseded projection = %q", got.Summary)
+	}
+	if strings.Contains(got.Summary, "removed graft work") {
+		t.Fatalf("superseded graft survived projection: %q", got.Summary)
+	}
+}
+
+func TestMemoryProjectionRetainsReachableFragmentWhenSourceMemoryIsUnavailable(t *testing.T) {
+	ctx := context.Background()
+	st := storage.NewFileStore(t.TempDir())
+	h := func(c byte) domain.ContentHash {
+		return domain.ContentHash("sha256:" + strings.Repeat(string(c), 64))
+	}
+	base := domain.MergeDigests(domain.MemoryDigest{}, domain.MemoryDigest{SnapshotID: h('a'), Summary: "reachable fallback memory"})
+	baseHash, err := st.PutMemory(ctx, base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rootDigest := domain.MergeDigests(base, domain.MemoryDigest{SnapshotID: h('d'), Summary: "root memory"})
+	baseSnapshot := domain.Snapshot{ID: h('a'), DocHash: h('a'), Branch: "main", MemoryHash: baseHash}
+	root := domain.Snapshot{ID: h('d'), DocHash: h('d'), Branch: "main", Parents: []domain.ContentHash{h('a')}}
+	for _, snap := range []domain.Snapshot{baseSnapshot, root} {
+		if err := st.PutSnapshot(ctx, snap); err != nil {
+			t.Fatal(err)
+		}
+	}
+	rootDigest.GraftCoverage = memoryGraftCoverage(ctx, st, root, rootDigest.Fragments, true)
+	if rootDigest.GraftCoverage == nil || len(rootDigest.GraftCoverage.PinnedSources) != 0 {
+		t.Fatalf("initial coverage = %+v, reachable readable base must not be pinned", rootDigest.GraftCoverage)
+	}
+	rootHash, err := st.PutMemory(ctx, rootDigest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root.MemoryHash = rootHash
+	if err := st.PutSnapshot(ctx, root); err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate a partial/corrupt pull after coverage was recorded. The source is
+	// still a natural parent, but its current derivative memory blob is absent.
+	// That pointer change invalidates root coverage; stale repair must use the
+	// fragment already embedded in rootDigest instead of silently losing it.
+	baseSnapshot.MemoryHash = h('f')
+	if err := st.PutSnapshot(ctx, baseSnapshot); err != nil {
+		t.Fatal(err)
+	}
+	root, err = st.GetSnapshot(ctx, root.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, ok, complete := snapshotMemoryProjectionDetailed(ctx, st, root)
+	if !ok || complete || !strings.Contains(got.Summary, "reachable fallback memory") || !strings.Contains(got.Summary, "root memory") {
+		t.Fatalf("partial-memory projection = %q, want reachable fallback + root", got.Summary)
+	}
+}
+
+func TestMemoryProjectionRetainsDeepFragmentsWhenLineageIsPartial(t *testing.T) {
+	ctx := context.Background()
+	st := storage.NewFileStore(t.TempDir())
+	h := func(c byte) domain.ContentHash {
+		return domain.ContentHash("sha256:" + strings.Repeat(string(c), 64))
+	}
+	putMemory := func(d domain.MemoryDigest) domain.ContentHash {
+		hash, err := st.PutMemory(ctx, d)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return hash
+	}
+	base := domain.MergeDigests(domain.MemoryDigest{}, domain.MemoryDigest{SnapshotID: h('a'), Summary: "deep base memory"})
+	middle := domain.MergeDigests(base, domain.MemoryDigest{SnapshotID: h('b'), Summary: "missing middle memory"})
+	rootDigest := domain.MergeDigests(middle, domain.MemoryDigest{SnapshotID: h('d'), Summary: "partial root memory"})
+	baseHash := putMemory(base)
+	middleHash := putMemory(middle)
+	root := domain.Snapshot{ID: h('d'), DocHash: h('d'), Branch: "main", Parents: []domain.ContentHash{h('b')}}
+	for _, snap := range []domain.Snapshot{
+		{ID: h('a'), DocHash: h('a'), Branch: "main", MemoryHash: baseHash},
+		{ID: h('b'), DocHash: h('b'), Branch: "main", Parents: []domain.ContentHash{h('a')}, MemoryHash: middleHash},
+		root,
+	} {
+		if err := st.PutSnapshot(ctx, snap); err != nil {
+			t.Fatal(err)
+		}
+	}
+	rootDigest.GraftCoverage = memoryGraftCoverage(ctx, st, root, rootDigest.Fragments, true)
+	if rootDigest.GraftCoverage == nil || len(rootDigest.GraftCoverage.PinnedSources) != 0 {
+		t.Fatalf("initial complete coverage = %+v", rootDigest.GraftCoverage)
+	}
+	root.MemoryHash = putMemory(rootDigest)
+	if err := st.PutSnapshot(ctx, root); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.DeleteSnapshot(ctx, h('b')); err != nil {
+		t.Fatal(err)
+	}
+	root, err := st.GetSnapshot(ctx, root.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, ok, complete := snapshotMemoryProjectionDetailed(ctx, st, root)
+	if !ok || complete {
+		t.Fatal("partial lineage discarded the root's available digest")
+	}
+	for _, want := range []string{"deep base memory", "missing middle memory", "partial root memory"} {
+		if count := strings.Count(got.Summary, want); count != 1 {
+			t.Fatalf("partial projection contains %q %d times, want once: %q", want, count, got.Summary)
+		}
+	}
+}
+
+func TestMemoryProjectionInvalidatesWhenAncestorGraftChanges(t *testing.T) {
+	ctx := context.Background()
+	st := storage.NewFileStore(t.TempDir())
+	h := func(c byte) domain.ContentHash {
+		return domain.ContentHash("sha256:" + strings.Repeat(string(c), 64))
+	}
+	putMemory := func(d domain.MemoryDigest) domain.ContentHash {
+		hash, err := st.PutMemory(ctx, d)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return hash
+	}
+	base := domain.MemoryDigest{SnapshotID: h('a'), Summary: "ancestor base"}
+	teammate := domain.MergeDigests(base, domain.MemoryDigest{SnapshotID: h('c'), Summary: "late ancestor graft"})
+	local := domain.MergeDigests(base, domain.MemoryDigest{SnapshotID: h('b'), Summary: "local ancestor"})
+	childDigest := domain.MergeDigests(local, domain.MemoryDigest{SnapshotID: h('d'), Summary: "covered child"})
+	baseHash := putMemory(base)
+	teammateHash := putMemory(teammate)
+	localHash := putMemory(local)
+	for _, snap := range []domain.Snapshot{
+		{ID: h('a'), DocHash: h('a'), Branch: "main", MemoryHash: baseHash},
+		{ID: h('c'), DocHash: h('c'), Branch: "main", Parents: []domain.ContentHash{h('a')}, MemoryHash: teammateHash},
+		{ID: h('b'), DocHash: h('b'), Branch: "main", Parents: []domain.ContentHash{h('a')}, MemoryHash: localHash},
+		{ID: h('d'), DocHash: h('d'), Branch: "main", Parents: []domain.ContentHash{h('b')}},
+	} {
+		if err := st.PutSnapshot(ctx, snap); err != nil {
+			t.Fatal(err)
+		}
+	}
+	child, _ := st.GetSnapshot(ctx, h('d'))
+	childDigest.GraftCoverage = memoryGraftCoverage(ctx, st, child, childDigest.Fragments, true)
+	if childDigest.GraftCoverage == nil {
+		t.Fatal("initial child lineage did not produce coverage")
+	}
+	childHash := putMemory(childDigest)
+	child.MemoryHash = childHash
+	if err := st.PutSnapshot(ctx, child); err != nil {
+		t.Fatal(err)
+	}
+
+	// The child itself is unchanged. Mutating B's graft register must still
+	// invalidate D through the transitive lineage fingerprint.
+	if err := st.PutSnapshot(ctx, domain.Snapshot{
+		ID: h('b'), DocHash: h('b'), Branch: "main", Parents: []domain.ContentHash{h('a')},
+		Grafted: true, GraftSeq: 1, GraftParents: []domain.ContentHash{h('c')},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	child, _ = st.GetSnapshot(ctx, h('d'))
+	got, ok := snapshotMemoryProjection(ctx, st, child)
+	if !ok || !strings.Contains(got.Summary, "local ancestor") ||
+		!strings.Contains(got.Summary, "late ancestor graft") || !strings.Contains(got.Summary, "covered child") {
+		t.Fatalf("ancestor mutation projection = %q", got.Summary)
+	}
+}
+
+func TestMemoryProjectionCoverageExcludesRootPointerButRejectsPartialLineage(t *testing.T) {
+	ctx := context.Background()
+	st := storage.NewFileStore(t.TempDir())
+	h := func(c byte) domain.ContentHash {
+		return domain.ContentHash("sha256:" + strings.Repeat(string(c), 64))
+	}
+	root := domain.Snapshot{ID: h('a'), DocHash: h('a'), Branch: "main"}
+	if err := st.PutSnapshot(ctx, root); err != nil {
+		t.Fatal(err)
+	}
+	digest := domain.MemoryDigest{SnapshotID: root.ID, Summary: "root memory"}
+	digest.GraftCoverage = memoryGraftCoverage(ctx, st, root, digest.Fragments, true)
+	if digest.GraftCoverage == nil {
+		t.Fatal("complete root did not produce coverage")
+	}
+	memoryHash, err := st.PutMemory(ctx, digest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root.MemoryHash = memoryHash
+	if err := st.PutSnapshot(ctx, root); err != nil {
+		t.Fatal(err)
+	}
+	walker := memoryProjectionWalker{fingerprinter: newMemoryProjectionFingerprinter(ctx, st)}
+	if !walker.memoryDigestCoversLineage(digest, root) {
+		t.Fatal("attaching the digest's own MemoryHash invalidated its coverage")
+	}
+	incomplete := *digest.GraftCoverage
+	incomplete.ProjectionComplete = false
+	digest.GraftCoverage = &incomplete
+	if walker.memoryDigestCoversLineage(digest, root) {
+		t.Fatal("incomplete projection was trusted as a traversal stop")
+	}
+	future := *digest.GraftCoverage
+	future.ProjectionComplete = true
+	future.ProjectionVersion++
+	digest.GraftCoverage = &future
+	if walker.memoryDigestCoversLineage(digest, root) {
+		t.Fatal("unknown future projection version was trusted as a stop point")
+	}
+
+	partial := domain.Snapshot{ID: h('b'), DocHash: h('b'), Parents: []domain.ContentHash{h('c')}}
+	if coverage := memoryGraftCoverage(ctx, st, partial, nil, true); coverage == nil || coverage.ProjectionComplete || coverage.LineageFingerprint != "" {
+		t.Fatalf("partial lineage produced trusted coverage: %+v", coverage)
+	}
+}
+
+func TestMemorizeRecordsExactGraftCoverage(t *testing.T) {
+	ctx := context.Background()
+	st := storage.NewFileStore(t.TempDir())
+	repo := domain.Repo{ID: "repo-memory-coverage", DefaultBranch: "main", LocalPath: t.TempDir()}
+	docHash, err := st.PutDoc(ctx, domain.SessionDoc{CIR: domain.CIRDocument{
+		Envelope: domain.Envelope{CIRVersion: "1", SourceProvider: domain.ProviderCodex},
+		Events:   []domain.Event{{Kind: domain.EventMessage, Role: "user", Seq: 0}},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	graftParent := domain.HashContent([]byte("coverage-parent"))
+	if err := st.PutSnapshot(ctx, domain.Snapshot{ID: graftParent, DocHash: graftParent, RepoID: repo.ID, Branch: "main"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.PutSnapshot(ctx, domain.Snapshot{
+		ID: docHash, DocHash: docHash, RepoID: repo.ID, Branch: "main",
+		Grafted: true, GraftSeq: 7, GraftParents: []domain.ContentHash{graftParent},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.PutRef(ctx, domain.Ref{Kind: domain.RefBranch, Name: "main", RepoID: repo.ID, Target: docHash}); err != nil {
+		t.Fatal(err)
+	}
+	service := NewMemorizeService(
+		branchSeedGit{repo: repo}, nil, nil, nil,
+		stubDistiller{d: domain.MemoryDigest{Summary: "fresh covered memory"}}, st,
+	)
+	out, err := service.Memorize(ctx, inbound.MemorizeInput{Cwd: repo.LocalPath, Provider: domain.ProviderCodex})
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest, err := st.GetMemory(ctx, out.MemoryHash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if digest.GraftCoverage == nil || digest.GraftCoverage.ProjectionVersion != domain.MemoryProjectionVersion || !digest.GraftCoverage.ProjectionComplete || digest.GraftCoverage.LineageFingerprint == "" || digest.GraftCoverage.GraftSeq != 7 ||
+		len(digest.GraftCoverage.GraftParents) != 1 || digest.GraftCoverage.GraftParents[0] != graftParent {
+		t.Fatalf("memorize graft coverage = %+v", digest.GraftCoverage)
+	}
+	if len(digest.Fragments) != 1 || digest.Fragments[0].SourceSnapshot != docHash {
+		t.Fatalf("memorize provenance = %+v, want current snapshot fragment", digest.Fragments)
+	}
+}
+
+func TestLegacyDigestContainmentIsExactAndPreservesStructure(t *testing.T) {
+	projection := domain.MemoryDigest{
+		Summary: "exact prior summary", KeyFacts: []string{"kept fact"}, OpenTasks: []string{"kept task"},
+	}
+	legacy := domain.MemoryDigest{
+		Summary: "prefix\nexact prior summary\nnew tail", KeyFacts: []string{"kept fact"}, OpenTasks: []string{"kept task"},
+	}
+	if !legacyDigestContainsProjectionNarrative(legacy, projection) {
+		t.Fatal("exact cumulative legacy digest did not absorb its prior projection")
+	}
+	missingFact := legacy
+	missingFact.KeyFacts = nil
+	walker := memoryProjectionWalker{projection: projection, found: true}
+	walker.mergeLegacyOpaque(missingFact)
+	if len(walker.projection.KeyFacts) != 1 || walker.projection.KeyFacts[0] != "kept fact" ||
+		len(walker.projection.OpenTasks) != 1 || walker.projection.OpenTasks[0] != "kept task" {
+		t.Fatalf("narrative containment discarded structure: %+v", walker.projection)
+	}
+	caseChanged := legacy
+	caseChanged.Summary = "EXACT PRIOR SUMMARY"
+	if legacyDigestContainsProjectionNarrative(caseChanged, projection) {
+		t.Fatal("fuzzy/case-insensitive containment was accepted")
 	}
 }
 

--- a/cli/internal/domain/entities.go
+++ b/cli/internal/domain/entities.go
@@ -8,6 +8,11 @@ import (
 // MaxGraftSeq is the upper bound of the graft Lamport version that can be represented by the server PostgreSQL BIGINT and the local JSON replica. Wrapping to seq=0 is not allowed.
 const MaxGraftSeq uint64 = 1<<63 - 1
 
+// MemoryProjectionVersion identifies the transitive frontier algorithm whose
+// coverage proof is safe to use as a traversal stop. Unknown future versions
+// remain storable but are conservatively reprojected by this client.
+const MemoryProjectionVersion uint32 = 1
+
 // JSON tags are in snake_case, the same as the backend(cxt-backend) domain and schemas/manifest.schema.json. Although completely separate, they must be compatible over the wire(REST/JSON), so field names are matched (.cxt local storage is in the same format).
 
 // TeamIdentity is a value object that identifies the snapshot author (domain model).
@@ -164,6 +169,26 @@ type MemoryDigest struct {
 	// KeyFacts, and OpenTasks remain the rendered compatibility view. Older
 	// digests without fragments are promoted as one immutable legacy fragment.
 	Fragments []MemoryFragment `json:"fragments,omitempty"`
+	// GraftCoverage records the exact mutable graft register observed when this
+	// digest was attached. Natural parents are immutable and need no coverage
+	// marker, but a nil value is legacy/unknown and cannot prove that the
+	// corrected transitive frontier algorithm covered grafts hidden below them.
+	GraftCoverage *MemoryGraftCoverage `json:"graft_coverage,omitempty"`
+}
+
+// MemoryGraftCoverage describes which transitive lineage a MemoryDigest tried
+// to project. ProjectionComplete=true makes the Merkle fingerprint a trusted
+// proof; false retains pinned/partial data but can never stop traversal. The
+// fingerprint covers natural/graft topology, every reachable graft register,
+// and ancestor memory pointers. The root register remains inline for a cheap
+// rejection before recomputing it.
+type MemoryGraftCoverage struct {
+	ProjectionVersion  uint32        `json:"projection_version"`
+	ProjectionComplete bool          `json:"projection_complete"`
+	LineageFingerprint ContentHash   `json:"lineage_fingerprint,omitempty"`
+	GraftSeq           uint64        `json:"graft_seq"`
+	GraftParents       []ContentHash `json:"graft_parents,omitempty"`
+	PinnedSources      []ContentHash `json:"pinned_sources,omitempty"`
 }
 
 // MemoryFragment is one snapshot's independently distilled contribution.

--- a/cli/internal/domain/hash_test.go
+++ b/cli/internal/domain/hash_test.go
@@ -2,6 +2,7 @@ package domain
 
 import (
 	"errors"
+	"strings"
 	"testing"
 )
 
@@ -16,6 +17,26 @@ func testSessionDoc(t *testing.T, text string) SessionDoc {
 		t.Fatal(err)
 	}
 	return SessionDoc{Hash: HashContent(canonical), CIR: cir}
+}
+
+func TestMemoryDigestCoverageWireHashParity(t *testing.T) {
+	h := func(c string) ContentHash { return ContentHash("sha256:" + strings.Repeat(c, 64)) }
+	digest := MemoryDigest{
+		SnapshotID: h("a"), Summary: "summary", KeyFacts: []string{"fact"}, OpenTasks: []string{}, Provider: ProviderCodex,
+		Fragments: []MemoryFragment{{SourceSnapshot: h("b"), Summary: "fragment"}},
+		GraftCoverage: &MemoryGraftCoverage{
+			ProjectionVersion: MemoryProjectionVersion, ProjectionComplete: true, LineageFingerprint: h("c"), GraftSeq: 2,
+			GraftParents: []ContentHash{h("d")}, PinnedSources: []ContentHash{h("e")},
+		},
+	}
+	wire := `{"snapshot_id":"` + string(h("a")) + `","summary":"summary","key_facts":["fact"],"open_tasks":[],"provider":"codex","fragments":[{"source_snapshot":"` + string(h("b")) + `","summary":"fragment"}],"graft_coverage":{"projection_version":1,"projection_complete":true,"lineage_fingerprint":"` + string(h("c")) + `","graft_seq":2,"graft_parents":["` + string(h("d")) + `"],"pinned_sources":["` + string(h("e")) + `"]}}`
+	got, err := MemoryDigestHash(digest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := HashContent([]byte(wire)); got != want {
+		t.Fatalf("coverage wire hash = %s, want %s", got, want)
+	}
 }
 
 func TestValidateSessionDocHashRecomputesCanonicalContent(t *testing.T) {

--- a/frontend/src/domain/entities.ts
+++ b/frontend/src/domain/entities.ts
@@ -191,6 +191,27 @@ export interface MemoryDigest {
   openTasks: string[];
 /** Injection target format hint (used for provider format determination). */
   provider: ProviderKind;
+/** Snapshot-scoped contributions used to union natural and graft lineages. */
+  fragments?: MemoryFragment[];
+/** Exact graft register projected when this digest was attached. */
+  graftCoverage?: MemoryGraftCoverage;
+}
+
+export interface MemoryFragment {
+  sourceSnapshot: ContentHash;
+  summary?: string;
+  keyFacts?: string[];
+  openTasks?: string[];
+  tasksAuthoritative?: boolean;
+}
+
+export interface MemoryGraftCoverage {
+  projectionVersion: number;
+  projectionComplete: boolean;
+  lineageFingerprint?: ContentHash;
+  graftSeq: number;
+  graftParents?: ContentHash[];
+  pinnedSources?: ContentHash[];
 }
 
 // ── Manifest ────────────────────────────────────────────────────

--- a/frontend/src/domain/index.ts
+++ b/frontend/src/domain/index.ts
@@ -36,6 +36,8 @@ export type {
   Ref,
   SessionDoc,
   MemoryDigest,
+  MemoryFragment,
+  MemoryGraftCoverage,
   Manifest,
 } from './entities.js';
 

--- a/frontend/src/infrastructure/mappers.ts
+++ b/frontend/src/infrastructure/mappers.ts
@@ -101,13 +101,42 @@ export function mapSessionDoc(raw: RawSessionDoc): SessionDoc {
 }
 
 export function mapMemoryDigest(raw: RawMemoryDigest): MemoryDigest {
-  return {
+  const fragmentsRaw = raw['fragments'];
+  const fragments = Array.isArray(fragmentsRaw)
+    ? fragmentsRaw.map((value) => {
+        const fragment = value != null && typeof value === 'object' ? (value as Record<string, unknown>) : {};
+        return {
+          sourceSnapshot: str(fragment, 'source_snapshot'),
+          summary: str(fragment, 'summary'),
+          keyFacts: strArr(fragment, 'key_facts'),
+          openTasks: strArr(fragment, 'open_tasks'),
+          tasksAuthoritative: fragment['tasks_authoritative'] === true,
+        };
+      })
+    : undefined;
+  const coverageRaw = raw['graft_coverage'];
+  const coverage = coverageRaw != null && typeof coverageRaw === 'object'
+    ? coverageRaw as Record<string, unknown>
+    : undefined;
+  const digest: MemoryDigest = {
     snapshotId: str(raw, 'snapshot_id'),
     summary: str(raw, 'summary'),
     keyFacts: strArr(raw, 'key_facts'),
     openTasks: strArr(raw, 'open_tasks'),
     provider: str(raw, 'provider') as ProviderKind,
   };
+  if (fragments) digest.fragments = fragments;
+  if (coverage) {
+    digest.graftCoverage = {
+      projectionVersion: num(coverage, 'projection_version'),
+      projectionComplete: coverage['projection_complete'] === true,
+      lineageFingerprint: str(coverage, 'lineage_fingerprint'),
+      graftSeq: num(coverage, 'graft_seq'),
+      graftParents: strArr(coverage, 'graft_parents'),
+      pinnedSources: strArr(coverage, 'pinned_sources'),
+    };
+  }
+  return digest;
 }
 
 export function mapManifest(raw: RawManifest): Manifest {

--- a/frontend/web/src/types.ts
+++ b/frontend/web/src/types.ts
@@ -242,6 +242,21 @@ export interface MemoryDigest {
   key_facts: string[] | null;
   open_tasks: string[] | null;
   provider: string;
+  fragments?: Array<{
+    source_snapshot: string;
+    summary?: string;
+    key_facts?: string[];
+    open_tasks?: string[];
+    tasks_authoritative?: boolean;
+  }>;
+  graft_coverage?: {
+    projection_version: number;
+    projection_complete: boolean;
+    lineage_fingerprint?: string;
+    graft_seq: number;
+    graft_parents?: string[];
+    pinned_sources?: string[];
+  };
 }
 
 /** Content-addressed session body (CIR) */

--- a/schemas/openapi.yaml
+++ b/schemas/openapi.yaml
@@ -352,6 +352,34 @@ components:
                 items: { type: string }
               tasks_authoritative:
                 type: boolean
+        graft_coverage:
+          type: object
+          description: "Versioned transitive-lineage state recorded when this digest was attached. A complete fingerprint covers natural/graft topology, every reachable graft register, and ancestor memory pointers; incomplete and legacy digests are preserved but conservatively reprojected."
+          required: [projection_version, projection_complete, graft_seq]
+          additionalProperties: false
+          properties:
+            projection_version:
+              type: integer
+              minimum: 1
+              maximum: 4294967295
+            projection_complete:
+              type: boolean
+              description: "True only when every reachable snapshot and memory frontier was readable while projecting. False values are preserved but never trusted as traversal stops."
+            lineage_fingerprint:
+              $ref: "#/components/schemas/ContentHash"
+            graft_seq:
+              type: integer
+              minimum: 0
+              maximum: 9223372036854775807
+            graft_parents:
+              type: array
+              items:
+                $ref: "#/components/schemas/ContentHash"
+            pinned_sources:
+              type: array
+              description: "Fragment source snapshots retained by this digest because they were imported or were not reproducible from the available root parent-memory projection."
+              items:
+                $ref: "#/components/schemas/ContentHash"
 
     ErrorResponse:
       type: object


### PR DESCRIPTION
Closes #64.

## Root cause

A snapshot can gain mutable `graft_parents` after its immutable memory digest was written. The old nearest-digest lookup stopped at that stale digest and treated it as if it covered the new overlay, so the context DAG remained lossless while the active memory projection silently omitted teammate/PR lineage.

## Fix

- project every nearest memory frontier through natural and graft parents;
- record the exact graft register covered by each new digest;
- treat legacy/changed coverage conservatively and repair it by projecting parents before the snapshot's own digest;
- preserve deterministic parent-before-child ordering and exact fragment deduplication;
- guard cycles and fail open through missing/corrupt partial ancestors;
- carry coverage through CLI/backend domain types, OpenAPI, and v2 chunk manifests without mutating old memory objects;
- preserve existing inherited memory and seed prompt budgets.

## Verification

The signed rebased commit has byte-identical tree content to the fully reviewed and tested pre-rebase commit (`87831e9`). Coverage includes the real one-generation graft-shadow shape, memoryless multi-parent boundaries, current/legacy coverage, nested/shared grafts, corruption/cycles, chunk round trips, hash parity, and schema drift. CI will rerun the complete backend/CLI/web/E2E matrix on this PR.
