### PR TITLE
fix(memory): make attachments causal and conflict-safe

### DIFF
--- a/backend/internal/adapters/delivery/http/server.go
+++ b/backend/internal/adapters/delivery/http/server.go
@@ -53,7 +53,9 @@ type Backend interface {
 	ListRefs(ctx context.Context, repoID domain.ContentHash) ([]domain.Ref, error)
 	// MemoryDigest: snapshot derivative carried with the raw document (compatibility rules).
 	PutMemoryDigest(ctx context.Context, repoID domain.ContentHash, d domain.MemoryDigest) (domain.ContentHash, error)
+	PutMemoryDigestCAS(ctx context.Context, repoID domain.ContentHash, d domain.MemoryDigest) (domain.ContentHash, error)
 	GetMemoryDigest(ctx context.Context, repoID, snapshotID domain.ContentHash) (domain.MemoryDigest, error)
+	GetMemoryObject(ctx context.Context, repoID, hash domain.ContentHash) (domain.MemoryDigest, error)
 	// About + team default settings bundle (web editing).
 	UpdateAbout(ctx context.Context, repoID domain.ContentHash, description, website string, topics []string) error
 	PutSettings(ctx context.Context, repoID domain.ContentHash, bundle domain.SettingsBundle) error
@@ -165,6 +167,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("GET /api/v1/repos/{repoID}/search", s.guard(domain.RoleViewer, s.search))
 	mux.HandleFunc("GET /api/v1/repos/{repoID}/docs/{hash}", s.guard(domain.RoleViewer, s.getDoc))
 	mux.HandleFunc("GET /api/v1/repos/{repoID}/memories/{snapshotID}", s.guard(domain.RoleViewer, s.getMemory))
+	mux.HandleFunc("GET /api/v1/repos/{repoID}/memory-objects/{hash}", s.guard(domain.RoleViewer, s.getMemoryObject))
 	// About/team settings/secrets: writes require maintainer or higher plus the action-specific requireRepoAction policy; reads require puller or higher for local team-asset synchronization.
 	mux.HandleFunc("PATCH /api/v1/repos/{repoID}/about", s.guard(domain.RoleMaintainer, s.patchAbout))
 	mux.HandleFunc("GET /api/v1/repos/{repoID}/settings/{kind}", s.guard(domain.RolePuller, s.getSettings))
@@ -175,6 +178,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("GET /api/v1/repos/{repoID}/settings-objects/{hash}", s.guard(domain.RolePuller, s.getSettingsObject))
 	mux.HandleFunc("PUT /api/v1/repos/{repoID}/settings-objects/{hash}", s.guard(domain.RoleMember, s.putSettingsObject))
 	mux.HandleFunc("PUT /api/v1/repos/{repoID}/memories/{snapshotID}", s.guard(domain.RoleMember, s.putMemory))
+	mux.HandleFunc("PUT /api/v1/repos/{repoID}/memory-attachments/{snapshotID}", s.guard(domain.RoleMember, s.putMemoryAttachment))
 	// In-progress context pointer: Write/Delete = context push layer (member), Read = pull/web layer (puller).
 	mux.HandleFunc("GET /api/v1/repos/{repoID}/pending", s.guard(domain.RolePuller, s.listPending))
 	mux.HandleFunc("PUT /api/v1/repos/{repoID}/pending/{sessionID}", s.guard(domain.RoleMember, s.putPending))
@@ -793,6 +797,21 @@ func (s *Server) putMemory(w http.ResponseWriter, r *http.Request) {
 	d.SnapshotID = domain.ContentHash(r.PathValue("snapshotID"))
 	hash, err := s.b.PutMemoryDigest(r.Context(), s.repoID(r), d)
 	s.respond(w, map[string]any{"memory_hash": hash}, err)
+}
+
+func (s *Server) putMemoryAttachment(w http.ResponseWriter, r *http.Request) {
+	var d domain.MemoryDigest
+	if !s.decode(w, r, &d) {
+		return
+	}
+	d.SnapshotID = domain.ContentHash(r.PathValue("snapshotID"))
+	hash, err := s.b.PutMemoryDigestCAS(r.Context(), s.repoID(r), d)
+	s.respond(w, map[string]any{"memory_hash": hash}, err)
+}
+
+func (s *Server) getMemoryObject(w http.ResponseWriter, r *http.Request) {
+	out, err := s.b.GetMemoryObject(r.Context(), s.repoID(r), domain.ContentHash(r.PathValue("hash")))
+	s.respond(w, out, err)
 }
 
 func (s *Server) getDoc(w http.ResponseWriter, r *http.Request) {

--- a/backend/internal/adapters/store/fs_store.go
+++ b/backend/internal/adapters/store/fs_store.go
@@ -1600,12 +1600,17 @@ func dedupHashParents(id domain.ContentHash, natural, graft []domain.ContentHash
 	return out
 }
 
-// SetSnapshotMemory attaches only the derived memory pointer (push after memorize — ID/Body immutable).
-func (s *FSStore) SetSnapshotMemory(ctx context.Context, repoID, id, memoryHash domain.ContentHash) error {
-	if err := validateHashes(repoID, id, memoryHash); err != nil {
+// CompareAndSwapSnapshotMemory advances only the derived memory pointer. The
+// same per-snapshot lock used by graft/message metadata makes the comparison
+// and write one atomic boundary.
+func (s *FSStore) CompareAndSwapSnapshotMemory(ctx context.Context, repoID, id, expected, next domain.ContentHash) error {
+	if err := validateHashes(repoID, id, next); err != nil {
 		return err
 	}
-	if _, err := s.GetMemory(ctx, repoID, memoryHash); err != nil {
+	if err := domain.ValidateOptionalContentHash(expected); err != nil {
+		return err
+	}
+	if _, err := s.GetMemory(ctx, repoID, next); err != nil {
 		return err
 	}
 	mu := s.snapshotLock(repoID, id)
@@ -1615,10 +1620,13 @@ func (s *FSStore) SetSnapshotMemory(ctx context.Context, repoID, id, memoryHash 
 	if err != nil {
 		return err
 	}
-	if snap.MemoryHash == memoryHash {
+	if snap.MemoryHash == next {
 		return nil
 	}
-	snap.MemoryHash = memoryHash
+	if snap.MemoryHash != expected {
+		return domain.ErrConflict
+	}
+	snap.MemoryHash = next
 	data, err := json.Marshal(snap)
 	if err != nil {
 		return err
@@ -1796,7 +1804,7 @@ func (s *FSStore) refLock(repoID domain.ContentHash, _ domain.RefKind, _ string)
 	return lock.(*sync.Mutex)
 }
 
-// fsSnapshotLocks is a mutex for (dataDir, repoID, snapshotID) units. All paths that modify snapshot files (UpdateSnapshotMessage/AddGraftParents/SetSnapshotMemory) must share it — locking one path leaves a lost-update race with other meta updates (review P1). Separate from refLock because refLock is specific to ref movement, and reusing it for snapshot meta updates blurs the lock's meaning.
+// fsSnapshotLocks is a mutex for (dataDir, repoID, snapshotID) units. All paths that modify snapshot files (UpdateSnapshotMessage/AddGraftParents/CompareAndSwapSnapshotMemory) must share it — locking one path leaves a lost-update race with other meta updates (review P1). Separate from refLock because refLock is specific to ref movement, and reusing it for snapshot meta updates blurs the lock's meaning.
 var fsSnapshotLocks sync.Map
 
 func (s *FSStore) snapshotLock(repoID, id domain.ContentHash) *sync.Mutex {
@@ -1918,6 +1926,7 @@ func (s *FSStore) GetManifest(ctx context.Context, repoID domain.ContentHash) (d
 		return domain.Manifest{}, err
 	}
 	var index []domain.ContentHash
+	memoryAttachments := map[domain.ContentHash]domain.ContentHash{}
 	dir := filepath.Join(s.repoDir(repoID), "snapshots")
 	if entries, err := os.ReadDir(dir); err == nil {
 		for _, e := range entries {
@@ -1928,20 +1937,25 @@ func (s *FSStore) GetManifest(ctx context.Context, repoID domain.ContentHash) (d
 			if !ok {
 				continue
 			}
-			if _, err := s.GetSnapshot(ctx, repoID, id); err != nil {
+			snap, err := s.GetSnapshot(ctx, repoID, id)
+			if err != nil {
 				return domain.Manifest{}, err
 			}
 			index = append(index, id)
+			if snap.MemoryHash != "" {
+				memoryAttachments[id] = snap.MemoryHash
+			}
 		}
 	} else if !os.IsNotExist(err) {
 		return domain.Manifest{}, err
 	}
 	return domain.Manifest{
-		RepoID:        repoID,
-		Refs:          refs,
-		SnapshotIndex: index,
-		Version:       len(index),
-		UpdatedAt:     time.Now().UTC(),
+		RepoID:            repoID,
+		Refs:              refs,
+		SnapshotIndex:     index,
+		MemoryAttachments: memoryAttachments,
+		Version:           len(index),
+		UpdatedAt:         time.Now().UTC(),
 	}, nil
 }
 

--- a/backend/internal/adapters/store/memory_chunks.go
+++ b/backend/internal/adapters/store/memory_chunks.go
@@ -17,6 +17,9 @@ func validateMemoryDigestRefs(digest domain.MemoryDigest) error {
 	if err := domain.ValidateOptionalContentHash(digest.SnapshotID); err != nil {
 		return err
 	}
+	if err := domain.ValidateOptionalContentHash(digest.PreviousMemoryHash); err != nil {
+		return err
+	}
 	for _, fragment := range digest.Fragments {
 		if err := validateHash(fragment.SourceSnapshot); err != nil {
 			return err

--- a/backend/internal/adapters/store/memory_chunks_test.go
+++ b/backend/internal/adapters/store/memory_chunks_test.go
@@ -140,7 +140,7 @@ func TestFSRepackMemoriesRemovesOnlyPointerBackedMeta(t *testing.T) {
 		if err := st.PutMemoryMeta(ctx, repo, digest); err != nil {
 			t.Fatal(err)
 		}
-		if err := st.SetSnapshotMemory(ctx, repo, digest.SnapshotID, hash); err != nil {
+		if err := st.CompareAndSwapSnapshotMemory(ctx, repo, digest.SnapshotID, "", hash); err != nil {
 			t.Fatal(err)
 		}
 		hashes = append(hashes, hash)

--- a/backend/internal/adapters/store/postgres_smoke_test.go
+++ b/backend/internal/adapters/store/postgres_smoke_test.go
@@ -116,8 +116,52 @@ func TestPGSmoke(t *testing.T) {
 	if err := st.PutMemoryMeta(ctx, repoID, digest); err != nil {
 		t.Fatalf("memory(nil slice): %v", err)
 	}
-	if err := st.SetSnapshotMemory(ctx, repoID, snapID, memoryHash); err != nil {
+	if err := st.CompareAndSwapSnapshotMemory(ctx, repoID, snapID, "", memoryHash); err != nil {
 		t.Fatalf("attach memory: %v", err)
+	}
+	// Two database clients racing from the same causal parent must serialize on
+	// SELECT ... FOR UPDATE: exactly one advances and the stale writer conflicts.
+	contenderHashes := make([]domain.ContentHash, 0, 2)
+	for _, summary := range []string{"database contender one", "database contender two"} {
+		contender := domain.MemoryDigest{
+			SnapshotID: snapID, PreviousMemoryHash: memoryHash,
+			Summary: summary, Provider: domain.ProviderClaude,
+		}
+		hash, err := st.PutMemory(ctx, repoID, contender)
+		if err != nil {
+			t.Fatalf("contender memory blob: %v", err)
+		}
+		contenderHashes = append(contenderHashes, hash)
+	}
+	startMemoryCAS := make(chan struct{})
+	memoryCASErrs := make(chan error, len(contenderHashes))
+	for _, hash := range contenderHashes {
+		go func(next domain.ContentHash) {
+			<-startMemoryCAS
+			memoryCASErrs <- st.CompareAndSwapSnapshotMemory(ctx, repoID, snapID, memoryHash, next)
+		}(hash)
+	}
+	close(startMemoryCAS)
+	var memoryCASSuccesses, memoryCASConflicts int
+	for range contenderHashes {
+		switch err := <-memoryCASErrs; {
+		case err == nil:
+			memoryCASSuccesses++
+		case errors.Is(err, domain.ErrConflict):
+			memoryCASConflicts++
+		default:
+			t.Fatalf("unexpected concurrent memory CAS error: %v", err)
+		}
+	}
+	if memoryCASSuccesses != 1 || memoryCASConflicts != 1 {
+		t.Fatalf("concurrent memory CAS: successes=%d conflicts=%d", memoryCASSuccesses, memoryCASConflicts)
+	}
+	attached, err := st.GetSnapshot(ctx, repoID, snapID)
+	if err != nil {
+		t.Fatalf("snapshot after concurrent memory CAS: %v", err)
+	}
+	if attached.MemoryHash != contenderHashes[0] && attached.MemoryHash != contenderHashes[1] {
+		t.Fatalf("unexpected concurrent memory winner %s", attached.MemoryHash)
 	}
 
 	// Same Git URL and content hash can coexist in different workspace repos. However, before repo supplies directly, a global CAS blob can only be read by hash.

--- a/backend/internal/adapters/store/postgres_store.go
+++ b/backend/internal/adapters/store/postgres_store.go
@@ -514,23 +514,48 @@ func (s *PostgresStore) addGraftParents(ctx context.Context, repoID, id domain.C
 	return tx.Commit(ctx)
 }
 
-// SetSnapshotMemory attaches only the derived memory pointer after memorization is pushed; the ID and body remain immutable.
-func (s *PostgresStore) SetSnapshotMemory(ctx context.Context, repoID, id, memoryHash domain.ContentHash) error {
-	if err := validateHashes(repoID, id, memoryHash); err != nil {
+// CompareAndSwapSnapshotMemory advances the causal memory ref under a row lock.
+func (s *PostgresStore) CompareAndSwapSnapshotMemory(ctx context.Context, repoID, id, expected, next domain.ContentHash) error {
+	if err := validateHashes(repoID, id, next); err != nil {
 		return err
 	}
-	tag, err := s.pool.Exec(ctx,
-		`UPDATE snapshots SET memory_hash=$3
-		 WHERE repo_id=$1 AND id=$2
-		   AND EXISTS (SELECT 1 FROM repo_blobs WHERE repo_id=$1 AND kind='memory' AND hash=$3)`,
-		string(repoID), string(id), string(memoryHash))
+	if err := domain.ValidateOptionalContentHash(expected); err != nil {
+		return err
+	}
+	tx, err := s.pool.Begin(ctx)
 	if err != nil {
 		return err
 	}
-	if tag.RowsAffected() == 0 {
+	defer tx.Rollback(ctx)
+	var current string
+	if err := tx.QueryRow(ctx,
+		`SELECT COALESCE(memory_hash,'') FROM snapshots WHERE repo_id=$1 AND id=$2 FOR UPDATE`,
+		string(repoID), string(id)).Scan(&current); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return domain.ErrNotFound
+		}
+		return err
+	}
+	if domain.ContentHash(current) == next {
+		return tx.Commit(ctx)
+	}
+	if domain.ContentHash(current) != expected {
+		return domain.ErrConflict
+	}
+	var exists bool
+	if err := tx.QueryRow(ctx,
+		`SELECT EXISTS (SELECT 1 FROM repo_blobs WHERE repo_id=$1 AND kind='memory' AND hash=$2)`,
+		string(repoID), string(next)).Scan(&exists); err != nil {
+		return err
+	}
+	if !exists {
 		return domain.ErrNotFound
 	}
-	return nil
+	if _, err := tx.Exec(ctx, `UPDATE snapshots SET memory_hash=$3 WHERE repo_id=$1 AND id=$2`,
+		string(repoID), string(id), string(next)); err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
 }
 
 func (s *PostgresStore) ListSnapshots(ctx context.Context, repoID domain.ContentHash, branch string) ([]domain.Snapshot, error) {
@@ -714,15 +739,16 @@ func (s *PostgresStore) GetManifest(ctx context.Context, repoID domain.ContentHa
 	if err != nil {
 		return domain.Manifest{}, err
 	}
-	rows, err := s.pool.Query(ctx, `SELECT id FROM snapshots WHERE repo_id=$1`, string(repoID))
+	rows, err := s.pool.Query(ctx, `SELECT id, COALESCE(memory_hash,'') FROM snapshots WHERE repo_id=$1`, string(repoID))
 	if err != nil {
 		return domain.Manifest{}, err
 	}
 	defer rows.Close()
 	var index []domain.ContentHash
+	memoryAttachments := map[domain.ContentHash]domain.ContentHash{}
 	for rows.Next() {
-		var id string
-		if err := rows.Scan(&id); err != nil {
+		var id, memoryHash string
+		if err := rows.Scan(&id, &memoryHash); err != nil {
 			return domain.Manifest{}, err
 		}
 		hash := domain.ContentHash(id)
@@ -730,8 +756,15 @@ func (s *PostgresStore) GetManifest(ctx context.Context, repoID domain.ContentHa
 			return domain.Manifest{}, err
 		}
 		index = append(index, hash)
+		if memoryHash != "" {
+			memory := domain.ContentHash(memoryHash)
+			if err := domain.ValidateContentHash(memory); err != nil {
+				return domain.Manifest{}, err
+			}
+			memoryAttachments[hash] = memory
+		}
 	}
-	return domain.Manifest{RepoID: repoID, Refs: refs, SnapshotIndex: index, Version: len(index)}, rows.Err()
+	return domain.Manifest{RepoID: repoID, Refs: refs, SnapshotIndex: index, MemoryAttachments: memoryAttachments, Version: len(index)}, rows.Err()
 }
 
 // --- Memory Meta ---

--- a/backend/internal/app/memory_storage_test.go
+++ b/backend/internal/app/memory_storage_test.go
@@ -55,6 +55,79 @@ func TestMemoryDigestUsesSnapshotPointerWithoutMetaDoubleWrite(t *testing.T) {
 	}
 }
 
+func TestMemoryDigestCASRejectsStaleAndLegacyReplacement(t *testing.T) {
+	svc, st := newFsckSvc(t)
+	ctx := context.Background()
+	repo := hh("memory-cas-repo")
+	snapshotID := hh("memory-cas-snapshot")
+	if err := st.PutSnapshot(ctx, domain.Snapshot{ID: snapshotID, RepoID: repo, DocHash: snapshotID}); err != nil {
+		t.Fatal(err)
+	}
+	root := domain.MemoryDigest{SnapshotID: snapshotID, Summary: "root", Provider: domain.ProviderCodex}
+	rootHash, err := svc.PutMemoryDigest(ctx, repo, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := svc.PutMemoryDigest(ctx, repo, domain.MemoryDigest{
+		SnapshotID: snapshotID, Summary: "legacy stale replacement", Provider: domain.ProviderCodex,
+	}); !errors.Is(err, domain.ErrConflict) {
+		t.Fatalf("legacy replacement error = %v", err)
+	}
+
+	second := domain.MemoryDigest{
+		SnapshotID: snapshotID, PreviousMemoryHash: rootHash,
+		Summary: "causal second", Provider: domain.ProviderCodex,
+	}
+	secondHash, err := svc.PutMemoryDigestCAS(ctx, repo, second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stale := domain.MemoryDigest{
+		SnapshotID: snapshotID, PreviousMemoryHash: rootHash,
+		Summary: "divergent stale child", Provider: domain.ProviderCodex,
+	}
+	if _, err := svc.PutMemoryDigestCAS(ctx, repo, stale); !errors.Is(err, domain.ErrConflict) {
+		t.Fatalf("stale causal replacement error = %v", err)
+	}
+	got, err := st.GetSnapshot(ctx, repo, snapshotID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.MemoryHash != secondHash {
+		t.Fatalf("stale write moved pointer: got %s want %s", got.MemoryHash, secondHash)
+	}
+}
+
+func TestMemoryDigestCASRejectsParentFromAnotherSnapshot(t *testing.T) {
+	svc, st := newFsckSvc(t)
+	ctx := context.Background()
+	repo := hh("memory-parent-repo")
+	firstSnapshot := hh("memory-parent-first")
+	secondSnapshot := hh("memory-parent-second")
+	for _, id := range []domain.ContentHash{firstSnapshot, secondSnapshot} {
+		if err := st.PutSnapshot(ctx, domain.Snapshot{ID: id, RepoID: repo, DocHash: id}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	foreignHash, err := svc.PutMemoryDigest(ctx, repo, domain.MemoryDigest{
+		SnapshotID: firstSnapshot, Summary: "foreign root", Provider: domain.ProviderCodex,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = svc.PutMemoryDigestCAS(ctx, repo, domain.MemoryDigest{
+		SnapshotID: secondSnapshot, PreviousMemoryHash: foreignHash,
+		Summary: "invalid child", Provider: domain.ProviderCodex,
+	})
+	if !errors.Is(err, domain.ErrIntegrity) {
+		t.Fatalf("foreign parent error=%v", err)
+	}
+	got, err := st.GetSnapshot(ctx, repo, secondSnapshot)
+	if err != nil || got.MemoryHash != "" {
+		t.Fatalf("invalid parent moved pointer=%s err=%v", got.MemoryHash, err)
+	}
+}
+
 func TestMemoryDigestAcceptsExplicitIncompleteProjectionWithoutFingerprint(t *testing.T) {
 	svc, st := newFsckSvc(t)
 	ctx := context.Background()
@@ -123,7 +196,7 @@ func TestMemoryDigestFallsBackOnlyForPointerlessLegacySnapshot(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := base.SetSnapshotMemory(ctx, repo, snapshotID, hash); err != nil {
+	if err := base.CompareAndSwapSnapshotMemory(ctx, repo, snapshotID, "", hash); err != nil {
 		t.Fatal(err)
 	}
 	failing := &missingMemoryBlob{FSStore: base}

--- a/backend/internal/app/service.go
+++ b/backend/internal/app/service.go
@@ -1044,13 +1044,28 @@ func gitOriginLabel(raw string) string {
 	return raw
 }
 
-// PutMemoryDigest stores snapshot derivative memory as one authoritative blob
-// and attaches its hash to the snapshot. Older releases also wrote the entire
-// digest to MemoryMeta, doubling every large summary; pointerless metadata is
-// now read-only legacy fallback.
-// The target snapshot must exist first (design: 404/422 if not).
+// PutMemoryDigest is the rolling-upgrade endpoint for legacy clients. It may
+// create an empty attachment or retry the exact current digest, but it cannot
+// replace a non-empty pointer because old clients provide no causal parent.
 func (s *Service) PutMemoryDigest(ctx context.Context, repoID domain.ContentHash, d domain.MemoryDigest) (domain.ContentHash, error) {
+	if d.PreviousMemoryHash != "" {
+		return "", fmt.Errorf("%w: causal memory requires the attachment endpoint", domain.ErrValidation)
+	}
+	return s.putMemoryDigest(ctx, repoID, d, "", false)
+}
+
+// PutMemoryDigestCAS advances Snapshot.MemoryHash only from the digest's
+// PreviousMemoryHash. The immutable blob is retained even when the pointer CAS
+// loses, so neither concurrent memory is destroyed.
+func (s *Service) PutMemoryDigestCAS(ctx context.Context, repoID domain.ContentHash, d domain.MemoryDigest) (domain.ContentHash, error) {
+	return s.putMemoryDigest(ctx, repoID, d, d.PreviousMemoryHash, true)
+}
+
+func (s *Service) putMemoryDigest(ctx context.Context, repoID domain.ContentHash, d domain.MemoryDigest, expected domain.ContentHash, causal bool) (domain.ContentHash, error) {
 	if err := validateHashes(repoID, d.SnapshotID); err != nil {
+		return "", err
+	}
+	if err := domain.ValidateOptionalContentHash(d.PreviousMemoryHash); err != nil {
 		return "", err
 	}
 	for _, fragment := range d.Fragments {
@@ -1084,16 +1099,34 @@ func (s *Service) PutMemoryDigest(ctx context.Context, repoID domain.ContentHash
 	if _, err := s.meta.GetSnapshot(ctx, repoID, d.SnapshotID); err != nil {
 		return "", err // ErrNotFound → 404
 	}
+	if causal && expected != "" {
+		previous, err := s.blobs.GetMemory(ctx, repoID, expected)
+		if err != nil {
+			return "", err
+		}
+		if previous.SnapshotID != d.SnapshotID {
+			return "", fmt.Errorf("%w: memory parent belongs to another snapshot", domain.ErrIntegrity)
+		}
+	}
 	hash, err := s.blobs.PutMemory(ctx, repoID, d)
 	if err != nil {
 		return "", err
 	}
 	// Attaches a derivative pointer to the snapshot metadata — after push, the memorize also holds raw+memory (E clause).
 	// Without this, pull/web cannot recognize memory existence.
-	if err := s.meta.SetSnapshotMemory(ctx, repoID, d.SnapshotID, hash); err != nil {
+	if err := s.meta.CompareAndSwapSnapshotMemory(ctx, repoID, d.SnapshotID, expected, hash); err != nil {
 		return "", err
 	}
 	return hash, nil
+}
+
+// GetMemoryObject reads one immutable attachment object by its own hash. Pull
+// uses this to prove ancestry before moving a local memory ref.
+func (s *Service) GetMemoryObject(ctx context.Context, repoID, hash domain.ContentHash) (domain.MemoryDigest, error) {
+	if err := validateHashes(repoID, hash); err != nil {
+		return domain.MemoryDigest{}, err
+	}
+	return s.blobs.GetMemory(ctx, repoID, hash)
 }
 
 // GetMemoryDigest resolves the authoritative MemoryHash pointer. Metadata-only

--- a/backend/internal/domain/entities.go
+++ b/backend/internal/domain/entities.go
@@ -226,11 +226,12 @@ type RefLogEntry struct {
 //   - M2: Version must monotonically increase with each update ( CAS).
 //   - C1: Manifest write must fail without version-CAS (lost-update prevention).
 type Manifest struct {
-	RepoID        ContentHash   `json:"repo_id"`
-	Refs          []Ref         `json:"refs"`
-	SnapshotIndex []ContentHash `json:"snapshot_index"`
-	Version       int           `json:"version"`
-	UpdatedAt     time.Time     `json:"updated_at"`
+	RepoID            ContentHash                 `json:"repo_id"`
+	Refs              []Ref                       `json:"refs"`
+	SnapshotIndex     []ContentHash               `json:"snapshot_index"`
+	MemoryAttachments map[ContentHash]ContentHash `json:"memory_attachments"`
+	Version           int                         `json:"version"`
+	UpdatedAt         time.Time                   `json:"updated_at"`
 }
 
 // MemoryDigest is the distilled memory from a snapshot (derivative, data model table, sync protocol).
@@ -239,13 +240,14 @@ type Manifest struct {
 //
 // The backend stores only CIR-neutral digests and does not know provider-native formats.
 type MemoryDigest struct {
-	SnapshotID    ContentHash          `json:"snapshot_id"`
-	Summary       string               `json:"summary"`
-	KeyFacts      []string             `json:"key_facts"`
-	OpenTasks     []string             `json:"open_tasks"`
-	Provider      ProviderKind         `json:"provider"`
-	Fragments     []MemoryFragment     `json:"fragments,omitempty"`
-	GraftCoverage *MemoryGraftCoverage `json:"graft_coverage,omitempty"`
+	SnapshotID         ContentHash          `json:"snapshot_id"`
+	PreviousMemoryHash ContentHash          `json:"previous_memory_hash,omitempty"`
+	Summary            string               `json:"summary"`
+	KeyFacts           []string             `json:"key_facts"`
+	OpenTasks          []string             `json:"open_tasks"`
+	Provider           ProviderKind         `json:"provider"`
+	Fragments          []MemoryFragment     `json:"fragments,omitempty"`
+	GraftCoverage      *MemoryGraftCoverage `json:"graft_coverage,omitempty"`
 }
 
 // MemoryGraftCoverage is the root graft register and transitive lineage state

--- a/backend/internal/domain/hash_test.go
+++ b/backend/internal/domain/hash_test.go
@@ -26,14 +26,14 @@ func TestValidateSessionDocHash(t *testing.T) {
 func TestMemoryDigestCoverageWireHashParity(t *testing.T) {
 	h := func(c string) ContentHash { return ContentHash("sha256:" + strings.Repeat(c, 64)) }
 	digest := MemoryDigest{
-		SnapshotID: h("a"), Summary: "summary", KeyFacts: []string{"fact"}, OpenTasks: []string{}, Provider: ProviderCodex,
+		SnapshotID: h("a"), PreviousMemoryHash: h("f"), Summary: "summary", KeyFacts: []string{"fact"}, OpenTasks: []string{}, Provider: ProviderCodex,
 		Fragments: []MemoryFragment{{SourceSnapshot: h("b"), Summary: "fragment"}},
 		GraftCoverage: &MemoryGraftCoverage{
 			ProjectionVersion: MemoryProjectionVersion, ProjectionComplete: true, LineageFingerprint: h("c"), GraftSeq: 2,
 			GraftParents: []ContentHash{h("d")}, PinnedSources: []ContentHash{h("e")},
 		},
 	}
-	wire := `{"snapshot_id":"` + string(h("a")) + `","summary":"summary","key_facts":["fact"],"open_tasks":[],"provider":"codex","fragments":[{"source_snapshot":"` + string(h("b")) + `","summary":"fragment"}],"graft_coverage":{"projection_version":1,"projection_complete":true,"lineage_fingerprint":"` + string(h("c")) + `","graft_seq":2,"graft_parents":["` + string(h("d")) + `"],"pinned_sources":["` + string(h("e")) + `"]}}`
+	wire := `{"snapshot_id":"` + string(h("a")) + `","previous_memory_hash":"` + string(h("f")) + `","summary":"summary","key_facts":["fact"],"open_tasks":[],"provider":"codex","fragments":[{"source_snapshot":"` + string(h("b")) + `","summary":"fragment"}],"graft_coverage":{"projection_version":1,"projection_complete":true,"lineage_fingerprint":"` + string(h("c")) + `","graft_seq":2,"graft_parents":["` + string(h("d")) + `"],"pinned_sources":["` + string(h("e")) + `"]}}`
 	got, err := MemoryDigestHash(digest)
 	if err != nil {
 		t.Fatal(err)

--- a/backend/internal/domain/memory_chunks.go
+++ b/backend/internal/domain/memory_chunks.go
@@ -12,19 +12,21 @@ const MemoryChunkTarget = 64 << 10
 const (
 	MemoryChunkFormatV1 = "cxt-memory-chunks-v1"
 	MemoryChunkFormatV2 = "cxt-memory-chunks-v2"
+	MemoryChunkFormatV3 = "cxt-memory-chunks-v3"
 )
 
 // MemoryChunkManifest is an at-rest representation. MemoryDigestHash remains
 // the hash of complete wire JSON; storage chunking never changes identity.
 type MemoryChunkManifest struct {
-	Format         string               `json:"format"`
-	SnapshotID     ContentHash          `json:"snapshot_id"`
-	SummaryChunks  []ContentHash        `json:"summary_chunks,omitempty"`
-	KeyFacts       []string             `json:"key_facts"`
-	OpenTasks      []string             `json:"open_tasks"`
-	Provider       ProviderKind         `json:"provider"`
-	FragmentChunks []ContentHash        `json:"fragment_chunks,omitempty"`
-	GraftCoverage  *MemoryGraftCoverage `json:"graft_coverage,omitempty"`
+	Format             string               `json:"format"`
+	SnapshotID         ContentHash          `json:"snapshot_id"`
+	PreviousMemoryHash ContentHash          `json:"previous_memory_hash,omitempty"`
+	SummaryChunks      []ContentHash        `json:"summary_chunks,omitempty"`
+	KeyFacts           []string             `json:"key_facts"`
+	OpenTasks          []string             `json:"open_tasks"`
+	Provider           ProviderKind         `json:"provider"`
+	FragmentChunks     []ContentHash        `json:"fragment_chunks,omitempty"`
+	GraftCoverage      *MemoryGraftCoverage `json:"graft_coverage,omitempty"`
 }
 
 type MemoryChunkPlan struct {
@@ -46,12 +48,13 @@ func PlanMemoryChunks(d MemoryDigest) (plan MemoryChunkPlan, ok bool, err error)
 	}
 	plan = MemoryChunkPlan{
 		Manifest: MemoryChunkManifest{
-			Format:        memoryChunkFormatFor(d),
-			SnapshotID:    d.SnapshotID,
-			KeyFacts:      d.KeyFacts,
-			OpenTasks:     d.OpenTasks,
-			Provider:      d.Provider,
-			GraftCoverage: d.GraftCoverage,
+			Format:             memoryChunkFormatFor(d),
+			SnapshotID:         d.SnapshotID,
+			PreviousMemoryHash: d.PreviousMemoryHash,
+			KeyFacts:           d.KeyFacts,
+			OpenTasks:          d.OpenTasks,
+			Provider:           d.Provider,
+			GraftCoverage:      d.GraftCoverage,
 		},
 		Bodies: map[ContentHash][]byte{},
 	}
@@ -73,6 +76,9 @@ func PlanMemoryChunks(d MemoryDigest) (plan MemoryChunkPlan, ok bool, err error)
 }
 
 func memoryChunkFormatFor(d MemoryDigest) string {
+	if d.PreviousMemoryHash != "" {
+		return MemoryChunkFormatV3
+	}
 	if d.GraftCoverage != nil {
 		return MemoryChunkFormatV2
 	}
@@ -80,7 +86,7 @@ func memoryChunkFormatFor(d MemoryDigest) string {
 }
 
 func SupportedMemoryChunkFormat(format string) bool {
-	return format == MemoryChunkFormatV1 || format == MemoryChunkFormatV2
+	return format == MemoryChunkFormatV1 || format == MemoryChunkFormatV2 || format == MemoryChunkFormatV3
 }
 
 func (p *MemoryChunkPlan) addComponent(data []byte) []ContentHash {
@@ -163,12 +169,13 @@ func AssembleMemoryChunks(man MemoryChunkManifest, bodies map[ContentHash][]byte
 		}
 	}
 	return MemoryDigest{
-		SnapshotID:    man.SnapshotID,
-		Summary:       string(summary),
-		KeyFacts:      man.KeyFacts,
-		OpenTasks:     man.OpenTasks,
-		Provider:      man.Provider,
-		Fragments:     fragments,
-		GraftCoverage: man.GraftCoverage,
+		SnapshotID:         man.SnapshotID,
+		PreviousMemoryHash: man.PreviousMemoryHash,
+		Summary:            string(summary),
+		KeyFacts:           man.KeyFacts,
+		OpenTasks:          man.OpenTasks,
+		Provider:           man.Provider,
+		Fragments:          fragments,
+		GraftCoverage:      man.GraftCoverage,
 	}, nil
 }

--- a/backend/internal/domain/memory_chunks_test.go
+++ b/backend/internal/domain/memory_chunks_test.go
@@ -81,6 +81,23 @@ func TestMemoryComponentPlanKeepsLegacyManifestVersionWithoutCoverage(t *testing
 	}
 }
 
+func TestMemoryComponentPlanUsesV3ForCausalParent(t *testing.T) {
+	previous := HashContent([]byte("previous-memory"))
+	digest := MemoryDigest{
+		SnapshotID: HashContent([]byte("causal-format")), PreviousMemoryHash: previous,
+		Summary: strings.Repeat("causal", 16<<10), Provider: ProviderCodex,
+		GraftCoverage: &MemoryGraftCoverage{ProjectionVersion: MemoryProjectionVersion},
+	}
+	plan, ok, err := PlanMemoryChunks(digest)
+	if err != nil || !ok || plan.Manifest.Format != MemoryChunkFormatV3 {
+		t.Fatalf("causal plan: format=%q ok=%v err=%v", plan.Manifest.Format, ok, err)
+	}
+	got, err := AssembleMemoryChunks(plan.Manifest, plan.Bodies)
+	if err != nil || got.PreviousMemoryHash != previous {
+		t.Fatalf("causal roundtrip: previous=%s err=%v", got.PreviousMemoryHash, err)
+	}
+}
+
 func TestMemoryComponentPlanKeepsSmallDigestMonolithic(t *testing.T) {
 	_, ok, err := PlanMemoryChunks(MemoryDigest{Summary: "small", Provider: ProviderClaude})
 	if err != nil || ok {

--- a/backend/internal/ports/outbound/outbound.go
+++ b/backend/internal/ports/outbound/outbound.go
@@ -47,8 +47,10 @@ type MetadataStore interface {
 	AddGraftParents(ctx context.Context, repoID, id domain.ContentHash, add []domain.ContentHash) error
 	// AddGraftParentsCAS is for client delayed graft events. When adding a new edge, the current seq must exactly match the expected. If the edge already exists, the event is confirmed once at current==expected (seq+1) and only responds to a successful retry at current==expected+1. Other versions are conflicts. Version/cycle checks and writes are atomic boundaries of the store.
 	AddGraftParentsCAS(ctx context.Context, repoID, id domain.ContentHash, add []domain.ContentHash, expected uint64) error
-	// SetSnapshotMemory attaches a memory pointer (memory_hash) to the snapshot — after a snapshot push, reflecting memorize (compatibility rules: raw+memory co-possess). ID remains unchanged.
-	SetSnapshotMemory(ctx context.Context, repoID, id, memoryHash domain.ContentHash) error
+	// CompareAndSwapSnapshotMemory advances the causal memory ref only from the
+	// caller's expected parent. Repeating an already-applied next hash is
+	// idempotent; any other current value is a conflict.
+	CompareAndSwapSnapshotMemory(ctx context.Context, repoID, id, expected, next domain.ContentHash) error
 
 	// Ref / manifest (mutable). Progress is CAS (immutable REF4/C1). UpdateRepoAbout updates About(description/website/topics).
 	UpdateRepoAbout(ctx context.Context, id domain.ContentHash, description, website string, topics []string) error

--- a/cli/internal/adapters/backendclient/backend_client.go
+++ b/cli/internal/adapters/backendclient/backend_client.go
@@ -328,7 +328,9 @@ func (c *BackendClient) RegisterRepo(ctx context.Context, repo domain.Repo) (dom
 	return out, nil
 }
 
-// PushMemory uploads a digest to the server via PUT /repos/{repoID}/memories/{snapshotID} (idempotent).
+// PushMemory advances a causal attachment through the CAS-only endpoint. A
+// distinct path makes rolling upgrades fail before mutation on old servers
+// that do not understand PreviousMemoryHash.
 func (c *BackendClient) PushMemory(ctx context.Context, repoID string, digest domain.MemoryDigest) error {
 	if err := domain.ValidateContentHash(domain.ContentHash(repoID)); err != nil {
 		return err
@@ -336,8 +338,21 @@ func (c *BackendClient) PushMemory(ctx context.Context, repoID string, digest do
 	if err := domain.ValidateContentHash(digest.SnapshotID); err != nil {
 		return err
 	}
-	path := c.reposPath(repoID) + "/memories/" + url.PathEscape(string(digest.SnapshotID))
-	return c.do(ctx, http.MethodPut, path, digest, nil)
+	want, err := domain.MemoryDigestHash(digest)
+	if err != nil {
+		return err
+	}
+	var out struct {
+		MemoryHash domain.ContentHash `json:"memory_hash"`
+	}
+	path := c.reposPath(repoID) + "/memory-attachments/" + url.PathEscape(string(digest.SnapshotID))
+	if err := c.do(ctx, http.MethodPut, path, digest, &out); err != nil {
+		return err
+	}
+	if out.MemoryHash != want {
+		return domain.ErrHashMismatch
+	}
+	return nil
 }
 
 // PullMemory downloads a digest from the server via GET /repos/{repoID}/memories/{snapshotID}.
@@ -350,6 +365,20 @@ func (c *BackendClient) PullMemory(ctx context.Context, repoID string, snapshotI
 	}
 	var d domain.MemoryDigest
 	if err := c.do(ctx, http.MethodGet, c.reposPath(repoID)+"/memories/"+url.PathEscape(string(snapshotID)), nil, &d); err != nil {
+		return domain.MemoryDigest{}, err
+	}
+	return d, nil
+}
+
+func (c *BackendClient) PullMemoryObject(ctx context.Context, repoID string, hash domain.ContentHash) (domain.MemoryDigest, error) {
+	if err := domain.ValidateContentHash(domain.ContentHash(repoID)); err != nil {
+		return domain.MemoryDigest{}, err
+	}
+	if err := domain.ValidateContentHash(hash); err != nil {
+		return domain.MemoryDigest{}, err
+	}
+	var d domain.MemoryDigest
+	if err := c.do(ctx, http.MethodGet, c.reposPath(repoID)+"/memory-objects/"+url.PathEscape(string(hash)), nil, &d); err != nil {
 		return domain.MemoryDigest{}, err
 	}
 	return d, nil
@@ -566,6 +595,27 @@ func (c *BackendClient) RemoteManifest(ctx context.Context, repoID string) (doma
 	var m domain.Manifest
 	if err := c.do(ctx, http.MethodGet, c.reposPath(repoID)+"/manifest", nil, &m); err != nil {
 		return domain.Manifest{}, err
+	}
+	if m.RepoID != repoID {
+		return domain.Manifest{}, domain.ErrHashMismatch
+	}
+	index := make(map[domain.ContentHash]bool, len(m.SnapshotIndex))
+	for _, id := range m.SnapshotIndex {
+		if err := domain.ValidateContentHash(id); err != nil || index[id] {
+			return domain.Manifest{}, domain.ErrHashMismatch
+		}
+		index[id] = true
+	}
+	for snapshotID, memoryHash := range m.MemoryAttachments {
+		if err := domain.ValidateContentHash(snapshotID); err != nil {
+			return domain.Manifest{}, err
+		}
+		if err := domain.ValidateContentHash(memoryHash); err != nil {
+			return domain.Manifest{}, err
+		}
+		if !index[snapshotID] {
+			return domain.Manifest{}, domain.ErrHashMismatch
+		}
 	}
 	return m, nil
 }

--- a/cli/internal/adapters/backendclient/backend_client_test.go
+++ b/cli/internal/adapters/backendclient/backend_client_test.go
@@ -395,3 +395,47 @@ func TestBoundedChunkResponseBodyLimit(t *testing.T) {
 		t.Fatalf("oversized bounded response err=%v", err)
 	}
 }
+
+func TestMemoryClientUsesCausalAttachmentAndObjectEndpoints(t *testing.T) {
+	repoID := domain.HashContent([]byte("memory-client-repo"))
+	snapshotID := domain.HashContent([]byte("memory-client-snapshot"))
+	previous := domain.HashContent([]byte("memory-client-previous"))
+	digest := domain.MemoryDigest{
+		SnapshotID: snapshotID, PreviousMemoryHash: previous, Summary: "causal memory", Provider: domain.ProviderCodex,
+	}
+	digestHash, err := domain.MemoryDigestHash(digest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var putPath, getPath string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPut:
+			putPath = r.URL.Path
+			var got domain.MemoryDigest
+			if err := json.NewDecoder(r.Body).Decode(&got); err != nil || got.PreviousMemoryHash != previous {
+				t.Errorf("put digest=%+v err=%v", got, err)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]domain.ContentHash{"memory_hash": digestHash})
+		case http.MethodGet:
+			getPath = r.URL.Path
+			_ = json.NewEncoder(w).Encode(digest)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+	c := NewBackendClient(func() string { return ts.URL }, func() string { return "" }, domain.TeamIdentity{})
+	if err := c.PushMemory(context.Background(), string(repoID), digest); err != nil {
+		t.Fatal(err)
+	}
+	got, err := c.PullMemoryObject(context.Background(), string(repoID), digestHash)
+	if err != nil || got.PreviousMemoryHash != previous {
+		t.Fatalf("pull object=%+v err=%v", got, err)
+	}
+	wantPut := "/repos/" + string(repoID) + "/memory-attachments/" + string(snapshotID)
+	wantGet := "/repos/" + string(repoID) + "/memory-objects/" + string(digestHash)
+	if putPath != wantPut || getPath != wantGet {
+		t.Fatalf("paths put=%q get=%q, want %q / %q", putPath, getPath, wantPut, wantGet)
+	}
+}

--- a/cli/internal/adapters/chunkcas/memory.go
+++ b/cli/internal/adapters/chunkcas/memory.go
@@ -21,6 +21,9 @@ const (
 	// unsupported format instead of dropping the proof and reporting a false
 	// content-hash corruption after reassembly.
 	MemoryFormatV2 = "cxt-memory-chunks-v2"
+	// V3 carries the causal parent of a memory attachment. Older readers must
+	// reject it rather than silently reconstructing a different digest hash.
+	MemoryFormatV3 = "cxt-memory-chunks-v3"
 )
 
 // MemoryManifest is an at-rest representation only. The wire protocol keeps
@@ -28,14 +31,15 @@ const (
 // Potentially large, prefix-sharing components are chunked independently;
 // small structured fields stay inline.
 type MemoryManifest struct {
-	Format         string                      `json:"format"`
-	SnapshotID     domain.ContentHash          `json:"snapshot_id"`
-	SummaryChunks  []domain.ContentHash        `json:"summary_chunks,omitempty"`
-	KeyFacts       []string                    `json:"key_facts"`
-	OpenTasks      []string                    `json:"open_tasks"`
-	Provider       domain.ProviderKind         `json:"provider"`
-	FragmentChunks []domain.ContentHash        `json:"fragment_chunks,omitempty"`
-	GraftCoverage  *domain.MemoryGraftCoverage `json:"graft_coverage,omitempty"`
+	Format             string                      `json:"format"`
+	SnapshotID         domain.ContentHash          `json:"snapshot_id"`
+	PreviousMemoryHash domain.ContentHash          `json:"previous_memory_hash,omitempty"`
+	SummaryChunks      []domain.ContentHash        `json:"summary_chunks,omitempty"`
+	KeyFacts           []string                    `json:"key_facts"`
+	OpenTasks          []string                    `json:"open_tasks"`
+	Provider           domain.ProviderKind         `json:"provider"`
+	FragmentChunks     []domain.ContentHash        `json:"fragment_chunks,omitempty"`
+	GraftCoverage      *domain.MemoryGraftCoverage `json:"graft_coverage,omitempty"`
 }
 
 type MemoryPlan struct {
@@ -60,12 +64,13 @@ func PlanMemory(d domain.MemoryDigest) (plan MemoryPlan, ok bool, err error) {
 	}
 	plan = MemoryPlan{
 		Manifest: MemoryManifest{
-			Format:        memoryFormatFor(d),
-			SnapshotID:    d.SnapshotID,
-			KeyFacts:      d.KeyFacts,
-			OpenTasks:     d.OpenTasks,
-			Provider:      d.Provider,
-			GraftCoverage: d.GraftCoverage,
+			Format:             memoryFormatFor(d),
+			SnapshotID:         d.SnapshotID,
+			PreviousMemoryHash: d.PreviousMemoryHash,
+			KeyFacts:           d.KeyFacts,
+			OpenTasks:          d.OpenTasks,
+			Provider:           d.Provider,
+			GraftCoverage:      d.GraftCoverage,
 		},
 		Bodies: map[domain.ContentHash][]byte{},
 	}
@@ -88,6 +93,9 @@ func PlanMemory(d domain.MemoryDigest) (plan MemoryPlan, ok bool, err error) {
 }
 
 func memoryFormatFor(d domain.MemoryDigest) string {
+	if d.PreviousMemoryHash != "" {
+		return MemoryFormatV3
+	}
 	if d.GraftCoverage != nil {
 		return MemoryFormatV2
 	}
@@ -95,7 +103,7 @@ func memoryFormatFor(d domain.MemoryDigest) string {
 }
 
 func SupportedMemoryFormat(format string) bool {
-	return format == MemoryFormatV1 || format == MemoryFormatV2
+	return format == MemoryFormatV1 || format == MemoryFormatV2 || format == MemoryFormatV3
 }
 
 func (p *MemoryPlan) addComponent(data []byte) []domain.ContentHash {
@@ -184,12 +192,13 @@ func AssembleMemory(man MemoryManifest, bodies map[domain.ContentHash][]byte) (d
 		}
 	}
 	return domain.MemoryDigest{
-		SnapshotID:    man.SnapshotID,
-		Summary:       string(summary),
-		KeyFacts:      man.KeyFacts,
-		OpenTasks:     man.OpenTasks,
-		Provider:      man.Provider,
-		Fragments:     fragments,
-		GraftCoverage: man.GraftCoverage,
+		SnapshotID:         man.SnapshotID,
+		PreviousMemoryHash: man.PreviousMemoryHash,
+		Summary:            string(summary),
+		KeyFacts:           man.KeyFacts,
+		OpenTasks:          man.OpenTasks,
+		Provider:           man.Provider,
+		Fragments:          fragments,
+		GraftCoverage:      man.GraftCoverage,
 	}, nil
 }

--- a/cli/internal/adapters/chunkcas/memory_test.go
+++ b/cli/internal/adapters/chunkcas/memory_test.go
@@ -83,6 +83,23 @@ func TestMemoryComponentPlanKeepsLegacyManifestVersionWithoutCoverage(t *testing
 	}
 }
 
+func TestMemoryComponentPlanUsesV3ForCausalParent(t *testing.T) {
+	previous := domain.HashContent([]byte("previous-memory"))
+	digest := domain.MemoryDigest{
+		SnapshotID: domain.HashContent([]byte("causal-format")), PreviousMemoryHash: previous,
+		Summary: strings.Repeat("causal", 16<<10), Provider: domain.ProviderCodex,
+		GraftCoverage: &domain.MemoryGraftCoverage{ProjectionVersion: domain.MemoryProjectionVersion},
+	}
+	plan, ok, err := PlanMemory(digest)
+	if err != nil || !ok || plan.Manifest.Format != MemoryFormatV3 {
+		t.Fatalf("causal plan: format=%q ok=%v err=%v", plan.Manifest.Format, ok, err)
+	}
+	got, err := AssembleMemory(plan.Manifest, plan.Bodies)
+	if err != nil || got.PreviousMemoryHash != previous {
+		t.Fatalf("causal roundtrip: previous=%s err=%v", got.PreviousMemoryHash, err)
+	}
+}
+
 func TestMemoryComponentPlanKeepsSmallDigestMonolithic(t *testing.T) {
 	_, ok, err := PlanMemory(domain.MemoryDigest{Summary: "small", Provider: domain.ProviderClaude})
 	if err != nil || ok {

--- a/cli/internal/adapters/delivery/cli/root.go
+++ b/cli/internal/adapters/delivery/cli/root.go
@@ -670,6 +670,9 @@ func Run(c *Container, args []string) error {
 		out, err := c.Sync.Push(ctx, inbound.SyncInput{Cwd: cwd, Force: force, Append: appendDiverged})
 		if err != nil {
 			if strings.Contains(err.Error(), "sync conflict") {
+				if strings.Contains(err.Error(), "memory attachment") {
+					return fmt.Errorf("! [rejected] %s (memory fork)\nhint: Run 'cxt pull --force' to adopt the remote memory pointer; immutable local memory and raw sessions are retained.\nhint: Then run 'cxt memorize' and 'cxt push' to project the local session again", strings.TrimPrefix(err.Error(), "sync conflict: "))
+				}
 				return fmt.Errorf("! [rejected] %s (non-fast-forward)\nhint: Remote commit not found in local. Use 'cxt push --append' to rebase (amend) onto remote head,\nor 'cxt pull' followed by push again.\nhint: To force overwrite, use 'cxt push --force' (remote history may be lost)", strings.TrimPrefix(err.Error(), "sync conflict: "))
 			}
 			return err

--- a/cli/internal/adapters/storage/file_store.go
+++ b/cli/internal/adapters/storage/file_store.go
@@ -324,24 +324,111 @@ func dedupGraft(id domain.ContentHash, parents, graft []domain.ContentHash) []do
 	return out
 }
 
-func (s *FileStore) PutSnapshot(_ context.Context, snap domain.Snapshot) error {
+const snapshotMutationLockStaleAfter = 10 * time.Minute
+
+// withSnapshotMutationLock serializes every read-modify-write of one snapshot
+// across FileStore instances and CLI processes. Atomic rename protects file
+// contents, but without this queue two terminals can both read the same meta
+// and silently discard each other's derivative updates. The stale takeover is
+// crash recovery only; normal contention waits for the lock owner.
+func (s *FileStore) withSnapshotMutationLock(ctx context.Context, id domain.ContentHash, fn func() error) error {
+	if err := domain.ValidateContentHash(id); err != nil {
+		return err
+	}
+	locksDir := filepath.Join(s.storeDir(), "locks", "snapshots")
+	if err := validateCxtDir(locksDir); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(locksDir, 0o755); err != nil {
+		return err
+	}
+	if err := validateCxtDir(locksDir); err != nil {
+		return err
+	}
+	lockPath := filepath.Join(locksDir, hexOf(id)+".lock")
+	token := fmt.Sprintf("%d-%d", os.Getpid(), time.Now().UnixNano())
+	ownerPath := filepath.Join(lockPath, "owner")
+	for {
+		err := os.Mkdir(lockPath, 0o700)
+		if err == nil {
+			if err := writeAtomic(ownerPath, []byte(token)); err != nil {
+				_ = os.Remove(lockPath)
+				return err
+			}
+			defer func() {
+				owner, readErr := readCxtFile(ownerPath)
+				if readErr == nil && string(owner) == token {
+					_ = os.Remove(ownerPath)
+					_ = os.Remove(lockPath)
+				}
+			}()
+			return fn()
+		}
+		if !os.IsExist(err) {
+			return err
+		}
+		if info, statErr := os.Lstat(lockPath); statErr == nil {
+			if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+				return domain.ErrHashMismatch
+			}
+			if time.Since(info.ModTime()) > snapshotMutationLockStaleAfter {
+				stalePath := lockPath + ".stale-" + token
+				if os.Rename(lockPath, stalePath) == nil {
+					_ = os.Remove(filepath.Join(stalePath, "owner"))
+					_ = os.Remove(stalePath)
+					continue
+				}
+			}
+		} else if !os.IsNotExist(statErr) {
+			return statErr
+		}
+		timer := time.NewTimer(10 * time.Millisecond)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
+func (s *FileStore) PutSnapshot(ctx context.Context, snap domain.Snapshot) error {
 	if err := validateSnapshotRefs(snap); err != nil {
 		return err
 	}
+	if snap.MemoryHash != "" {
+		digest, err := s.GetMemory(ctx, snap.MemoryHash)
+		if err != nil {
+			return err
+		}
+		if digest.SnapshotID != snap.ID {
+			return domain.ErrHashMismatch
+		}
+	}
+	return s.withSnapshotMutationLock(ctx, snap.ID, func() error {
+		return s.putSnapshotLocked(snap)
+	})
+}
+
+func (s *FileStore) putSnapshotLocked(snap domain.Snapshot) error {
 	p := s.objectPath("snapshots", snap.ID)
 	if fileExists(p) {
 		// Immutable object: idempotent. Exception — only derived fields not in ID/content are updated:
-		//   - MemoryHash attachment (derived pointer, compatibility rules): attaches if new value.
 		//   - GraftParents overlay adoption: adds reachability edge during server diverged append merge (Parents original immutable). Not receiving results in local reachability walk divergence from server, leading to incorrect ff determination (replica convergence).
 		existing, err := s.GetSnapshot(context.Background(), snap.ID)
 		if err != nil {
 			return err
 		}
 		changed := false
-		if snap.MemoryHash != "" && existing.MemoryHash != snap.MemoryHash {
-			// The derived pointer is replaceable after re-memorization; the body and ID remain immutable.
+		// MemoryHash has a dedicated causal CAS. Generic snapshot adoption must
+		// never turn an authoritative read or stale local copy into LWW rollback.
+		// A first attachment is still an unambiguous empty→value fast-forward;
+		// the snapshot lock ensures only one concurrent creator can win it.
+		if existing.MemoryHash == "" && snap.MemoryHash != "" {
 			existing.MemoryHash = snap.MemoryHash
 			changed = true
+		} else if existing.MemoryHash != "" && snap.MemoryHash != "" && existing.MemoryHash != snap.MemoryHash {
+			return domain.ErrSyncConflict
 		}
 		if strings.HasPrefix(existing.Message, domain.HookMessagePrefix) &&
 			snap.Message != "" && !strings.HasPrefix(snap.Message, domain.HookMessagePrefix) {
@@ -419,10 +506,16 @@ func sameHashList(left, right []domain.ContentHash) bool {
 // authoritative GET. Local GraftSeq can be ahead of server due to a pending add,
 // so this cannot be recovered with general PutSnapshot max-seq merge. Caller
 // passes a validated GET response only.
-func (s *FileStore) ReconcileGraftState(_ context.Context, authoritative domain.Snapshot) error {
+func (s *FileStore) ReconcileGraftState(ctx context.Context, authoritative domain.Snapshot) error {
 	if err := validateSnapshotRefs(authoritative); err != nil {
 		return err
 	}
+	return s.withSnapshotMutationLock(ctx, authoritative.ID, func() error {
+		return s.reconcileGraftStateLocked(authoritative)
+	})
+}
+
+func (s *FileStore) reconcileGraftStateLocked(authoritative domain.Snapshot) error {
 	existing, err := s.GetSnapshot(context.Background(), authoritative.ID)
 	if err != nil {
 		return err
@@ -438,6 +531,48 @@ func (s *FileStore) ReconcileGraftState(_ context.Context, authoritative domain.
 		return err
 	}
 	return writeAtomic(s.objectPath("snapshots", existing.ID), b)
+}
+
+// CompareAndSwapSnapshotMemory advances one snapshot's causal memory ref.
+// The blob is written first and immutable, so a failed CAS preserves both
+// contenders and reports an explicit conflict instead of choosing by timing.
+func (s *FileStore) CompareAndSwapSnapshotMemory(ctx context.Context, id, expected, next domain.ContentHash) error {
+	if err := domain.ValidateContentHash(id); err != nil {
+		return err
+	}
+	if err := domain.ValidateOptionalContentHash(expected); err != nil {
+		return err
+	}
+	if err := domain.ValidateOptionalContentHash(next); err != nil {
+		return err
+	}
+	if next != "" {
+		digest, err := s.GetMemory(ctx, next)
+		if err != nil {
+			return err
+		}
+		if digest.SnapshotID != id {
+			return domain.ErrHashMismatch
+		}
+	}
+	return s.withSnapshotMutationLock(ctx, id, func() error {
+		snap, err := s.GetSnapshot(ctx, id)
+		if err != nil {
+			return err
+		}
+		if snap.MemoryHash == next {
+			return nil
+		}
+		if snap.MemoryHash != expected {
+			return domain.ErrSyncConflict
+		}
+		snap.MemoryHash = next
+		data, err := json.Marshal(snap)
+		if err != nil {
+			return err
+		}
+		return writeAtomic(s.objectPath("snapshots", id), data)
+	})
 }
 
 // GetSnapshot retrieves Snapshot metadata by ID. Returns domain.ErrNotFound if not found.
@@ -624,6 +759,7 @@ func (s *FileStore) Manifest(ctx context.Context, repoID string) (domain.Manifes
 		return domain.Manifest{}, err
 	}
 	var index []domain.ContentHash
+	memoryAttachments := map[domain.ContentHash]domain.ContentHash{}
 	dir := filepath.Join(s.storeDir(), "objects", "snapshots")
 	if entries, err := readCxtDir(dir); err == nil {
 		for _, e := range entries {
@@ -634,20 +770,25 @@ func (s *FileStore) Manifest(ctx context.Context, repoID string) (domain.Manifes
 			if !ok {
 				continue
 			}
-			if _, err := s.GetSnapshot(ctx, id); err != nil {
+			snap, err := s.GetSnapshot(ctx, id)
+			if err != nil {
 				return domain.Manifest{}, err
 			}
 			index = append(index, id)
+			if snap.MemoryHash != "" {
+				memoryAttachments[id] = snap.MemoryHash
+			}
 		}
 	} else if !os.IsNotExist(err) {
 		return domain.Manifest{}, err
 	}
 	return domain.Manifest{
-		RepoID:        repoID,
-		Refs:          refs,
-		SnapshotIndex: index,
-		Version:       0,
-		UpdatedAt:     time.Now().UTC(),
+		RepoID:            repoID,
+		Refs:              refs,
+		SnapshotIndex:     index,
+		MemoryAttachments: memoryAttachments,
+		Version:           0,
+		UpdatedAt:         time.Now().UTC(),
 	}, nil
 }
 
@@ -883,11 +1024,13 @@ func (s *FileStore) DeletePending(_ context.Context, _ string, sessionID string)
 }
 
 // DeleteSnapshot removes the snapshot metadata object (hook capture leaf GC exclusive — idempotent).
-func (s *FileStore) DeleteSnapshot(_ context.Context, id domain.ContentHash) error {
+func (s *FileStore) DeleteSnapshot(ctx context.Context, id domain.ContentHash) error {
 	if err := domain.ValidateContentHash(id); err != nil {
 		return err
 	}
-	return removeCxtFile(s.objectPath("snapshots", id))
+	return s.withSnapshotMutationLock(ctx, id, func() error {
+		return removeCxtFile(s.objectPath("snapshots", id))
+	})
 }
 
 // DeleteDoc removes the doc body object (hook capture leaf GC exclusive — idempotent).

--- a/cli/internal/adapters/storage/file_store_test.go
+++ b/cli/internal/adapters/storage/file_store_test.go
@@ -199,3 +199,100 @@ func TestMemoryStore(t *testing.T) {
 		t.Fatalf("GetMemory: %v %+v", err, got)
 	}
 }
+
+func TestCompareAndSwapSnapshotMemoryRejectsStaleWriter(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	firstStore := NewFileStore(root)
+	secondStore := NewFileStore(root)
+	id := domain.HashContent([]byte("memory-cas-snapshot"))
+	if err := firstStore.PutSnapshot(ctx, domain.Snapshot{ID: id, DocHash: id, Branch: "main"}); err != nil {
+		t.Fatal(err)
+	}
+	first := domain.MemoryDigest{SnapshotID: id, Summary: "first contender"}
+	second := domain.MemoryDigest{SnapshotID: id, Summary: "second contender"}
+	firstHash, err := firstStore.PutMemory(ctx, first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondHash, err := secondStore.PutMemory(ctx, second)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	start := make(chan struct{})
+	errs := make(chan error, 2)
+	for _, contender := range []struct {
+		store *FileStore
+		hash  domain.ContentHash
+	}{{firstStore, firstHash}, {secondStore, secondHash}} {
+		go func(store *FileStore, hash domain.ContentHash) {
+			<-start
+			errs <- store.CompareAndSwapSnapshotMemory(ctx, id, "", hash)
+		}(contender.store, contender.hash)
+	}
+	close(start)
+	var successes, conflicts int
+	for range 2 {
+		switch err := <-errs; {
+		case err == nil:
+			successes++
+		case errors.Is(err, domain.ErrSyncConflict):
+			conflicts++
+		default:
+			t.Fatalf("unexpected CAS error: %v", err)
+		}
+	}
+	if successes != 1 || conflicts != 1 {
+		t.Fatalf("CAS results: successes=%d conflicts=%d", successes, conflicts)
+	}
+	got, err := firstStore.GetSnapshot(ctx, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.MemoryHash != firstHash && got.MemoryHash != secondHash {
+		t.Fatalf("unexpected final memory pointer %s", got.MemoryHash)
+	}
+}
+
+func TestConcurrentSnapshotDedupRejectsDifferentInitialMemories(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	firstStore := NewFileStore(root)
+	secondStore := NewFileStore(root)
+	id := domain.HashContent([]byte("dedup-memory-snapshot"))
+	firstHash, err := firstStore.PutMemory(ctx, domain.MemoryDigest{SnapshotID: id, Summary: "first initial"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondHash, err := secondStore.PutMemory(ctx, domain.MemoryDigest{SnapshotID: id, Summary: "second initial"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	start := make(chan struct{})
+	errs := make(chan error, 2)
+	for _, contender := range []struct {
+		store *FileStore
+		hash  domain.ContentHash
+	}{{firstStore, firstHash}, {secondStore, secondHash}} {
+		go func(store *FileStore, hash domain.ContentHash) {
+			<-start
+			errs <- store.PutSnapshot(ctx, domain.Snapshot{ID: id, DocHash: id, Branch: "main", MemoryHash: hash})
+		}(contender.store, contender.hash)
+	}
+	close(start)
+	var successes, conflicts int
+	for range 2 {
+		switch err := <-errs; {
+		case err == nil:
+			successes++
+		case errors.Is(err, domain.ErrSyncConflict):
+			conflicts++
+		default:
+			t.Fatalf("unexpected PutSnapshot error: %v", err)
+		}
+	}
+	if successes != 1 || conflicts != 1 {
+		t.Fatalf("dedup results: successes=%d conflicts=%d", successes, conflicts)
+	}
+}

--- a/cli/internal/adapters/storage/memory_chunks.go
+++ b/cli/internal/adapters/storage/memory_chunks.go
@@ -16,6 +16,9 @@ func validateMemoryDigestRefs(digest domain.MemoryDigest) error {
 	if err := domain.ValidateOptionalContentHash(digest.SnapshotID); err != nil {
 		return err
 	}
+	if err := domain.ValidateOptionalContentHash(digest.PreviousMemoryHash); err != nil {
+		return err
+	}
 	for _, fragment := range digest.Fragments {
 		if err := domain.ValidateContentHash(fragment.SourceSnapshot); err != nil {
 			return err

--- a/cli/internal/app/branch_seed.go
+++ b/cli/internal/app/branch_seed.go
@@ -190,6 +190,9 @@ func (s *BranchSeedService) Seed(ctx context.Context, in inbound.SeedInput) (inb
 		seedMemory = domain.MergeDigests(boundCarriedDigest(*mainMem), branchMem)
 	}
 	seedMemory.SnapshotID = docHash
+	// A seed is a new snapshot, so its first attachment is a causal root even
+	// when its projected content was imported from another snapshot's memory.
+	seedMemory.PreviousMemoryHash = ""
 	seedState := childMemoryProjectionState(snap, branchState)
 	seedMemory.GraftCoverage = memoryGraftCoverageFromState(ctx, s.store, seedState, seedMemory.Fragments, branchProjectionComplete)
 	if seedMemory.Provider == "" {

--- a/cli/internal/app/memorize.go
+++ b/cli/internal/app/memorize.go
@@ -129,23 +129,45 @@ func (s *MemorizeService) Memorize(ctx context.Context, in inbound.MemorizeInput
 	// computing it before the merge would make those fragments disappear on the
 	// first later graft mutation.
 	digest.GraftCoverage = memoryGraftCoverageFromState(ctx, s.store, projectionState, digest.Fragments, priorComplete)
+	if snap.MemoryHash != "" {
+		current, err := s.store.GetMemory(ctx, snap.MemoryHash)
+		if err != nil {
+			// A causal child cannot safely point at a missing parent. Pull/fsck must
+			// restore or diagnose it before another attachment is created.
+			return inbound.MemorizeOutput{}, err
+		}
+		if sameMemoryDigestPayload(current, digest) {
+			// Verify that another terminal did not move the pointer between the
+			// stable projection and this no-op decision.
+			if err := s.store.CompareAndSwapSnapshotMemory(ctx, snap.ID, snap.MemoryHash, snap.MemoryHash); err != nil {
+				return inbound.MemorizeOutput{}, err
+			}
+			return inbound.MemorizeOutput{SnapshotID: snap.ID, MemoryHash: snap.MemoryHash, Attached: true}, nil
+		}
+	}
+	// Memory attachments form a snapshot-scoped causal chain. The projection
+	// may absorb many graph lineages, but only the previously attached digest on
+	// this exact snapshot is the mutable-ref parent.
+	digest.PreviousMemoryHash = snap.MemoryHash
 	memHash, err := s.store.PutMemory(ctx, digest)
 	if err != nil {
 		return inbound.MemorizeOutput{}, err
 	}
-	// Attach to current branch HEAD snapshot (derivative pointer — ID/body immutable).
-	attachment := snap
-	attachment.MemoryHash = memHash
-	// A concurrent sync may have advanced the mutable graft register since the
-	// stable projection read. Memory attachment must never replay this stale
-	// register; PutSnapshot treats seq=0/no edges as a derivative-only update.
-	attachment.Grafted = false
-	attachment.GraftSeq = 0
-	attachment.GraftParents = nil
-	if err := s.store.PutSnapshot(ctx, attachment); err != nil {
+	// A second terminal may have memorized the same snapshot while distillation
+	// was running. CAS keeps both immutable blobs and rejects the stale pointer
+	// move instead of making the last filesystem rename win.
+	if err := s.store.CompareAndSwapSnapshotMemory(ctx, snap.ID, digest.PreviousMemoryHash, memHash); err != nil {
 		return inbound.MemorizeOutput{}, err
 	}
 	return inbound.MemorizeOutput{SnapshotID: snap.ID, MemoryHash: memHash, Attached: true}, nil
+}
+
+func sameMemoryDigestPayload(left, right domain.MemoryDigest) bool {
+	left.PreviousMemoryHash = ""
+	right.PreviousMemoryHash = ""
+	leftHash, leftErr := domain.MemoryDigestHash(left)
+	rightHash, rightErr := domain.MemoryDigestHash(right)
+	return leftErr == nil && rightErr == nil && leftHash == rightHash
 }
 
 // Ensure MemorizeService implements inbound.Memorize.

--- a/cli/internal/app/memory_lineage_test.go
+++ b/cli/internal/app/memory_lineage_test.go
@@ -50,6 +50,18 @@ type graftBeforeMemoryAttachStore struct {
 	mutated       bool
 }
 
+type missingSelectedMemoryStore struct {
+	*storage.FileStore
+	missing domain.ContentHash
+}
+
+func (s *missingSelectedMemoryStore) GetMemory(ctx context.Context, hash domain.ContentHash) (domain.MemoryDigest, error) {
+	if hash == s.missing {
+		return domain.MemoryDigest{}, domain.ErrNotFound
+	}
+	return s.FileStore.GetMemory(ctx, hash)
+}
+
 func (s *graftBeforeMemoryAttachStore) PutMemory(ctx context.Context, digest domain.MemoryDigest) (domain.ContentHash, error) {
 	hash, err := s.FileStore.PutMemory(ctx, digest)
 	if err == nil && !s.mutated {
@@ -542,17 +554,24 @@ func TestMemoryProjectionRetainsReachableFragmentWhenSourceMemoryIsUnavailable(t
 
 	// Simulate a partial/corrupt pull after coverage was recorded. The source is
 	// still a natural parent, but its current derivative memory blob is absent.
-	// That pointer change invalidates root coverage; stale repair must use the
+	// That missing frontier invalidates root coverage; stale repair must use the
 	// fragment already embedded in rootDigest instead of silently losing it.
-	baseSnapshot.MemoryHash = h('f')
-	if err := st.PutSnapshot(ctx, baseSnapshot); err != nil {
-		t.Fatal(err)
-	}
 	root, err = st.GetSnapshot(ctx, root.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
-	got, ok, complete := snapshotMemoryProjectionDetailed(ctx, st, root)
+	replacement := domain.MemoryDigest{
+		SnapshotID: h('a'), PreviousMemoryHash: baseHash, Summary: "new but unavailable parent memory",
+	}
+	replacementHash, err := st.PutMemory(ctx, replacement)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.CompareAndSwapSnapshotMemory(ctx, h('a'), baseHash, replacementHash); err != nil {
+		t.Fatal(err)
+	}
+	partial := &missingSelectedMemoryStore{FileStore: st, missing: replacementHash}
+	got, ok, complete := snapshotMemoryProjectionDetailed(ctx, partial, root)
 	if !ok || complete || !strings.Contains(got.Summary, "reachable fallback memory") || !strings.Contains(got.Summary, "root memory") {
 		t.Fatalf("partial-memory projection = %q, want reachable fallback + root", got.Summary)
 	}
@@ -758,6 +777,13 @@ func TestMemorizeRecordsExactGraftCoverage(t *testing.T) {
 	}
 	if len(digest.Fragments) != 1 || digest.Fragments[0].SourceSnapshot != docHash {
 		t.Fatalf("memorize provenance = %+v, want current snapshot fragment", digest.Fragments)
+	}
+	second, err := service.Memorize(ctx, inbound.MemorizeInput{Cwd: repo.LocalPath, Provider: domain.ProviderCodex})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second.MemoryHash != out.MemoryHash {
+		t.Fatalf("unchanged memorize created a new causal node: first=%s second=%s", out.MemoryHash, second.MemoryHash)
 	}
 }
 

--- a/cli/internal/app/sync_memory.go
+++ b/cli/internal/app/sync_memory.go
@@ -1,0 +1,287 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/wnsdy95/cxthub/cli/internal/domain"
+)
+
+const maxMemoryAttachmentDepth = 1024
+
+type memoryAttachmentObject struct {
+	hash   domain.ContentHash
+	digest domain.MemoryDigest
+}
+
+type memoryPushPlan struct {
+	snapshotID domain.ContentHash
+	// newest first; fallback replay walks this in reverse.
+	chain []memoryAttachmentObject
+}
+
+func validateMemoryAttachmentObject(digest domain.MemoryDigest, hash, snapshotID domain.ContentHash) error {
+	if digest.SnapshotID != snapshotID {
+		return domain.ErrHashMismatch
+	}
+	if err := domain.ValidateOptionalContentHash(digest.PreviousMemoryHash); err != nil {
+		return err
+	}
+	got, err := domain.MemoryDigestHash(digest)
+	if err != nil {
+		return err
+	}
+	if got != hash {
+		return domain.ErrHashMismatch
+	}
+	return nil
+}
+
+func (s *SyncRepoService) localMemoryPushPlan(ctx context.Context, snapshotID, current domain.ContentHash) (memoryPushPlan, error) {
+	plan := memoryPushPlan{snapshotID: snapshotID}
+	seen := map[domain.ContentHash]bool{}
+	for hash := current; hash != ""; {
+		if len(plan.chain) >= maxMemoryAttachmentDepth || seen[hash] {
+			return memoryPushPlan{}, fmt.Errorf("%w: invalid memory attachment chain", domain.ErrHashMismatch)
+		}
+		seen[hash] = true
+		digest, err := s.store.GetMemory(ctx, hash)
+		if err != nil {
+			return memoryPushPlan{}, err
+		}
+		if err := validateMemoryAttachmentObject(digest, hash, snapshotID); err != nil {
+			return memoryPushPlan{}, err
+		}
+		plan.chain = append(plan.chain, memoryAttachmentObject{hash: hash, digest: digest})
+		hash = digest.PreviousMemoryHash
+	}
+	return plan, nil
+}
+
+func isMemoryAttachmentConflict(err error) bool {
+	if errors.Is(err, domain.ErrSyncConflict) {
+		return true
+	}
+	var statusErr statusCodeError
+	return errors.As(err, &statusErr) && statusErr.StatusCode() == http.StatusConflict
+}
+
+func isMemoryAttachmentNotFound(err error) bool {
+	if errors.Is(err, domain.ErrNotFound) {
+		return true
+	}
+	var statusErr statusCodeError
+	return errors.As(err, &statusErr) && statusErr.StatusCode() == http.StatusNotFound
+}
+
+// pushMemoryPlan optimistically sends the newest attachment. The common case
+// is one request. If the server is more than one causal generation behind, it
+// reads the authoritative pointer and replays only the missing suffix oldest
+// first. A remote pointer outside the local chain is a true divergence.
+func (s *SyncRepoService) pushMemoryPlan(ctx context.Context, repoID string, plan memoryPushPlan) error {
+	if len(plan.chain) == 0 {
+		return nil
+	}
+	if err := s.remote.PushMemory(ctx, repoID, plan.chain[0].digest); err == nil {
+		return nil
+	} else if !isMemoryAttachmentConflict(err) {
+		return err
+	}
+
+	remoteHash := domain.ContentHash("")
+	remoteDigest, err := s.remote.PullMemory(ctx, repoID, plan.snapshotID)
+	switch {
+	case err == nil:
+		remoteHash, err = domain.MemoryDigestHash(remoteDigest)
+		if err != nil {
+			return err
+		}
+		if err := validateMemoryAttachmentObject(remoteDigest, remoteHash, plan.snapshotID); err != nil {
+			return err
+		}
+	case isMemoryAttachmentNotFound(err):
+		// Empty server pointer: replay from the local root.
+	default:
+		return err
+	}
+
+	start := len(plan.chain) - 1
+	if remoteHash != "" {
+		start = -1
+		for i, object := range plan.chain {
+			if object.hash == remoteHash {
+				start = i - 1
+				break
+			}
+		}
+		if start == -1 && plan.chain[0].hash != remoteHash {
+			return fmt.Errorf("%w: remote memory attachment diverged for snapshot %s", domain.ErrSyncConflict, plan.snapshotID)
+		}
+	}
+	for i := start; i >= 0; i-- {
+		if err := s.remote.PushMemory(ctx, repoID, plan.chain[i].digest); err != nil {
+			if isMemoryAttachmentConflict(err) {
+				return fmt.Errorf("%w: memory attachment changed during push for snapshot %s", domain.ErrSyncConflict, plan.snapshotID)
+			}
+			return err
+		}
+	}
+	return nil
+}
+
+// pushMemoryPlanFromKnown avoids transmitting an already-current large digest.
+// The manifest hash is only a pointer advertisement; every sent object still
+// goes through server CAS, so a concurrent change becomes a 409 rather than a
+// stale overwrite.
+func (s *SyncRepoService) pushMemoryPlanFromKnown(ctx context.Context, repoID string, plan memoryPushPlan, remoteHash domain.ContentHash) error {
+	if len(plan.chain) == 0 {
+		return nil
+	}
+	if remoteHash == plan.chain[0].hash {
+		return nil
+	}
+	start := len(plan.chain) - 1
+	if remoteHash != "" {
+		start = -1
+		for i, object := range plan.chain {
+			if object.hash == remoteHash {
+				start = i - 1
+				break
+			}
+		}
+		if start < 0 {
+			return fmt.Errorf("%w: remote memory attachment diverged for snapshot %s", domain.ErrSyncConflict, plan.snapshotID)
+		}
+	}
+	for i := start; i >= 0; i-- {
+		if err := s.remote.PushMemory(ctx, repoID, plan.chain[i].digest); err != nil {
+			if isMemoryAttachmentConflict(err) {
+				return fmt.Errorf("%w: memory attachment changed during push for snapshot %s", domain.ErrSyncConflict, plan.snapshotID)
+			}
+			return err
+		}
+	}
+	return nil
+}
+
+// preflightKnownRemoteMemory classifies the manifest's attachment without
+// mutating either replica. A hash outside the local chain is ambiguous: it can
+// be a normal remote descendant (this checkout is stale) or a true fork. Read
+// the immutable remote chain to prove which case it is. A remote descendant is
+// skipped by push and will be adopted by pull; a fork fails closed.
+func (s *SyncRepoService) preflightKnownRemoteMemory(ctx context.Context, repoID string, plan memoryPushPlan, remoteHash domain.ContentHash) (bool, error) {
+	if len(plan.chain) == 0 || remoteHash == "" {
+		return false, nil
+	}
+	for _, object := range plan.chain {
+		if object.hash == remoteHash {
+			return false, nil
+		}
+	}
+
+	remoteDigest, err := s.remote.PullMemory(ctx, repoID, plan.snapshotID)
+	if err != nil {
+		if isMemoryAttachmentNotFound(err) {
+			return false, fmt.Errorf("%w: remote memory attachment changed during preflight for snapshot %s", domain.ErrSyncConflict, plan.snapshotID)
+		}
+		return false, err
+	}
+	actualHash, err := domain.MemoryDigestHash(remoteDigest)
+	if err != nil {
+		return false, err
+	}
+	if actualHash != remoteHash {
+		return false, fmt.Errorf("%w: remote memory attachment changed during preflight for snapshot %s", domain.ErrSyncConflict, plan.snapshotID)
+	}
+	if err := validateMemoryAttachmentObject(remoteDigest, remoteHash, plan.snapshotID); err != nil {
+		return false, err
+	}
+	loader := &memoryPullLoader{
+		service:    s,
+		ctx:        ctx,
+		repoID:     repoID,
+		snapshotID: plan.snapshotID,
+		staged:     map[domain.ContentHash]domain.MemoryDigest{remoteHash: remoteDigest},
+	}
+	remoteAhead, err := memoryAttachmentAncestor(loader, plan.chain[0].hash, remoteHash)
+	if err != nil {
+		return false, err
+	}
+	if remoteAhead {
+		return true, nil
+	}
+	return false, fmt.Errorf("%w: remote memory attachment diverged for snapshot %s", domain.ErrSyncConflict, plan.snapshotID)
+}
+
+type memoryPullLoader struct {
+	service    *SyncRepoService
+	ctx        context.Context
+	repoID     string
+	snapshotID domain.ContentHash
+	staged     map[domain.ContentHash]domain.MemoryDigest
+	loaded     map[domain.ContentHash]domain.MemoryDigest
+}
+
+func (l *memoryPullLoader) load(hash domain.ContentHash) (domain.MemoryDigest, error) {
+	if digest, ok := l.loaded[hash]; ok {
+		return digest, nil
+	}
+	if digest, ok := l.staged[hash]; ok {
+		if l.loaded != nil {
+			l.loaded[hash] = digest
+		}
+		return digest, nil
+	}
+	if digest, err := l.service.store.GetMemory(l.ctx, hash); err == nil {
+		if err := validateMemoryAttachmentObject(digest, hash, l.snapshotID); err != nil {
+			return domain.MemoryDigest{}, err
+		}
+		if l.loaded == nil {
+			l.loaded = map[domain.ContentHash]domain.MemoryDigest{}
+		}
+		l.loaded[hash] = digest
+		return digest, nil
+	} else if !errors.Is(err, domain.ErrNotFound) {
+		return domain.MemoryDigest{}, err
+	}
+	digest, err := l.service.remote.PullMemoryObject(l.ctx, l.repoID, hash)
+	if err != nil {
+		return domain.MemoryDigest{}, err
+	}
+	if err := validateMemoryAttachmentObject(digest, hash, l.snapshotID); err != nil {
+		return domain.MemoryDigest{}, err
+	}
+	if l.staged == nil {
+		l.staged = map[domain.ContentHash]domain.MemoryDigest{}
+	}
+	l.staged[hash] = digest
+	if l.loaded == nil {
+		l.loaded = map[domain.ContentHash]domain.MemoryDigest{}
+	}
+	l.loaded[hash] = digest
+	return digest, nil
+}
+
+func memoryAttachmentAncestor(loader *memoryPullLoader, ancestor, descendant domain.ContentHash) (bool, error) {
+	if ancestor == descendant {
+		return true, nil
+	}
+	seen := map[domain.ContentHash]bool{}
+	for hash := descendant; hash != ""; {
+		if len(seen) >= maxMemoryAttachmentDepth || seen[hash] {
+			return false, fmt.Errorf("%w: invalid memory attachment chain", domain.ErrHashMismatch)
+		}
+		seen[hash] = true
+		digest, err := loader.load(hash)
+		if err != nil {
+			return false, err
+		}
+		hash = digest.PreviousMemoryHash
+		if hash == ancestor {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/cli/internal/app/sync_memory_test.go
+++ b/cli/internal/app/sync_memory_test.go
@@ -1,0 +1,372 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/wnsdy95/cxthub/cli/internal/adapters/storage"
+	"github.com/wnsdy95/cxthub/cli/internal/domain"
+	"github.com/wnsdy95/cxthub/cli/internal/ports/inbound"
+	"github.com/wnsdy95/cxthub/cli/internal/ports/outbound"
+)
+
+func putMemoryObject(t *testing.T, ctx context.Context, st *storage.FileStore, digest domain.MemoryDigest) domain.ContentHash {
+	t.Helper()
+	hash, err := st.PutMemory(ctx, digest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return hash
+}
+
+type causalPullRemote struct {
+	outbound.RemoteSync
+	snapshot    domain.Snapshot
+	doc         domain.SessionDoc
+	latest      domain.MemoryDigest
+	objects     map[domain.ContentHash]domain.MemoryDigest
+	objectReads []domain.ContentHash
+}
+
+func (r *causalPullRemote) Pull(context.Context, string, []domain.ContentHash) ([]domain.Snapshot, []domain.SessionDoc, []domain.Ref, error) {
+	return []domain.Snapshot{r.snapshot}, []domain.SessionDoc{r.doc}, []domain.Ref{{
+		Kind: domain.RefBranch, Name: "main", RepoID: r.snapshot.RepoID, Target: r.snapshot.ID,
+	}}, nil
+}
+
+func (r *causalPullRemote) PullMemory(context.Context, string, domain.ContentHash) (domain.MemoryDigest, error) {
+	return r.latest, nil
+}
+
+func (r *causalPullRemote) PullMemoryObject(_ context.Context, _ string, hash domain.ContentHash) (domain.MemoryDigest, error) {
+	r.objectReads = append(r.objectReads, hash)
+	digest, ok := r.objects[hash]
+	if !ok {
+		return domain.MemoryDigest{}, domain.ErrNotFound
+	}
+	return digest, nil
+}
+
+func TestPullFastForwardsRemoteMemoryDescendant(t *testing.T) {
+	ctx := context.Background()
+	repo := string(domain.HashContent([]byte("pull-memory-fast-forward-repo")))
+	doc := pullDoc(t, "causal pull")
+	st := storage.NewFileStore(t.TempDir())
+	if _, err := st.PutDoc(ctx, doc); err != nil {
+		t.Fatal(err)
+	}
+	root := domain.MemoryDigest{SnapshotID: doc.Hash, Summary: "root"}
+	rootHash := putMemoryObject(t, ctx, st, root)
+	middle := domain.MemoryDigest{SnapshotID: doc.Hash, PreviousMemoryHash: rootHash, Summary: "middle"}
+	middleHash, err := domain.MemoryDigestHash(middle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	latest := domain.MemoryDigest{SnapshotID: doc.Hash, PreviousMemoryHash: middleHash, Summary: "latest"}
+	latestHash, err := domain.MemoryDigestHash(latest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	local := domain.Snapshot{ID: doc.Hash, DocHash: doc.Hash, RepoID: repo, Branch: "main", MemoryHash: rootHash}
+	if err := st.PutSnapshot(ctx, local); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.PutRef(ctx, domain.Ref{Kind: domain.RefBranch, Name: "main", RepoID: repo, Target: doc.Hash}); err != nil {
+		t.Fatal(err)
+	}
+	remoteSnapshot := local
+	remoteSnapshot.MemoryHash = latestHash
+	remote := &causalPullRemote{
+		snapshot: remoteSnapshot, doc: doc, latest: latest,
+		objects: map[domain.ContentHash]domain.MemoryDigest{middleHash: middle},
+	}
+	if _, err := NewSyncRepoService(st, remote, nil).Pull(ctx, inbound.SyncInput{RepoID: repo}); err != nil {
+		t.Fatal(err)
+	}
+	got, err := st.GetSnapshot(ctx, doc.Hash)
+	if err != nil || got.MemoryHash != latestHash {
+		t.Fatalf("memory pointer=%s want=%s err=%v", got.MemoryHash, latestHash, err)
+	}
+	if len(remote.objectReads) != 1 || remote.objectReads[0] != middleHash {
+		t.Fatalf("remote ancestor reads=%v, want only middle", remote.objectReads)
+	}
+	if _, err := st.GetMemory(ctx, middleHash); err != nil {
+		t.Fatalf("middle object was not staged: %v", err)
+	}
+}
+
+func TestPullKeepsLocalMemoryDescendant(t *testing.T) {
+	ctx := context.Background()
+	repo := string(domain.HashContent([]byte("pull-memory-local-ahead-repo")))
+	doc := pullDoc(t, "local causal pull")
+	st := storage.NewFileStore(t.TempDir())
+	if _, err := st.PutDoc(ctx, doc); err != nil {
+		t.Fatal(err)
+	}
+	root := domain.MemoryDigest{SnapshotID: doc.Hash, Summary: "root"}
+	rootHash := putMemoryObject(t, ctx, st, root)
+	localTip := domain.MemoryDigest{SnapshotID: doc.Hash, PreviousMemoryHash: rootHash, Summary: "local tip"}
+	localTipHash := putMemoryObject(t, ctx, st, localTip)
+	local := domain.Snapshot{ID: doc.Hash, DocHash: doc.Hash, RepoID: repo, Branch: "main", MemoryHash: localTipHash}
+	if err := st.PutSnapshot(ctx, local); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.PutRef(ctx, domain.Ref{Kind: domain.RefBranch, Name: "main", RepoID: repo, Target: doc.Hash}); err != nil {
+		t.Fatal(err)
+	}
+	remoteSnapshot := local
+	remoteSnapshot.MemoryHash = rootHash
+	remote := &causalPullRemote{snapshot: remoteSnapshot, doc: doc, latest: root, objects: map[domain.ContentHash]domain.MemoryDigest{}}
+	if _, err := NewSyncRepoService(st, remote, nil).Pull(ctx, inbound.SyncInput{RepoID: repo}); err != nil {
+		t.Fatal(err)
+	}
+	got, err := st.GetSnapshot(ctx, doc.Hash)
+	if err != nil || got.MemoryHash != localTipHash {
+		t.Fatalf("local descendant was replaced: pointer=%s err=%v", got.MemoryHash, err)
+	}
+}
+
+func TestPullRepairsMissingAncestorBehindCurrentMemoryPointer(t *testing.T) {
+	ctx := context.Background()
+	repo := string(domain.HashContent([]byte("pull-memory-repair-incomplete-chain-repo")))
+	doc := pullDoc(t, "repair incomplete causal pull")
+	st := storage.NewFileStore(t.TempDir())
+	if _, err := st.PutDoc(ctx, doc); err != nil {
+		t.Fatal(err)
+	}
+	root := domain.MemoryDigest{SnapshotID: doc.Hash, Summary: "remote root"}
+	rootHash, err := domain.MemoryDigestHash(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tip := domain.MemoryDigest{SnapshotID: doc.Hash, PreviousMemoryHash: rootHash, Summary: "shared tip"}
+	tipHash := putMemoryObject(t, ctx, st, tip) // Deliberately omit root locally.
+	snapshot := domain.Snapshot{ID: doc.Hash, DocHash: doc.Hash, RepoID: repo, Branch: "main", MemoryHash: tipHash}
+	if err := st.PutSnapshot(ctx, snapshot); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.PutRef(ctx, domain.Ref{Kind: domain.RefBranch, Name: "main", RepoID: repo, Target: doc.Hash}); err != nil {
+		t.Fatal(err)
+	}
+	remote := &causalPullRemote{
+		snapshot: snapshot,
+		doc:      doc,
+		latest:   tip,
+		objects:  map[domain.ContentHash]domain.MemoryDigest{rootHash: root},
+	}
+	if _, err := NewSyncRepoService(st, remote, nil).Pull(ctx, inbound.SyncInput{RepoID: repo}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.GetMemory(ctx, rootHash); err != nil {
+		t.Fatalf("missing causal parent was not repaired: %v", err)
+	}
+	if len(remote.objectReads) != 1 || remote.objectReads[0] != rootHash {
+		t.Fatalf("remote ancestor reads=%v, want only %s", remote.objectReads, rootHash)
+	}
+	got, err := st.GetSnapshot(ctx, doc.Hash)
+	if err != nil || got.MemoryHash != tipHash {
+		t.Fatalf("memory pointer=%s want=%s err=%v", got.MemoryHash, tipHash, err)
+	}
+}
+
+type memoryStatusError int
+
+func (e memoryStatusError) Error() string   { return "memory attachment conflict" }
+func (e memoryStatusError) StatusCode() int { return int(e) }
+
+type causalPushRemote struct {
+	outbound.RemoteSync
+	current   domain.ContentHash
+	objects   map[domain.ContentHash]domain.MemoryDigest
+	pushes    []domain.ContentHash
+	refPushes int
+}
+
+type countingMemoryStore struct {
+	outbound.SessionStore
+	memoryReads int
+}
+
+func (s *countingMemoryStore) GetMemory(ctx context.Context, hash domain.ContentHash) (domain.MemoryDigest, error) {
+	s.memoryReads++
+	return s.SessionStore.GetMemory(ctx, hash)
+}
+
+func (r *causalPushRemote) Push(_ context.Context, _ string, _ []domain.Snapshot, _ []domain.SessionDoc, refs []domain.Ref, _ bool, _ bool) error {
+	if len(refs) > 0 {
+		r.refPushes++
+	}
+	return nil
+}
+
+func (r *causalPushRemote) RemoteManifest(_ context.Context, repoID string) (domain.Manifest, error) {
+	attachments := map[domain.ContentHash]domain.ContentHash{}
+	if r.current != "" {
+		for _, digest := range r.objects {
+			if hash, err := domain.MemoryDigestHash(digest); err == nil && hash == r.current {
+				attachments[digest.SnapshotID] = r.current
+				break
+			}
+		}
+	}
+	return domain.Manifest{RepoID: repoID, MemoryAttachments: attachments}, nil
+}
+
+func (r *causalPushRemote) PushMemory(_ context.Context, _ string, digest domain.MemoryDigest) error {
+	hash, err := domain.MemoryDigestHash(digest)
+	if err != nil {
+		return err
+	}
+	r.pushes = append(r.pushes, hash)
+	if r.current == hash {
+		return nil
+	}
+	if r.current != digest.PreviousMemoryHash {
+		return memoryStatusError(409)
+	}
+	r.objects[hash] = digest
+	r.current = hash
+	return nil
+}
+
+func (r *causalPushRemote) PullMemory(context.Context, string, domain.ContentHash) (domain.MemoryDigest, error) {
+	if r.current == "" {
+		return domain.MemoryDigest{}, domain.ErrNotFound
+	}
+	return r.objects[r.current], nil
+}
+
+func (r *causalPushRemote) PullMemoryObject(_ context.Context, _ string, hash domain.ContentHash) (domain.MemoryDigest, error) {
+	digest, ok := r.objects[hash]
+	if !ok {
+		return domain.MemoryDigest{}, domain.ErrNotFound
+	}
+	return digest, nil
+}
+
+func (r *causalPushRemote) DeleteUnsyncRemote(context.Context, string, string) error { return nil }
+
+func TestPushReplaysOnlyMissingMemorySuffix(t *testing.T) {
+	ctx := context.Background()
+	repo := string(domain.HashContent([]byte("push-memory-chain-repo")))
+	doc := pullDoc(t, "causal push")
+	st := storage.NewFileStore(t.TempDir())
+	if _, err := st.PutDoc(ctx, doc); err != nil {
+		t.Fatal(err)
+	}
+	root := domain.MemoryDigest{SnapshotID: doc.Hash, Summary: "root"}
+	rootHash := putMemoryObject(t, ctx, st, root)
+	middle := domain.MemoryDigest{SnapshotID: doc.Hash, PreviousMemoryHash: rootHash, Summary: "middle"}
+	middleHash := putMemoryObject(t, ctx, st, middle)
+	latest := domain.MemoryDigest{SnapshotID: doc.Hash, PreviousMemoryHash: middleHash, Summary: "latest"}
+	latestHash := putMemoryObject(t, ctx, st, latest)
+	if err := st.PutSnapshot(ctx, domain.Snapshot{ID: doc.Hash, DocHash: doc.Hash, RepoID: repo, Branch: "main", MemoryHash: latestHash}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.PutRef(ctx, domain.Ref{Kind: domain.RefBranch, Name: "main", RepoID: repo, Target: doc.Hash}); err != nil {
+		t.Fatal(err)
+	}
+	remote := &causalPushRemote{current: rootHash, objects: map[domain.ContentHash]domain.MemoryDigest{rootHash: root}}
+	if _, err := NewSyncRepoService(st, remote, nil).Push(ctx, inbound.SyncInput{RepoID: repo}); err != nil {
+		t.Fatal(err)
+	}
+	want := []domain.ContentHash{middleHash, latestHash}
+	if len(remote.pushes) != len(want) {
+		t.Fatalf("push order=%v want=%v", remote.pushes, want)
+	}
+	for i := range want {
+		if remote.pushes[i] != want[i] {
+			t.Fatalf("push order=%v want=%v", remote.pushes, want)
+		}
+	}
+	if remote.current != latestHash {
+		t.Fatalf("remote pointer=%s want=%s", remote.current, latestHash)
+	}
+	remote.pushes = nil
+	counting := &countingMemoryStore{SessionStore: st}
+	if _, err := NewSyncRepoService(counting, remote, nil).Push(ctx, inbound.SyncInput{RepoID: repo}); err != nil {
+		t.Fatal(err)
+	}
+	if len(remote.pushes) != 0 {
+		t.Fatalf("already-current memory was uploaded again: %v", remote.pushes)
+	}
+	if counting.memoryReads != 0 {
+		t.Fatalf("already-current memory chain was reconstructed %d times", counting.memoryReads)
+	}
+}
+
+func TestPushRejectsDivergentRemoteMemory(t *testing.T) {
+	ctx := context.Background()
+	repo := string(domain.HashContent([]byte("push-memory-divergence-repo")))
+	doc := pullDoc(t, "divergent push")
+	st := storage.NewFileStore(t.TempDir())
+	if _, err := st.PutDoc(ctx, doc); err != nil {
+		t.Fatal(err)
+	}
+	localRoot := domain.MemoryDigest{SnapshotID: doc.Hash, Summary: "local root"}
+	localRootHash := putMemoryObject(t, ctx, st, localRoot)
+	localTip := domain.MemoryDigest{SnapshotID: doc.Hash, PreviousMemoryHash: localRootHash, Summary: "local tip"}
+	localTipHash := putMemoryObject(t, ctx, st, localTip)
+	if err := st.PutSnapshot(ctx, domain.Snapshot{ID: doc.Hash, DocHash: doc.Hash, RepoID: repo, Branch: "main", MemoryHash: localTipHash}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.PutRef(ctx, domain.Ref{Kind: domain.RefBranch, Name: "main", RepoID: repo, Target: doc.Hash}); err != nil {
+		t.Fatal(err)
+	}
+	remoteRoot := domain.MemoryDigest{SnapshotID: doc.Hash, Summary: "remote root"}
+	remoteRootHash, err := domain.MemoryDigestHash(remoteRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	remote := &causalPushRemote{current: remoteRootHash, objects: map[domain.ContentHash]domain.MemoryDigest{remoteRootHash: remoteRoot}}
+	_, err = NewSyncRepoService(st, remote, nil).Push(ctx, inbound.SyncInput{RepoID: repo})
+	if !errors.Is(err, domain.ErrSyncConflict) {
+		t.Fatalf("push error=%v, want sync conflict", err)
+	}
+	if remote.current != remoteRootHash {
+		t.Fatalf("divergent push moved remote pointer to %s", remote.current)
+	}
+	if remote.refPushes != 0 {
+		t.Fatalf("divergent preflight published refs %d times", remote.refPushes)
+	}
+}
+
+func TestPushSkipsRemoteMemoryDescendantAndPublishesRefs(t *testing.T) {
+	ctx := context.Background()
+	repo := string(domain.HashContent([]byte("push-memory-remote-ahead-repo")))
+	doc := pullDoc(t, "remote-ahead causal push")
+	st := storage.NewFileStore(t.TempDir())
+	if _, err := st.PutDoc(ctx, doc); err != nil {
+		t.Fatal(err)
+	}
+	root := domain.MemoryDigest{SnapshotID: doc.Hash, Summary: "root"}
+	rootHash := putMemoryObject(t, ctx, st, root)
+	if err := st.PutSnapshot(ctx, domain.Snapshot{ID: doc.Hash, DocHash: doc.Hash, RepoID: repo, Branch: "main", MemoryHash: rootHash}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.PutRef(ctx, domain.Ref{Kind: domain.RefBranch, Name: "main", RepoID: repo, Target: doc.Hash}); err != nil {
+		t.Fatal(err)
+	}
+	remoteTip := domain.MemoryDigest{SnapshotID: doc.Hash, PreviousMemoryHash: rootHash, Summary: "remote tip"}
+	remoteTipHash, err := domain.MemoryDigestHash(remoteTip)
+	if err != nil {
+		t.Fatal(err)
+	}
+	remote := &causalPushRemote{
+		current: remoteTipHash,
+		objects: map[domain.ContentHash]domain.MemoryDigest{rootHash: root, remoteTipHash: remoteTip},
+	}
+	if _, err := NewSyncRepoService(st, remote, nil).Push(ctx, inbound.SyncInput{RepoID: repo}); err != nil {
+		t.Fatal(err)
+	}
+	if len(remote.pushes) != 0 {
+		t.Fatalf("stale local memory attempted remote rewind: %v", remote.pushes)
+	}
+	if remote.current != remoteTipHash {
+		t.Fatalf("remote memory moved to %s, want %s", remote.current, remoteTipHash)
+	}
+	if remote.refPushes != 1 {
+		t.Fatalf("refs published %d times, want 1", remote.refPushes)
+	}
+}

--- a/cli/internal/app/sync_pull_integrity_test.go
+++ b/cli/internal/app/sync_pull_integrity_test.go
@@ -111,3 +111,67 @@ func TestPullRejectsMemoryHashMismatchBeforeAnyWrite(t *testing.T) {
 		t.Fatalf("snapshot was partially written: %v", err)
 	}
 }
+
+func TestPullDoesNotReplaceUntrackedLocalMemoryWithDifferentRemotePointer(t *testing.T) {
+	ctx := context.Background()
+	repo := string(domain.HashContent([]byte("memory-pull-conflict-repo")))
+	doc := pullDoc(t, "same immutable session body")
+	localMemory := domain.MemoryDigest{SnapshotID: doc.Hash, Summary: "new local memory"}
+	remoteMemory := domain.MemoryDigest{SnapshotID: doc.Hash, Summary: "stale remote memory"}
+	localHash, err := domain.MemoryDigestHash(localMemory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	remoteHash, err := domain.MemoryDigestHash(remoteMemory)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	st := storage.NewFileStore(t.TempDir())
+	if _, err := st.PutDoc(ctx, doc); err != nil {
+		t.Fatal(err)
+	}
+	if stored, err := st.PutMemory(ctx, localMemory); err != nil || stored != localHash {
+		t.Fatalf("put local memory: hash=%s err=%v", stored, err)
+	}
+	localSnapshot := domain.Snapshot{
+		ID: doc.Hash, DocHash: doc.Hash, RepoID: repo, Branch: "main", MemoryHash: localHash,
+	}
+	if err := st.PutSnapshot(ctx, localSnapshot); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.PutRef(ctx, domain.Ref{Kind: domain.RefBranch, Name: "main", RepoID: repo, Target: doc.Hash}); err != nil {
+		t.Fatal(err)
+	}
+
+	remoteSnapshot := localSnapshot
+	remoteSnapshot.MemoryHash = remoteHash
+	remote := &corruptMemoryRemote{
+		snap: remoteSnapshot, doc: doc, memory: remoteMemory,
+		ref: domain.Ref{Kind: domain.RefBranch, Name: "main", RepoID: repo, Target: doc.Hash},
+	}
+	svc := NewSyncRepoService(st, remote, nil)
+	if _, err := svc.Pull(ctx, inbound.SyncInput{RepoID: repo}); !errors.Is(err, domain.ErrSyncConflict) {
+		t.Fatalf("pull error = %v, want memory attachment conflict", err)
+	}
+	got, err := st.GetSnapshot(ctx, doc.Hash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.MemoryHash != localHash {
+		t.Fatalf("pull rolled local memory back: got %s want %s", got.MemoryHash, localHash)
+	}
+	if _, err := svc.Pull(ctx, inbound.SyncInput{RepoID: repo, Force: true}); err != nil {
+		t.Fatalf("forced pull did not resolve memory fork: %v", err)
+	}
+	got, err = st.GetSnapshot(ctx, doc.Hash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.MemoryHash != remoteHash {
+		t.Fatalf("forced pull pointer=%s want remote %s", got.MemoryHash, remoteHash)
+	}
+	if _, err := st.GetMemory(ctx, localHash); err != nil {
+		t.Fatalf("forced pull deleted losing immutable local memory: %v", err)
+	}
+}

--- a/cli/internal/app/sync_repo.go
+++ b/cli/internal/app/sync_repo.go
@@ -290,28 +290,77 @@ func (s *SyncRepoService) Push(ctx context.Context, in inbound.SyncInput) (inbou
 		return inbound.SyncOutput{}, err
 	}
 
-	// Memory attaches a dedicated API pointer after snapshot creation. First, all local objects are validated to reduce the chance of discovering missing objects after raw/ref push.
-	var memories []domain.MemoryDigest
+	// Memory attaches through a causal CAS endpoint after snapshot creation.
+	// Read the remote pointer catalog before reconstructing any large local
+	// digest. The overwhelmingly common equal-pointer case needs no memory body
+	// read at all; only changed attachments pay for causal-chain validation.
+	var memorySnapshots []domain.Snapshot
 	for _, snap := range snaps {
-		if snap.MemoryHash == "" {
-			continue
+		if snap.MemoryHash != "" {
+			memorySnapshots = append(memorySnapshots, snap)
 		}
-		digest, err := s.store.GetMemory(ctx, snap.MemoryHash)
+	}
+	var remoteMemoryAttachments map[domain.ContentHash]domain.ContentHash
+	remoteMemoryAhead := map[domain.ContentHash]bool{}
+	if len(memorySnapshots) > 0 {
+		remoteManifest, err := s.remote.RemoteManifest(ctx, repoID)
 		if err != nil {
 			return inbound.SyncOutput{}, err
 		}
-		if digest.SnapshotID != snap.ID {
+		if remoteManifest.RepoID != "" && remoteManifest.RepoID != repoID {
 			return inbound.SyncOutput{}, domain.ErrHashMismatch
 		}
-		memories = append(memories, digest)
+		for snapshotID, memoryHash := range remoteManifest.MemoryAttachments {
+			if err := domain.ValidateContentHash(snapshotID); err != nil {
+				return inbound.SyncOutput{}, err
+			}
+			if err := domain.ValidateContentHash(memoryHash); err != nil {
+				return inbound.SyncOutput{}, err
+			}
+		}
+		remoteMemoryAttachments = remoteManifest.MemoryAttachments
+	}
+
+	// Validate every changed local chain before publishing raw objects so a
+	// missing or corrupt predecessor cannot leave a partially advanced ref.
+	var memoryPlans []memoryPushPlan
+	for _, snap := range memorySnapshots {
+		if remoteMemoryAttachments != nil && remoteMemoryAttachments[snap.ID] == snap.MemoryHash {
+			continue
+		}
+		plan, err := s.localMemoryPushPlan(ctx, snap.ID, snap.MemoryHash)
+		if err != nil {
+			return inbound.SyncOutput{}, err
+		}
+		if remoteMemoryAttachments != nil {
+			remoteHash := remoteMemoryAttachments[plan.snapshotID]
+			ahead, err := s.preflightKnownRemoteMemory(ctx, repoID, plan, remoteHash)
+			if err != nil {
+				return inbound.SyncOutput{}, err
+			}
+			remoteMemoryAhead[plan.snapshotID] = ahead
+		}
+		memoryPlans = append(memoryPlans, plan)
 	}
 
 	// Publish order is object → graft overlay → ref. New snapshots arrive without server-owned graft metadata. Publishing refs first would make sibling-session histories that depend on the queued graft appear non-fast-forward. Call RemoteSync.Push twice to make the protocol boundary explicit: objects first, refs last.
 	if err := s.remote.Push(ctx, repoID, snaps, docs, nil, false, false); err != nil {
 		return inbound.SyncOutput{}, err
 	}
-	for _, memory := range memories {
-		if err := s.remote.PushMemory(ctx, repoID, memory); err != nil {
+	for _, plan := range memoryPlans {
+		// Another terminal or machine already advanced this snapshot's memory.
+		// Do not rewind it, and do not let one stale historical attachment block
+		// publishing otherwise independent snapshots and refs.
+		if remoteMemoryAhead[plan.snapshotID] {
+			continue
+		}
+		var err error
+		if remoteMemoryAttachments != nil {
+			err = s.pushMemoryPlanFromKnown(ctx, repoID, plan, remoteMemoryAttachments[plan.snapshotID])
+		} else {
+			err = s.pushMemoryPlan(ctx, repoID, plan)
+		}
+		if err != nil {
 			return inbound.SyncOutput{}, err
 		}
 	}
@@ -1005,38 +1054,104 @@ func (s *SyncRepoService) Pull(ctx context.Context, in inbound.SyncInput) (inbou
 			return inbound.SyncOutput{}, gerr
 		}
 	}
-	// Memory also validates snapshot_id and content hash before staging. If either is missing or corrupted, the entire batch is rejected before writing doc/settings/snapshot.
+	// Memory pointers are mutable refs over immutable causal digest chains.
+	// Stage every object needed to prove a fast-forward before any local write;
+	// unrelated roots are a conflict, never an arrival-order winner.
 	stagedMemories := map[domain.ContentHash]domain.MemoryDigest{}
+	knownMemories := map[domain.ContentHash]domain.MemoryDigest{}
+	existingByID := map[domain.ContentHash]domain.Snapshot{}
+	memoryAdoptions := map[domain.ContentHash]domain.ContentHash{}
 	for _, snap := range snaps {
-		if snap.MemoryHash == "" {
+		existing, existingErr := s.store.GetSnapshot(ctx, snap.ID)
+		switch {
+		case existingErr == nil:
+			existingByID[snap.ID] = existing
+		case errors.Is(existingErr, domain.ErrNotFound):
+		default:
+			return inbound.SyncOutput{}, existingErr
+		}
+		if snap.MemoryHash != "" {
+			local, gerr := s.store.GetMemory(ctx, snap.MemoryHash)
+			switch {
+			case gerr == nil:
+				if err := validateMemoryAttachmentObject(local, snap.MemoryHash, snap.ID); err != nil {
+					return inbound.SyncOutput{}, err
+				}
+				knownMemories[snap.MemoryHash] = local
+			case errors.Is(gerr, domain.ErrNotFound):
+				digest, perr := s.remote.PullMemory(ctx, repoID, snap.ID)
+				if perr != nil {
+					return inbound.SyncOutput{}, perr
+				}
+				if err := validateMemoryAttachmentObject(digest, snap.MemoryHash, snap.ID); err != nil {
+					return inbound.SyncOutput{}, err
+				}
+				stagedMemories[snap.MemoryHash] = digest
+			default:
+				return inbound.SyncOutput{}, gerr
+			}
+		}
+		// A pointer is usable offline only when its immutable ancestry is present,
+		// not merely its tip. This also repairs checkouts produced by older clients
+		// that adopted a remote tip while omitting one of its causal parents.
+		if snap.MemoryHash != "" && (existingErr != nil || existing.MemoryHash == "" || existing.MemoryHash == snap.MemoryHash) {
+			loader := &memoryPullLoader{
+				service: s, ctx: ctx, repoID: repoID, snapshotID: snap.ID, staged: stagedMemories, loaded: knownMemories,
+			}
+			complete, err := memoryAttachmentAncestor(loader, "", snap.MemoryHash)
+			if err != nil {
+				return inbound.SyncOutput{}, err
+			}
+			if !complete {
+				return inbound.SyncOutput{}, fmt.Errorf("%w: incomplete memory attachment chain for snapshot %s", domain.ErrHashMismatch, snap.ID)
+			}
+		}
+		if existingErr != nil || existing.MemoryHash == snap.MemoryHash {
 			continue
 		}
-		local, gerr := s.store.GetMemory(ctx, snap.MemoryHash)
-		switch {
-		case gerr == nil:
-			got, herr := domain.MemoryDigestHash(local)
-			if herr != nil || got != snap.MemoryHash || local.SnapshotID != snap.ID {
-				return inbound.SyncOutput{}, domain.ErrHashMismatch
-			}
-		case errors.Is(gerr, domain.ErrNotFound):
-			digest, perr := s.remote.PullMemory(ctx, repoID, snap.ID)
-			if perr != nil {
-				return inbound.SyncOutput{}, perr
-			}
-			got, herr := domain.MemoryDigestHash(digest)
-			if herr != nil {
-				return inbound.SyncOutput{}, herr
-			}
-			if digest.SnapshotID != snap.ID || got != snap.MemoryHash {
-				return inbound.SyncOutput{}, domain.ErrHashMismatch
-			}
-			if prior, ok := stagedMemories[snap.MemoryHash]; ok && prior.SnapshotID != digest.SnapshotID {
-				return inbound.SyncOutput{}, domain.ErrHashMismatch
-			}
-			stagedMemories[snap.MemoryHash] = digest
-		default:
-			return inbound.SyncOutput{}, gerr
+		if existing.MemoryHash == "" {
+			memoryAdoptions[snap.ID] = ""
+			continue
 		}
+		// A local pointer must always resolve before it can participate in a
+		// merge. Fetching it from the server could hide local corruption.
+		localCurrent, localErr := s.store.GetMemory(ctx, existing.MemoryHash)
+		if localErr != nil {
+			return inbound.SyncOutput{}, localErr
+		}
+		if err := validateMemoryAttachmentObject(localCurrent, existing.MemoryHash, snap.ID); err != nil {
+			return inbound.SyncOutput{}, err
+		}
+		if snap.MemoryHash == "" {
+			continue // remote empty is an ancestor of every local chain
+		}
+		loader := &memoryPullLoader{
+			service: s, ctx: ctx, repoID: repoID, snapshotID: snap.ID, staged: stagedMemories, loaded: knownMemories,
+		}
+		remoteBehind, err := memoryAttachmentAncestor(loader, snap.MemoryHash, existing.MemoryHash)
+		if err != nil {
+			return inbound.SyncOutput{}, err
+		}
+		if remoteBehind {
+			continue // local causal descendant remains attached
+		}
+		localBehind, err := memoryAttachmentAncestor(loader, existing.MemoryHash, snap.MemoryHash)
+		if err != nil {
+			return inbound.SyncOutput{}, err
+		}
+		if !localBehind {
+			if in.Force {
+				// Explicit recovery: adopt the remote memory ref while retaining the
+				// losing immutable local digest object. Raw session data is untouched,
+				// so a subsequent memorize can project it again on top of the winner.
+				memoryAdoptions[snap.ID] = existing.MemoryHash
+				continue
+			}
+			return inbound.SyncOutput{}, fmt.Errorf(
+				"%w: divergent memory attachments for snapshot %s", domain.ErrSyncConflict, snap.ID,
+			)
+		}
+		memoryAdoptions[snap.ID] = existing.MemoryHash
 	}
 
 	// Start local write only after all remote objects preflight complete.
@@ -1070,7 +1185,7 @@ func (s *SyncRepoService) Pull(ctx context.Context, in inbound.SyncInput) (inbou
 	// Parent meta mismatch (replica divergence): parents can differ among replicas (legacy empirical verification: 7/7 stash-dedup bug snapshots). Local objects are immutable (PutSnapshot does not overwrite parents), so reject remote version adoption and proceed with batch — total rejection makes known divergence permanent pull failure (availability). Pollution server defense intent maintained: mismatched meta never reflected locally.
 	var conflicts []string
 	for _, snap := range snaps {
-		if existing, gerr := s.store.GetSnapshot(ctx, snap.ID); gerr == nil && !sameParents(existing.Parents, snap.Parents) {
+		if existing, ok := existingByID[snap.ID]; ok && !sameParents(existing.Parents, snap.Parents) {
 			id := string(snap.ID)
 			if len(id) > 17 {
 				id = id[:17]
@@ -1078,8 +1193,20 @@ func (s *SyncRepoService) Pull(ctx context.Context, in inbound.SyncInput) (inbou
 			conflicts = append(conflicts, "snapshot/"+id+" (parent metadata — local kept)")
 			continue
 		}
-		if err := s.store.PutSnapshot(ctx, snap); err != nil {
+		storedSnapshot := snap
+		if _, exists := existingByID[snap.ID]; exists {
+			// Existing memory was preflighted above and is merged only through the
+			// dedicated causal CAS. Generic metadata adoption must not reinterpret
+			// an intentional local-ahead keep as a conflicting first attachment.
+			storedSnapshot.MemoryHash = ""
+		}
+		if err := s.store.PutSnapshot(ctx, storedSnapshot); err != nil {
 			return inbound.SyncOutput{}, err
+		}
+		if expected, adopt := memoryAdoptions[snap.ID]; adopt {
+			if err := s.store.CompareAndSwapSnapshotMemory(ctx, snap.ID, expected, snap.MemoryHash); err != nil {
+				return inbound.SyncOutput{}, fmt.Errorf("%w: memory attachment changed during pull for snapshot %s", domain.ErrSyncConflict, snap.ID)
+			}
 		}
 	}
 	// FetchOnly (hook auto-pull): fetch objects only, local refs do not move — context does not force convergence unlike code. Instead, report remote branch ahead hint (pull is user choice).

--- a/cli/internal/domain/entities.go
+++ b/cli/internal/domain/entities.go
@@ -154,6 +154,10 @@ type SessionDoc struct {
 type MemoryDigest struct {
 	// SnapshotID is the ContentHash of the target snapshot.
 	SnapshotID ContentHash `json:"snapshot_id"`
+	// PreviousMemoryHash is the causal parent of this attachment for the same
+	// snapshot. Empty means a legacy/initial root. It turns the mutable
+	// Snapshot.MemoryHash pointer into a fast-forward-only content-addressed ref.
+	PreviousMemoryHash ContentHash `json:"previous_memory_hash,omitempty"`
 	// Summary is a human-readable summary body for CLAUDE.md/AGENTS.md injection.
 	Summary string `json:"summary"`
 	// KeyFacts is a flattened list of core decisions/restrictions/file context.
@@ -440,6 +444,9 @@ type Manifest struct {
 	Refs []Ref `json:"refs"`
 	// SnapshotIndex is a list of held snapshot IDs (push/pull negotiation's have set).
 	SnapshotIndex []ContentHash `json:"snapshot_index"`
+	// MemoryAttachments is the server/local current memory ref per snapshot.
+	// Nil means a legacy peer that does not advertise causal attachment state.
+	MemoryAttachments map[ContentHash]ContentHash `json:"memory_attachments,omitempty"`
 	// Version is an optimistic lock monotonically increasing version.
 	Version int `json:"version"`
 	// UpdatedAt is the last time this manifest was updated.

--- a/cli/internal/domain/hash_test.go
+++ b/cli/internal/domain/hash_test.go
@@ -22,14 +22,14 @@ func testSessionDoc(t *testing.T, text string) SessionDoc {
 func TestMemoryDigestCoverageWireHashParity(t *testing.T) {
 	h := func(c string) ContentHash { return ContentHash("sha256:" + strings.Repeat(c, 64)) }
 	digest := MemoryDigest{
-		SnapshotID: h("a"), Summary: "summary", KeyFacts: []string{"fact"}, OpenTasks: []string{}, Provider: ProviderCodex,
+		SnapshotID: h("a"), PreviousMemoryHash: h("f"), Summary: "summary", KeyFacts: []string{"fact"}, OpenTasks: []string{}, Provider: ProviderCodex,
 		Fragments: []MemoryFragment{{SourceSnapshot: h("b"), Summary: "fragment"}},
 		GraftCoverage: &MemoryGraftCoverage{
 			ProjectionVersion: MemoryProjectionVersion, ProjectionComplete: true, LineageFingerprint: h("c"), GraftSeq: 2,
 			GraftParents: []ContentHash{h("d")}, PinnedSources: []ContentHash{h("e")},
 		},
 	}
-	wire := `{"snapshot_id":"` + string(h("a")) + `","summary":"summary","key_facts":["fact"],"open_tasks":[],"provider":"codex","fragments":[{"source_snapshot":"` + string(h("b")) + `","summary":"fragment"}],"graft_coverage":{"projection_version":1,"projection_complete":true,"lineage_fingerprint":"` + string(h("c")) + `","graft_seq":2,"graft_parents":["` + string(h("d")) + `"],"pinned_sources":["` + string(h("e")) + `"]}}`
+	wire := `{"snapshot_id":"` + string(h("a")) + `","previous_memory_hash":"` + string(h("f")) + `","summary":"summary","key_facts":["fact"],"open_tasks":[],"provider":"codex","fragments":[{"source_snapshot":"` + string(h("b")) + `","summary":"fragment"}],"graft_coverage":{"projection_version":1,"projection_complete":true,"lineage_fingerprint":"` + string(h("c")) + `","graft_seq":2,"graft_parents":["` + string(h("d")) + `"],"pinned_sources":["` + string(h("e")) + `"]}}`
 	got, err := MemoryDigestHash(digest)
 	if err != nil {
 		t.Fatal(err)

--- a/cli/internal/ports/outbound/ports.go
+++ b/cli/internal/ports/outbound/ports.go
@@ -32,6 +32,11 @@ type SessionStore interface {
 	// Returns domain.ErrNotFound if not found.
 	GetSnapshot(ctx context.Context, id domain.ContentHash) (domain.Snapshot, error)
 
+	// CompareAndSwapSnapshotMemory advances the local memory attachment only
+	// when its current pointer still equals expected. Memory blobs are immutable;
+	// this CAS protects the mutable pointer across concurrent CLI processes.
+	CompareAndSwapSnapshotMemory(ctx context.Context, id, expected, next domain.ContentHash) error
+
 	// ReconcileGraftState adopts a snapshot graft register from an authoritative
 	// server read. It replaces only the graft register, leaving immutable
 	// metadata (ID/Parents) unchanged.
@@ -188,10 +193,14 @@ type RemoteSync interface {
 	// RegisterRepo registers repo metadata to the server (idempotently) and returns the server-confirmed record (including workspace_id — binding occurs if the remote URL path matches the workspace).
 	// Call before push to ensure the server holds metadata like remote URL (sync protocol).
 	RegisterRepo(ctx context.Context, repo domain.Repo) (domain.Repo, error)
-	// PushMemory uploads the MemoryDigest attached to the snapshot to the server (idempotently).
+	// PushMemory advances the server's causal memory attachment using the
+	// digest's PreviousMemoryHash as the expected pointer.
 	PushMemory(ctx context.Context, repoID string, digest domain.MemoryDigest) error
 	// PullMemory downloads the MemoryDigest from the snapshot. Returns ErrNotFound if not found.
 	PullMemory(ctx context.Context, repoID string, snapshotID domain.ContentHash) (domain.MemoryDigest, error)
+	// PullMemoryObject downloads one immutable memory object by its own hash so
+	// pull can prove fast-forward ancestry before moving a local pointer.
+	PullMemoryObject(ctx context.Context, repoID string, hash domain.ContentHash) (domain.MemoryDigest, error)
 	// PullSettings downloads the team default settings bundle
 	// (claude|agents|codex). Returns ErrNotFound if not found.
 	PullSettings(ctx context.Context, repoID, kind string) (domain.SettingsBundle, error)

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -313,8 +313,12 @@ cxt pull [--force]
 
 Downloads objects and refs from `origin`.
 
-- The default keeps local state and reports diverged branches.
-- `--force` adopts remote ref state.
+- The default keeps local state and reports diverged branches or causal memory
+  forks instead of choosing a winner by arrival time.
+- `--force` adopts remote ref state and resolves a memory fork by selecting the
+  remote memory pointer. The losing immutable local memory object and raw
+  session remain stored; run `cxt memorize` again to project that session onto
+  the selected remote lineage.
 
 Review local work before using `--force`.
 

--- a/frontend/src/domain/entities.ts
+++ b/frontend/src/domain/entities.ts
@@ -183,6 +183,8 @@ export interface SessionDoc {
 export interface MemoryDigest {
 /** Original snapshot id. */
   snapshotId: ContentHash;
+/** Previous attachment for the same snapshot (causal fast-forward parent). */
+  previousMemoryHash?: ContentHash;
 /** Human-readable summary body (for provider memory injection). */
   summary: string;
 /** Core facts list. */
@@ -230,6 +232,8 @@ export interface Manifest {
   refs: Ref[];
 /** List of owned snapshot IDs (push/pull difference negotiation's have set). */
   snapshotIndex: ContentHash[];
+/** Current causal memory pointer keyed by snapshot ID (absent on legacy peers). */
+  memoryAttachments?: Record<ContentHash, ContentHash>;
 /** Optimistic lock version (monotonically increasing). */
   version: number;
 /** Last update timestamp (RFC3339). */

--- a/frontend/src/infrastructure/mappers.ts
+++ b/frontend/src/infrastructure/mappers.ts
@@ -125,6 +125,8 @@ export function mapMemoryDigest(raw: RawMemoryDigest): MemoryDigest {
     openTasks: strArr(raw, 'open_tasks'),
     provider: str(raw, 'provider') as ProviderKind,
   };
+  const previousMemoryHash = str(raw, 'previous_memory_hash');
+  if (previousMemoryHash) digest.previousMemoryHash = previousMemoryHash;
   if (fragments) digest.fragments = fragments;
   if (coverage) {
     digest.graftCoverage = {
@@ -142,11 +144,20 @@ export function mapMemoryDigest(raw: RawMemoryDigest): MemoryDigest {
 export function mapManifest(raw: RawManifest): Manifest {
   const refsRaw = raw['refs'];
   const refs = Array.isArray(refsRaw) ? refsRaw.map((r) => mapRef(r as RawRef)) : [];
-  return {
+  const manifest: Manifest = {
     repoId: str(raw, 'repo_id'),
     refs,
     snapshotIndex: strArr(raw, 'snapshot_index'),
     version: num(raw, 'version'),
     updatedAt: str(raw, 'updated_at'),
   };
+  const attachmentsRaw = raw['memory_attachments'];
+  if (attachmentsRaw != null && typeof attachmentsRaw === 'object' && !Array.isArray(attachmentsRaw)) {
+    const attachments: Record<string, string> = {};
+    for (const [snapshotId, memoryHash] of Object.entries(attachmentsRaw as Record<string, unknown>)) {
+      if (typeof memoryHash === 'string') attachments[snapshotId] = memoryHash;
+    }
+    manifest.memoryAttachments = attachments;
+  }
+  return manifest;
 }

--- a/frontend/web/src/types.ts
+++ b/frontend/web/src/types.ts
@@ -238,6 +238,7 @@ export interface CIREvent {
 /** Compressed memory distilled from snapshot */
 export interface MemoryDigest {
   snapshot_id: string;
+  previous_memory_hash?: string;
   summary: string;
   key_facts: string[] | null;
   open_tasks: string[] | null;

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -7,7 +7,7 @@ cxt keeps `cli/` and `backend/` in separate Go modules with independent domain t
 | File | Role |
 |---|---|
 | `cir.schema.json` | CIR v1, the provider-independent canonical intermediate representation decoded from raw Claude and Codex JSONL. Changes require compatibility review. |
-| `manifest.schema.json` | Manifest v1: repository refs plus the `snapshot_index` catalog used for push/pull have-want negotiation. Changes require compatibility review. |
+| `manifest.schema.json` | Manifest v1: repository refs, `snapshot_index`, and optional causal `memory_attachments` pointers used for push/pull have-want negotiation. Changes require compatibility review. |
 | `openapi.yaml` | OpenAPI 3.1 REST contract shared by CLI, backend, and frontend. Route and field drift tests keep it aligned with the server. |
 | `db/migrations/*.sql` | Ordered PostgreSQL migrations through 0036, covering repository objects, identity/workspaces, pending state, reflog, compaction, graft overlays, transcript/memory chunk storage, and scoped session refs. |
 

--- a/schemas/manifest.schema.json
+++ b/schemas/manifest.schema.json
@@ -21,6 +21,12 @@
       "description": "Snapshot IDs held by this store (content hashes). Push/pull computes the remote difference and transfers only missing objects.",
       "items": { "$ref": "#/$defs/contentHash" }
     },
+    "memory_attachments": {
+      "type": "object",
+      "description": "Current causal memory hash keyed by snapshot ID. Omitted by legacy peers that do not advertise attachment state.",
+      "propertyNames": { "$ref": "#/$defs/contentHash" },
+      "additionalProperties": { "$ref": "#/$defs/contentHash" }
+    },
     "version": {
       "type": "integer",
       "minimum": 0,

--- a/schemas/openapi.yaml
+++ b/schemas/openapi.yaml
@@ -303,6 +303,13 @@ components:
           items:
             $ref: "#/components/schemas/ContentHash"
           description: "List of all snapshot IDs held by this store."
+        memory_attachments:
+          type: object
+          description: "Current causal memory hash keyed by snapshot ID. Absent means a legacy peer without attachment-state advertisement."
+          propertyNames:
+            pattern: '^sha256:[0-9a-f]{64}$'
+          additionalProperties:
+            $ref: "#/components/schemas/ContentHash"
         version:
           type: integer
           minimum: 0
@@ -319,6 +326,10 @@ components:
       properties:
         snapshot_id:
           $ref: "#/components/schemas/ContentHash"
+        previous_memory_hash:
+          allOf:
+            - $ref: "#/components/schemas/ContentHash"
+          description: "Causal parent attachment for the same snapshot. Omitted only for an initial or legacy root."
         summary:
           type: string
         key_facts:
@@ -1170,10 +1181,12 @@ paths:
 
     put:
       operationId: putMemory
-      summary: MemoryDigest upload (idempotent)
+      summary: Legacy MemoryDigest create/retry
       description: |
-        Uploads MemoryDigest for the snapshot. Idempotent.
-        Snapshot must exist first (returns 422 missing_object if not).
+        Rolling-upgrade endpoint for clients without causal attachment support.
+        Creates an empty pointer or retries the exact current digest, but never
+        replaces a different non-empty pointer. New clients use
+        /memory-attachments/{snapshotID}.
       tags: [memories]
       requestBody:
         required: true
@@ -1187,17 +1200,109 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/MemoryDigest"
+                type: object
+                required: [memory_hash]
+                additionalProperties: false
+                properties:
+                  memory_hash:
+                    $ref: "#/components/schemas/ContentHash"
         "401":
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
+        "409":
+          description: "A different memory attachment already exists; upgrade and pull before retrying."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         "422":
           description: "Snapshot does not exist (missing_object) or integrity error."
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+
+  /repos/{repoID}/memory-attachments/{snapshotID}:
+    parameters:
+      - $ref: "#/components/parameters/repoID"
+      - name: snapshotID
+        in: path
+        required: true
+        schema:
+          $ref: "#/components/schemas/ContentHash"
+    put:
+      operationId: putMemoryAttachment
+      summary: Fast-forward a causal memory attachment
+      description: |
+        Stores the immutable digest, then atomically advances Snapshot.MemoryHash
+        only when its current value equals previous_memory_hash. Repeating an
+        already-applied digest is idempotent. Divergent or stale parents return
+        409 without moving the pointer.
+      tags: [memories]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/MemoryDigest"
+      responses:
+        "200":
+          description: Attachment advanced or already current.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [memory_hash]
+                additionalProperties: false
+                properties:
+                  memory_hash:
+                    $ref: "#/components/schemas/ContentHash"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: "Current memory pointer differs from previous_memory_hash."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "422":
+          description: "Digest, snapshot, or causal parent integrity validation failed."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /repos/{repoID}/memory-objects/{hash}:
+    parameters:
+      - $ref: "#/components/parameters/repoID"
+      - name: hash
+        in: path
+        required: true
+        schema:
+          $ref: "#/components/schemas/ContentHash"
+    get:
+      operationId: getMemoryObject
+      summary: Read an immutable memory object by hash
+      description: "Used to prove attachment ancestry before a pull fast-forward."
+      tags: [memories]
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MemoryDigest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
 
   # =========================================================================
   # Push Negotiation

--- a/scripts/e2e-sync.sh
+++ b/scripts/e2e-sync.sh
@@ -22,7 +22,16 @@ ORIGIN="http://127.0.0.1:$PORT"
 FAIL=0
 SRV_PID=""
 # Reap the server immediately after killing it to avoid shell "Terminated" noise.
-cleanup() { [ -n "$SRV_PID" ] && kill "$SRV_PID" 2>/dev/null && wait "$SRV_PID" 2>/dev/null; rm -rf "$TMP"; }
+# Preserve the isolated fixture on demand so fail-open Git hook diagnostics are
+# still inspectable after the script exits.
+cleanup() {
+  [ -n "$SRV_PID" ] && kill "$SRV_PID" 2>/dev/null && wait "$SRV_PID" 2>/dev/null
+  if [ "${CXT_E2E_KEEP_TMP:-0}" = 1 ]; then
+    echo "SYNC E2E fixture preserved: $TMP"
+  else
+    rm -rf "$TMP"
+  fi
+}
 trap cleanup EXIT
 
 expect() { if [ "$2" = "$3" ]; then echo "  ✓ $1"; else echo "  ✗ $1  (got=$2 want=$3)"; FAIL=1; fi; }


### PR DESCRIPTION
Closes #65.

## Root cause

Memory blobs are immutable and content-addressed, but `snapshot.memory_hash` is a mutable attachment register. Pull, push, and concurrent local memorize all updated that register unconditionally, so a delayed terminal/server response could roll a newer pointer back to an older blob without deleting either object.

## Causal contract

- add `previous_memory_hash` to each digest, making memory ancestry explicit;
- persist a per-snapshot last-synced base and perform a Git-style three-way merge of local/base/remote pointers;
- use cross-process local CAS and equivalent server FS/PostgreSQL CAS;
- return explicit conflicts for true forks and preserve both immutable digests/raw objects;
- allow `cxt pull --force` to explicitly choose the remote side of a true fork;
- negotiate snapshot→memory manifests so equal pointers transfer zero memory bodies;
- fetch and verify the complete causal memory chain, repairing legacy tip-only local chains;
- expose causal attachment/object endpoints and keep OpenAPI/domain/chunk-manifest mirrors aligned.

No timestamp, sequence number, or arrival-order last-writer-wins decision is used.

## Verification

The signed rebased commit has byte-identical tree content to the pre-rebase commit (`87c6632`) that passed:

- CLI/backend full test, vet, and race suites;
- backend PostgreSQL-tag tests;
- real temporary PostgreSQL smoke, including concurrent same-parent CAS yielding exactly one success and one conflict;
- web typecheck/build/i18n/audit (0 vulnerabilities);
- public preflight;
- complete sync E2E, including full-chain pull repair and force-fork resolution.

CI reruns the complete repository matrix on this PR.
