### PR TITLE
fix(context): deliver pull briefings once per terminal

### DIFF
--- a/cli/internal/adapters/capture/briefing.go
+++ b/cli/internal/adapters/capture/briefing.go
@@ -28,10 +28,18 @@ const briefingMaxBytes = 4 << 10
 // briefingTTL is the briefing validity period — stale briefings pulled long ago are not consumed.
 const briefingTTL = 24 * time.Hour
 
+const briefingLockStaleAfter = 2 * time.Minute
+
 type briefingFile struct {
 	At    time.Time `json:"at"`
 	Text  string    `json:"text,omitempty"`  // legacy single-entry format
 	Texts []string  `json:"texts,omitempty"` // ordered pull queue
+}
+
+type pullBriefingCursorFile struct {
+	Branch    string             `json:"branch"`
+	Target    domain.ContentHash `json:"target"`
+	UpdatedAt time.Time          `json:"updated_at"`
 }
 
 const legacyBriefingRelativePath = ".cxt/briefing.json"
@@ -49,6 +57,19 @@ func briefingRelativePath() string {
 	}
 	key := strings.TrimPrefix(string(domain.HashContent([]byte(owner))), "sha256:")
 	return filepath.Join(".cxt", "briefings", key+".json")
+}
+
+// pullBriefingCursorRelativePath is separate from the consumable briefing
+// queue. A pull briefing disappears after one prompt, while this cursor must
+// survive so later pulls do not inject the same remote range again. Both the
+// delivery owner and branch are represented only by an opaque content hash.
+func pullBriefingCursorRelativePath(branch string) string {
+	owner := briefingOwner()
+	if owner == "" {
+		owner = "unowned"
+	}
+	key := strings.TrimPrefix(string(domain.HashContent([]byte(owner+"\x00"+branch))), "sha256:")
+	return filepath.Join(".cxt", "briefing-cursors", key+".json")
 }
 
 func briefingOwner() string {
@@ -70,6 +91,38 @@ func briefingOwner() string {
 	return "wrapper\x00" + pid + "\x00" + agent
 }
 
+func withBriefingFileLock(cwd, relative string, fn func() error) error {
+	return withBriefingFileLockTimeout(cwd, relative, time.Second, fn)
+}
+
+func withBriefingFileLockTimeout(cwd, relative string, wait time.Duration, fn func() error) error {
+	lockPath, err := providerfs.PrepareRepoFile(cwd, relative+".lock", 0o755)
+	if err != nil {
+		return err
+	}
+	deadline := time.Now().Add(wait)
+	for {
+		lock, lockErr := os.OpenFile(lockPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o644)
+		if lockErr == nil {
+			_ = lock.Close()
+			break
+		}
+		if !os.IsExist(lockErr) {
+			return lockErr
+		}
+		if info, statErr := os.Lstat(lockPath); statErr == nil && info.Mode().IsRegular() && time.Since(info.ModTime()) > briefingLockStaleAfter {
+			_ = os.Remove(lockPath)
+			continue
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("briefing file lock timeout")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	defer func() { _ = os.Remove(lockPath) }()
+	return fn()
+}
+
 // WriteBriefing queues the briefing for the initiating terminal/wrapper.
 // In an inactive repo (.cxt file absent), it is a no-op (same as opt-in gate).
 func WriteBriefing(cwd, text string) error {
@@ -77,22 +130,91 @@ func WriteBriefing(cwd, text string) error {
 		return nil
 	}
 	relative := briefingRelativePath()
-	entries := []string{}
-	if data, err := providerfs.ReadRepoFile(cwd, relative); err == nil {
-		var old briefingFile
-		if json.Unmarshal(data, &old) == nil && time.Since(old.At) <= briefingTTL {
-			entries = briefingEntries(old)
+	return withBriefingFileLock(cwd, relative, func() error {
+		entries := []string{}
+		if data, err := providerfs.ReadRepoFile(cwd, relative); err == nil {
+			var old briefingFile
+			if json.Unmarshal(data, &old) == nil && time.Since(old.At) <= briefingTTL {
+				entries = briefingEntries(old)
+			}
 		}
+		if len(entries) == 0 || entries[len(entries)-1] != text {
+			entries = append(entries, text)
+		}
+		entries = boundBriefingEntries(entries, briefingMaxBytes)
+		b, err := json.Marshal(briefingFile{At: time.Now().UTC(), Texts: entries})
+		if err != nil {
+			return err
+		}
+		return providerfs.WriteRepoFileAtomic(cwd, relative, b, 0o644)
+	})
+}
+
+// ReadPullBriefingCursor returns the last remote branch tip durably queued for
+// this terminal/wrapper. Corrupt, cross-branch, and invalid-hash files fail
+// closed and are ignored by the caller, which falls back to the local ref.
+func ReadPullBriefingCursor(cwd, branch string) (domain.ContentHash, bool) {
+	if domain.ValidateBranchName(branch) != nil {
+		return "", false
 	}
-	if len(entries) == 0 || entries[len(entries)-1] != text {
-		entries = append(entries, text)
-	}
-	entries = boundBriefingEntries(entries, briefingMaxBytes)
-	b, err := json.Marshal(briefingFile{At: time.Now().UTC(), Texts: entries})
+	data, err := providerfs.ReadRepoFile(cwd, pullBriefingCursorRelativePath(branch))
 	if err != nil {
+		return "", false
+	}
+	var cursor pullBriefingCursorFile
+	if json.Unmarshal(data, &cursor) != nil || cursor.Branch != branch || domain.ValidateContentHash(cursor.Target) != nil {
+		return "", false
+	}
+	return cursor.Target, true
+}
+
+// CompareAndSwapPullBriefingCursor advances only after the corresponding queue
+// entry is durable (ordering enforced by the caller). The filesystem lock and
+// expected pointer prevent concurrent post-merge hooks from moving C back to B.
+// A lost race leaves the queue intact and safely re-evaluates on the next pull.
+func CompareAndSwapPullBriefingCursor(cwd, branch string, expected, target domain.ContentHash) error {
+	if !cxtEnabled(cwd) {
+		return nil
+	}
+	if err := domain.ValidateBranchName(branch); err != nil {
 		return err
 	}
-	return providerfs.WriteRepoFileAtomic(cwd, relative, b, 0o644)
+	if err := domain.ValidateContentHash(target); err != nil {
+		return err
+	}
+	if err := domain.ValidateOptionalContentHash(expected); err != nil {
+		return err
+	}
+	relative := pullBriefingCursorRelativePath(branch)
+	return withBriefingFileLock(cwd, relative, func() error {
+		current, _ := ReadPullBriefingCursor(cwd, branch)
+		if current == target {
+			return nil
+		}
+		if current != expected {
+			return domain.ErrSyncConflict
+		}
+		b, err := json.Marshal(pullBriefingCursorFile{Branch: branch, Target: target, UpdatedAt: time.Now().UTC()})
+		if err != nil {
+			return err
+		}
+		return providerfs.WriteRepoFileAtomic(cwd, relative, b, 0o644)
+	})
+}
+
+// WithPullBriefingTransaction serializes one terminal's pull delivery for a
+// branch across graph selection, queueing, and cursor advancement. The queue
+// and cursor retain their own narrower locks because prompt consumption and
+// direct cursor repair do not take this transaction lock.
+func WithPullBriefingTransaction(cwd, branch string, fn func() error) error {
+	if !cxtEnabled(cwd) {
+		return nil
+	}
+	if err := domain.ValidateBranchName(branch); err != nil {
+		return err
+	}
+	relative := pullBriefingCursorRelativePath(branch) + ".transaction"
+	return withBriefingFileLockTimeout(cwd, relative, 30*time.Second, fn)
 }
 
 // ConsumeBriefing reads and consumes only the current terminal/wrapper queue.
@@ -101,35 +223,40 @@ func WriteBriefing(cwd, text string) error {
 // only one will succeed in renaming the file (the other will get ENOENT). Previous read-then-delete could lead to duplicate briefing injection (backlog #1 TOCTOU).
 func ConsumeBriefing(cwd string) (string, bool) {
 	relative := briefingRelativePath()
-	source, err := providerfs.PrepareRepoFile(cwd, relative, 0o755)
-	if err != nil {
+	var text string
+	var consumed bool
+	if err := withBriefingFileLock(cwd, relative, func() error {
+		source, err := providerfs.PrepareRepoFile(cwd, relative, 0o755)
+		if err != nil {
+			return err
+		}
+		claimRel := filepath.Join(filepath.Dir(relative), fmt.Sprintf("%s.claim.%d", filepath.Base(relative), os.Getpid()))
+		claim, err := providerfs.PrepareRepoFile(cwd, claimRel, 0o755)
+		if err != nil {
+			return err
+		}
+		if err := os.Rename(source, claim); err != nil {
+			return err // absent or another hook already claimed it
+		}
+		defer func() { _ = os.Remove(claim) }()
+		data, err := providerfs.ReadRegularFile(claim)
+		if err != nil {
+			return err
+		}
+		var f briefingFile
+		if json.Unmarshal(data, &f) != nil || time.Since(f.At) > briefingTTL {
+			return nil
+		}
+		entries := briefingEntries(f)
+		if len(entries) == 0 {
+			return nil
+		}
+		text, consumed = strings.Join(entries, "\n\n"), true
+		return nil
+	}); err != nil {
 		return "", false
 	}
-	claimRel := filepath.Join(filepath.Dir(relative), fmt.Sprintf("%s.claim.%d", filepath.Base(relative), os.Getpid()))
-	claim, err := providerfs.PrepareRepoFile(cwd, claimRel, 0o755)
-	if err != nil {
-		return "", false
-	}
-	if err := os.Rename(source, claim); err != nil {
-		return "", false // absent or another hook already claimed it
-	}
-	defer func() { _ = os.Remove(claim) }()
-	data, err := providerfs.ReadRegularFile(claim)
-	if err != nil {
-		return "", false
-	}
-	var f briefingFile
-	if json.Unmarshal(data, &f) != nil {
-		return "", false
-	}
-	if time.Since(f.At) > briefingTTL {
-		return "", false
-	}
-	entries := briefingEntries(f)
-	if len(entries) == 0 {
-		return "", false
-	}
-	return strings.Join(entries, "\n\n"), true
+	return text, consumed
 }
 
 func briefingEntries(f briefingFile) []string {

--- a/cli/internal/adapters/capture/briefing_security_test.go
+++ b/cli/internal/adapters/capture/briefing_security_test.go
@@ -1,11 +1,15 @@
 package capture
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"unicode/utf8"
+
+	"github.com/wnsdy95/cxthub/cli/internal/domain"
 )
 
 func TestConsumeBriefingRefusesSymlinkedCxtDirectory(t *testing.T) {
@@ -68,6 +72,82 @@ func TestBriefingQueuesMultiplePullsUntilNextPrompt(t *testing.T) {
 	}
 }
 
+func TestBriefingConcurrentWritersPreserveEveryEntry(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.Mkdir(filepath.Join(repo, ".cxt"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("TERM_SESSION_ID", "concurrent-briefing-terminal")
+
+	const writers = 16
+	start := make(chan struct{})
+	errs := make(chan error, writers)
+	for i := 0; i < writers; i++ {
+		text := fmt.Sprintf("pull context %02d", i)
+		go func() {
+			<-start
+			errs <- WriteBriefing(repo, text)
+		}()
+	}
+	close(start)
+	for i := 0; i < writers; i++ {
+		if err := <-errs; err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	text, ok := ConsumeBriefing(repo)
+	if !ok {
+		t.Fatal("concurrent briefing queue was empty")
+	}
+	for i := 0; i < writers; i++ {
+		want := fmt.Sprintf("pull context %02d", i)
+		if got := strings.Count(text, want); got != 1 {
+			t.Fatalf("%q count=%d in %q", want, got, text)
+		}
+	}
+}
+
+func TestBriefingConsumeAndWriteNeverReplayConsumedEntry(t *testing.T) {
+	for iteration := 0; iteration < 50; iteration++ {
+		repo := t.TempDir()
+		if err := os.Mkdir(filepath.Join(repo, ".cxt"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv("TERM_SESSION_ID", fmt.Sprintf("consume-write-%d", iteration))
+		if err := WriteBriefing(repo, "old pull context"); err != nil {
+			t.Fatal(err)
+		}
+
+		start := make(chan struct{})
+		written := make(chan error, 1)
+		consumed := make(chan string, 1)
+		go func() {
+			<-start
+			written <- WriteBriefing(repo, "new pull context")
+		}()
+		go func() {
+			<-start
+			text, _ := ConsumeBriefing(repo)
+			consumed <- text
+		}()
+		close(start)
+		if err := <-written; err != nil {
+			t.Fatal(err)
+		}
+		all := <-consumed
+		if rest, ok := ConsumeBriefing(repo); ok {
+			all += "\n\n" + rest
+		}
+		if got := strings.Count(all, "old pull context"); got != 1 {
+			t.Fatalf("iteration %d replayed/lost old entry: count=%d all=%q", iteration, got, all)
+		}
+		if got := strings.Count(all, "new pull context"); got != 1 {
+			t.Fatalf("iteration %d replayed/lost new entry: count=%d all=%q", iteration, got, all)
+		}
+	}
+}
+
 func TestBriefingIsScopedToInitiatingTerminal(t *testing.T) {
 	repo := t.TempDir()
 	if err := os.Mkdir(filepath.Join(repo, ".cxt"), 0o755); err != nil {
@@ -102,6 +182,104 @@ func TestBriefingIsScopedToInitiatingTerminal(t *testing.T) {
 	}
 	if text, ok := ConsumeBriefing(repo); ok || text != "" {
 		t.Fatalf("terminal A briefing was consumed twice: %q", text)
+	}
+}
+
+func TestPullBriefingCursorSurvivesConsumptionAndIsScoped(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.Mkdir(filepath.Join(repo, ".cxt"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mainTarget := domain.HashContent([]byte("terminal-a-main-cursor"))
+	t.Setenv("TERM_SESSION_ID", "terminal-a")
+	if err := CompareAndSwapPullBriefingCursor(repo, "main", "", mainTarget); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteBriefing(repo, "consume me once"); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := ConsumeBriefing(repo); !ok {
+		t.Fatal("briefing queue was not consumed")
+	}
+	if got, ok := ReadPullBriefingCursor(repo, "main"); !ok || got != mainTarget {
+		t.Fatalf("cursor after queue consumption=%s ok=%v", got, ok)
+	}
+	if _, ok := ReadPullBriefingCursor(repo, "feature/x"); ok {
+		t.Fatal("main cursor leaked into another branch")
+	}
+
+	t.Setenv("TERM_SESSION_ID", "terminal-b")
+	if _, ok := ReadPullBriefingCursor(repo, "main"); ok {
+		t.Fatal("terminal A cursor leaked into terminal B")
+	}
+	t.Setenv("TERM_SESSION_ID", "terminal-a")
+	if relative := pullBriefingCursorRelativePath("main"); strings.Contains(relative, "terminal-a") || strings.Contains(relative, "main") {
+		t.Fatalf("cursor path exposes scope input: %q", relative)
+	}
+}
+
+func TestPullBriefingCursorRefusesSymlinkedDirectory(t *testing.T) {
+	repo := t.TempDir()
+	outside := t.TempDir()
+	if err := os.Mkdir(filepath.Join(repo, ".cxt"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(repo, ".cxt", "briefing-cursors")); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	t.Setenv("TERM_SESSION_ID", "cursor-security-terminal")
+	if err := CompareAndSwapPullBriefingCursor(repo, "main", "", domain.HashContent([]byte("cursor target"))); err == nil {
+		t.Fatal("cursor write followed a symlinked directory")
+	}
+	entries, err := os.ReadDir(outside)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("cursor escaped repository: %v", entries)
+	}
+}
+
+func TestPullBriefingCursorConcurrentCASRejectsStaleWriter(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.Mkdir(filepath.Join(repo, ".cxt"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("TERM_SESSION_ID", "cursor-cas-terminal")
+	root := domain.HashContent([]byte("cursor root"))
+	if err := CompareAndSwapPullBriefingCursor(repo, "main", "", root); err != nil {
+		t.Fatal(err)
+	}
+	contenders := []domain.ContentHash{
+		domain.HashContent([]byte("cursor child one")),
+		domain.HashContent([]byte("cursor child two")),
+	}
+	start := make(chan struct{})
+	errs := make(chan error, len(contenders))
+	for _, contender := range contenders {
+		go func(next domain.ContentHash) {
+			<-start
+			errs <- CompareAndSwapPullBriefingCursor(repo, "main", root, next)
+		}(contender)
+	}
+	close(start)
+	var successes, conflicts int
+	for range contenders {
+		switch err := <-errs; {
+		case err == nil:
+			successes++
+		case errors.Is(err, domain.ErrSyncConflict):
+			conflicts++
+		default:
+			t.Fatalf("unexpected cursor CAS error: %v", err)
+		}
+	}
+	if successes != 1 || conflicts != 1 {
+		t.Fatalf("cursor CAS results: successes=%d conflicts=%d", successes, conflicts)
+	}
+	got, ok := ReadPullBriefingCursor(repo, "main")
+	if !ok || (got != contenders[0] && got != contenders[1]) {
+		t.Fatalf("cursor winner=%s ok=%v", got, ok)
 	}
 }
 

--- a/cli/internal/adapters/delivery/cli/githook.go
+++ b/cli/internal/adapters/delivery/cli/githook.go
@@ -1100,59 +1100,149 @@ func refSync(ctx context.Context, c *Container, cwd string) {
 // Branch base = the commit the new branch points to and the linked snapshot ([git <sha>]) — if none, the latest of the current branch.
 // A ref is created (the active session is not affected — git branch is a background task),
 // and if the cxt branch already exists (e.g., due to a team context pull), it is preserved.
-// writePullBriefing summarizes the team member snapshots received via git pull (remote head → local head) into a briefing sidecar.
+// pullBriefingDelta returns the remote DAG difference after the last delivered
+// cursor (or local branch ref fallback). It traverses natural and overlay graft
+// parents, so an appended side history is neither disconnected nor repeatedly
+// re-read from an intentionally stationary local ref. The newest 12 visible
+// entries are retained and returned oldest-to-newest, so the queue's prefix
+// truncation preserves the newest information. The full difference is still
+// validated before a caller may advance its cursor.
+func pullBriefingDelta(
+	snapshots []domain.Snapshot,
+	remoteTarget, localTarget, cursorTarget domain.ContentHash,
+) ([]domain.Snapshot, bool) {
+	byID := make(map[domain.ContentHash]domain.Snapshot, len(snapshots))
+	for _, snap := range snapshots {
+		byID[snap.ID] = snap
+	}
+	if remoteTarget == "" {
+		return nil, true
+	}
+	if _, ok := byID[remoteTarget]; !ok {
+		return nil, false
+	}
+
+	reachable := func(start, target domain.ContentHash) bool {
+		if start == "" || target == "" {
+			return false
+		}
+		seen := map[domain.ContentHash]bool{}
+		stack := []domain.ContentHash{start}
+		for len(stack) > 0 {
+			cur := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+			if cur == target {
+				return true
+			}
+			if cur == "" || seen[cur] {
+				continue
+			}
+			seen[cur] = true
+			if snap, ok := byID[cur]; ok {
+				stack = append(stack, snap.ReachabilityParents()...)
+			}
+		}
+		return false
+	}
+
+	base := localTarget
+	if cursorTarget != "" && reachable(remoteTarget, cursorTarget) {
+		base = cursorTarget
+	}
+	excluded := map[domain.ContentHash]bool{}
+	if base != "" {
+		stack := []domain.ContentHash{base}
+		for len(stack) > 0 {
+			cur := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+			if cur == "" || excluded[cur] {
+				continue
+			}
+			excluded[cur] = true
+			if snap, ok := byID[cur]; ok {
+				stack = append(stack, snap.ReachabilityParents()...)
+			}
+		}
+	}
+
+	const maxVisible = 12
+	var visible []domain.Snapshot
+	seen := map[domain.ContentHash]bool{}
+	queue := []domain.ContentHash{remoteTarget}
+	for next := 0; next < len(queue); next++ {
+		cur := queue[next]
+		if cur == "" || seen[cur] || excluded[cur] {
+			continue
+		}
+		seen[cur] = true
+		snap, ok := byID[cur]
+		if !ok {
+			return visible, false
+		}
+		if !strings.HasPrefix(snap.Message, domain.HookMessagePrefix) && len(visible) < maxVisible {
+			visible = append(visible, snap)
+		}
+		queue = append(queue, snap.ReachabilityParents()...)
+	}
+	for left, right := 0, len(visible)-1; left < right; left, right = left+1, right-1 {
+		visible[left], visible[right] = visible[right], visible[left]
+	}
+	return visible, true
+}
+
+// writePullBriefing summarizes the team member snapshots received via git pull
+// into a terminal-scoped briefing sidecar and advances a separate durable
+// remote cursor. The active/local context ref remains untouched.
 // The next prompt's UserPromptSubmit hook consumes this once, injecting it into the live agent session (no raw merge — summary layer at commit message and author level).
 func writePullBriefing(ctx context.Context, c *Container, cwd, branch string) {
-	ref, err := c.Sync.ResolveRemoteBranch(ctx, inbound.SyncInput{Cwd: cwd}, branch)
-	if err != nil || ref.Target == "" {
-		return
-	}
-	all, err := c.List.List(ctx, inbound.ListInput{})
-	if err != nil {
-		return
-	}
-	byID := map[domain.ContentHash]*domain.Snapshot{}
-	for i := range all.Snapshots {
-		byID[all.Snapshots[i].ID] = &all.Snapshots[i]
-	}
-	var localTarget domain.ContentHash
-	for _, r := range all.Refs {
-		if r.Kind == domain.RefBranch && r.Name == branch {
-			localTarget = r.Target
-			break
+	if err := capture.WithPullBriefingTransaction(cwd, branch, func() error {
+		ref, err := c.Sync.ResolveRemoteBranch(ctx, inbound.SyncInput{Cwd: cwd}, branch)
+		if err != nil || ref.Target == "" {
+			return err
 		}
-	}
-	// The "ingestion range" is from the remote head to the local head (latest first, max 12).
-	var items []string
-	seen := map[domain.ContentHash]bool{}
-	for cur := ref.Target; cur != "" && cur != localTarget && !seen[cur] && len(items) < 12; {
-		seen[cur] = true
-		s := byID[cur]
-		if s == nil {
-			break // object not reached (fetch failure etc.) — only what is available
+		all, err := c.List.List(ctx, inbound.ListInput{})
+		if err != nil {
+			return err
 		}
-		if !strings.HasPrefix(s.Message, domain.HookMessagePrefix) {
-			who := s.Author.Name
+		var localTarget domain.ContentHash
+		for _, r := range all.Refs {
+			if r.Kind == domain.RefBranch && r.Name == branch {
+				localTarget = r.Target
+				break
+			}
+		}
+		cursorTarget, _ := capture.ReadPullBriefingCursor(cwd, branch)
+		delta, complete := pullBriefingDelta(all.Snapshots, ref.Target, localTarget, cursorTarget)
+		if !complete {
+			return nil // fetched graph is incomplete — do not skip an unobserved range
+		}
+		var items []string
+		for _, snap := range delta {
+			who := snap.Author.Name
 			if who == "" {
-				who = s.Author.Email
+				who = snap.Author.Email
 			}
 			if who == "" {
-				who = s.Provider
+				who = snap.Provider
 			}
-			items = append(items, fmt.Sprintf("- %s: %s", who, s.Message))
+			items = append(items, fmt.Sprintf("- %s: %s", who, snap.Message))
 		}
-		if len(s.Parents) == 0 {
-			break
+		if len(items) > 0 {
+			text := fmt.Sprintf("── Teammate context arrived (git pull, %s) ──\n%s\n(full conversations are available in the web context tab — the code changes are already in your working tree)",
+				branch, strings.Join(items, "\n"))
+			if err := capture.WriteBriefing(cwd, text); err != nil {
+				return err // queue first: a cursor must never skip an undelivered range
+			}
 		}
-		cur = s.Parents[0]
-	}
-	if len(items) == 0 {
-		return
-	}
-	text := fmt.Sprintf("── Teammate context arrived (git pull, %s) ──\n%s\n(full conversations are available in the web context tab — the code changes are already in your working tree)",
-		branch, strings.Join(items, "\n"))
-	if capture.WriteBriefing(cwd, text) == nil {
-		fmt.Printf("cxt: %d team member contexts received — will be briefed to the agent in the next prompt\n", len(items))
+		if err := capture.CompareAndSwapPullBriefingCursor(cwd, branch, cursorTarget, ref.Target); err != nil {
+			return err
+		}
+		if len(items) > 0 {
+			fmt.Printf("cxt: %d team member contexts received — will be briefed to the agent in the next prompt\n", len(items))
+		}
+		return nil
+	}); err != nil && !errors.Is(err, domain.ErrSyncConflict) {
+		hookWarn("pull briefing cursor was not saved: %v", err)
 	}
 }
 

--- a/cli/internal/adapters/delivery/cli/githook_briefing_test.go
+++ b/cli/internal/adapters/delivery/cli/githook_briefing_test.go
@@ -1,0 +1,94 @@
+package cli
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/wnsdy95/cxthub/cli/internal/domain"
+)
+
+func briefingHash(label string) domain.ContentHash {
+	return domain.HashContent([]byte("pull-briefing-" + label))
+}
+
+func TestPullBriefingDeltaUsesCursorAndGraftReachability(t *testing.T) {
+	a := briefingHash("local-a")
+	x := briefingHash("incoming-root-x")
+	b := briefingHash("incoming-b")
+	c := briefingHash("incoming-c")
+	d := briefingHash("later-d")
+	snapshots := []domain.Snapshot{
+		{ID: a, Message: "local A"},
+		{ID: x, Message: domain.HookMessagePrefix + " transient root"},
+		{ID: b, Parents: []domain.ContentHash{x}, GraftParents: []domain.ContentHash{a}, Message: "team B"},
+		{ID: c, Parents: []domain.ContentHash{b}, Message: "team C"},
+		// The previous cursor C is reachable from D only through an overlay edge.
+		{ID: d, Parents: []domain.ContentHash{x}, GraftParents: []domain.ContentHash{c}, Message: "team D"},
+	}
+
+	first, complete := pullBriefingDelta(snapshots, c, a, "")
+	if !complete || len(first) != 2 || first[0].ID != b || first[1].ID != c {
+		t.Fatalf("first delta=%+v complete=%v, want B,C", first, complete)
+	}
+	repeated, complete := pullBriefingDelta(snapshots, c, a, c)
+	if !complete || len(repeated) != 0 {
+		t.Fatalf("repeated delta=%+v complete=%v, want empty", repeated, complete)
+	}
+	later, complete := pullBriefingDelta(snapshots, d, a, c)
+	if !complete || len(later) != 1 || later[0].ID != d {
+		t.Fatalf("later graft delta=%+v complete=%v, want only D", later, complete)
+	}
+}
+
+func TestPullBriefingDeltaFallsBackAfterCursorRewrite(t *testing.T) {
+	local := briefingHash("rewrite-local")
+	staleCursor := briefingHash("rewrite-stale-cursor")
+	remote := briefingHash("rewrite-remote")
+	snapshots := []domain.Snapshot{
+		{ID: local, Message: "local"},
+		{ID: staleCursor, Message: "stale cursor"},
+		{ID: remote, Parents: []domain.ContentHash{local}, Message: "rewritten team context"},
+	}
+	delta, complete := pullBriefingDelta(snapshots, remote, local, staleCursor)
+	if !complete || len(delta) != 1 || delta[0].ID != remote {
+		t.Fatalf("rewrite delta=%+v complete=%v", delta, complete)
+	}
+}
+
+func TestPullBriefingDeltaDoesNotAdvanceAcrossMissingObjects(t *testing.T) {
+	missing := briefingHash("missing-parent")
+	remote := briefingHash("missing-remote")
+	delta, complete := pullBriefingDelta([]domain.Snapshot{{
+		ID: remote, Parents: []domain.ContentHash{missing}, Message: "visible but incomplete",
+	}}, remote, "", "")
+	if complete || len(delta) != 1 || delta[0].ID != remote {
+		t.Fatalf("incomplete delta=%+v complete=%v", delta, complete)
+	}
+}
+
+func TestPullBriefingDeltaRetainsNewestTwelveInChronologicalOrder(t *testing.T) {
+	local := briefingHash("bounded-local")
+	previous := local
+	snapshots := []domain.Snapshot{{ID: local, Message: "local"}}
+	var ids []domain.ContentHash
+	for i := 1; i <= 15; i++ {
+		id := briefingHash(fmt.Sprintf("bounded-%02d", i))
+		snapshots = append(snapshots, domain.Snapshot{
+			ID:      id,
+			Parents: []domain.ContentHash{previous},
+			Message: fmt.Sprintf("team %02d", i),
+		})
+		ids = append(ids, id)
+		previous = id
+	}
+
+	delta, complete := pullBriefingDelta(snapshots, previous, local, "")
+	if !complete || len(delta) != 12 {
+		t.Fatalf("bounded delta len=%d complete=%v", len(delta), complete)
+	}
+	for i, snap := range delta {
+		if want := ids[i+3]; snap.ID != want {
+			t.Fatalf("delta[%d]=%s, want %s", i, snap.ID, want)
+		}
+	}
+}

--- a/scripts/e2e-sync.sh
+++ b/scripts/e2e-sync.sh
@@ -191,6 +191,9 @@ except Exception: print('parse-fail')")" True
 expect "briefing is consumed once and deleted" "$(find .cxt/briefings -maxdepth 1 -type f -name '*.json' | wc -l | tr -d ' ')" 0
 BRIEF2=$(echo "{\"cwd\":\"$TMP/repo1\"}" | TERM_SESSION_ID="$PULL_TERM" cxt hook --provider claude --event UserPromptSubmit)
 expect "subsequent prompt emits no briefing" "$([ -z "$BRIEF2" ] && echo yes)" yes
+REPEAT_HOOKOUT=$(TERM_SESSION_ID="$PULL_TERM" cxt git-hook post-merge 0 2>&1)
+expect "same remote tip is not briefed again" "$(echo "$REPEAT_HOOKOUT" | grep -c 'briefed to the agent')" 0
+expect "repeat pull leaves no briefing queue" "$(find .cxt/briefings -maxdepth 1 -type f -name '*.json' | wc -l | tr -d ' ')" 0
 
 echo "── F. repo1: both-moved diverge push → automatic rebase-graft"
 HEAD_PREV=$(main_head)


### PR DESCRIPTION
Closes #66.

## Root cause

`git pull` intentionally fetches teammate context without moving the active/local cxt branch ref, so the current agent session is never sliced or replaced. The briefing range nevertheless reused that stationary local ref as its base on every pull and followed only `parents[0]`. Old teammate summaries were therefore injected repeatedly and grafted append history was classified incorrectly, accelerating unnecessary compaction.

## Fix

- keep the active/local context ref stationary;
- store a durable remote-tip cursor per repository delivery owner (terminal/wrapper) and branch;
- compute `remote reachability − delivered cursor reachability` across `parents ∪ graft_parents`;
- queue before cursor advancement and refuse to advance across missing objects;
- fall back to the local ref after a remote rewrite;
- serialize graph selection, queueing, cursor CAS, concurrent writers, and prompt consumption;
- retain the newest 12 visible entries but emit them oldest→newest so the existing 4 KiB prefix truncation preserves newest information;
- keep one-time consumption, terminal isolation, and symlink protections.

## Verification

The signed rebased commit has byte-identical tree content to the fully tested pre-rebase commit (`4efc833`). It passed:

- targeted unit and race tests for DAG deltas, cursor CAS, concurrent queue writes, and consume/write races;
- full CLI `go test ./...`, `go vet ./...`, and `go test -race ./...`;
- complete sync E2E, including a second post-merge at the same remote tip producing no briefing output and no queue;
- public preflight.

CI reruns the complete repository matrix on this PR.
