### PR TITLE
perf(sync): negotiate before loading cumulative documents

### DIFF
--- a/cli/internal/adapters/backendclient/backend_client.go
+++ b/cli/internal/adapters/backendclient/backend_client.go
@@ -37,6 +37,7 @@ func NewBackendClient(baseURL, token func() string, identity domain.TeamIdentity
 }
 
 var _ outbound.RemoteSync = (*BackendClient)(nil)
+var _ outbound.PushObjectNegotiator = (*BackendClient)(nil)
 
 // --- wire DTO (same snake_case as backend) ---
 
@@ -620,6 +621,56 @@ func (c *BackendClient) RemoteManifest(ctx context.Context, repoID string) (doma
 	return m, nil
 }
 
+// NegotiatePushObjects performs the hash-only first phase before the
+// application opens any cumulative SessionDoc bodies. It uses the existing
+// sync endpoint, so old servers that support Push already support this
+// optimization. A server response must be a unique subset of what the client
+// advertised; arbitrary wants are rejected before they can drive local reads.
+// Missing docs are opened afterward, and Push's second negotiation handles
+// their chunk manifests and resumes partially staged chunk uploads.
+func (c *BackendClient) NegotiatePushObjects(ctx context.Context, repoID string, snapshotHaves, docHaves []domain.ContentHash) (outbound.PushObjectWants, error) {
+	if err := domain.ValidateContentHash(domain.ContentHash(repoID)); err != nil {
+		return outbound.PushObjectWants{}, err
+	}
+	for _, hash := range append(append([]domain.ContentHash(nil), snapshotHaves...), docHaves...) {
+		if err := domain.ValidateContentHash(hash); err != nil {
+			return outbound.PushObjectWants{}, err
+		}
+	}
+	var neg negotiateResp
+	if err := c.do(ctx, http.MethodPost, c.reposPath(repoID)+"/push/negotiate", negotiateReq{
+		SnapshotHaves: snapshotHaves,
+		DocHaves:      docHaves,
+	}, &neg); err != nil {
+		return outbound.PushObjectWants{}, err
+	}
+	if err := validateNegotiatedSubset(snapshotHaves, neg.SnapshotWants); err != nil {
+		return outbound.PushObjectWants{}, err
+	}
+	if err := validateNegotiatedSubset(docHaves, neg.DocWants); err != nil {
+		return outbound.PushObjectWants{}, err
+	}
+	return outbound.PushObjectWants{Snapshots: neg.SnapshotWants, Docs: neg.DocWants}, nil
+}
+
+func validateNegotiatedSubset(haves, wants []domain.ContentHash) error {
+	offered := make(map[domain.ContentHash]bool, len(haves))
+	for _, hash := range haves {
+		offered[hash] = true
+	}
+	seen := make(map[domain.ContentHash]bool, len(wants))
+	for _, hash := range wants {
+		if err := domain.ValidateContentHash(hash); err != nil {
+			return err
+		}
+		if !offered[hash] || seen[hash] {
+			return domain.ErrHashMismatch
+		}
+		seen[hash] = true
+	}
+	return nil
+}
+
 // Push performs three steps: negotiate(A) → objects(B) → refs PUT(C) for uploading only missing parts (sync protocol).
 func (c *BackendClient) Push(ctx context.Context, repoID string, snapshots []domain.Snapshot, docs []domain.SessionDoc, refs []domain.Ref, force, appendDiverged bool) error {
 	if err := domain.ValidateContentHash(domain.ContentHash(repoID)); err != nil {
@@ -675,8 +726,10 @@ func (c *BackendClient) Push(ctx context.Context, repoID string, snapshots []dom
 	}
 
 	var neg negotiateResp
-	if err := c.do(ctx, http.MethodPost, c.reposPath(repoID)+"/push/negotiate", negotiateReq{snapHaves, docHaves, chunkHaves}, &neg); err != nil {
-		return err
+	if len(snapHaves) > 0 || len(docHaves) > 0 {
+		if err := c.do(ctx, http.MethodPost, c.reposPath(repoID)+"/push/negotiate", negotiateReq{snapHaves, docHaves, chunkHaves}, &neg); err != nil {
+			return err
+		}
 	}
 	wantSnap, wantDoc, wantChunk := setOf(neg.SnapshotWants), setOf(neg.DocWants), setOf(neg.ChunkWants)
 

--- a/cli/internal/adapters/backendclient/backend_client_test.go
+++ b/cli/internal/adapters/backendclient/backend_client_test.go
@@ -210,6 +210,81 @@ func TestPushUploadsBoundedChunksBeforeManifestCommit(t *testing.T) {
 	}
 }
 
+func TestNegotiatePushObjectsUsesHashOnlyInventory(t *testing.T) {
+	repoID := domain.HashContent([]byte("lazy-negotiate-repo"))
+	snapshot := domain.HashContent([]byte("lazy-negotiate-snapshot"))
+	doc := domain.HashContent([]byte("lazy-negotiate-doc"))
+	requests := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if r.URL.Path != "/repos/"+string(repoID)+"/push/negotiate" {
+			http.NotFound(w, r)
+			return
+		}
+		var req negotiateReq
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode negotiate: %v", err)
+		}
+		if len(req.SnapshotHaves) != 1 || req.SnapshotHaves[0] != snapshot || len(req.DocHaves) != 1 || req.DocHaves[0] != doc || len(req.ChunkHaves) != 0 {
+			t.Errorf("inventory snapshots=%v docs=%v chunks=%v", req.SnapshotHaves, req.DocHaves, req.ChunkHaves)
+		}
+		_ = json.NewEncoder(w).Encode(negotiateResp{SnapshotWants: []domain.ContentHash{snapshot}, DocWants: []domain.ContentHash{doc}})
+	}))
+	defer ts.Close()
+
+	c := NewBackendClient(func() string { return ts.URL }, func() string { return "" }, domain.TeamIdentity{})
+	wants, err := c.NegotiatePushObjects(context.Background(), string(repoID), []domain.ContentHash{snapshot}, []domain.ContentHash{doc})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if requests != 1 || len(wants.Snapshots) != 1 || wants.Snapshots[0] != snapshot || len(wants.Docs) != 1 || wants.Docs[0] != doc {
+		t.Fatalf("requests=%d wants=%+v", requests, wants)
+	}
+}
+
+func TestNegotiatePushObjectsRejectsWantOutsideInventory(t *testing.T) {
+	repoID := domain.HashContent([]byte("untrusted-negotiate-repo"))
+	offered := domain.HashContent([]byte("offered-snapshot"))
+	unoffered := domain.HashContent([]byte("unoffered-snapshot"))
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(negotiateResp{SnapshotWants: []domain.ContentHash{unoffered}})
+	}))
+	defer ts.Close()
+
+	c := NewBackendClient(func() string { return ts.URL }, func() string { return "" }, domain.TeamIdentity{})
+	if _, err := c.NegotiatePushObjects(context.Background(), string(repoID), []domain.ContentHash{offered}, nil); !errors.Is(err, domain.ErrHashMismatch) {
+		t.Fatalf("negotiate error=%v, want hash mismatch", err)
+	}
+}
+
+func TestRefOnlyPushSkipsObjectNegotiation(t *testing.T) {
+	repoID := domain.HashContent([]byte("ref-only-push-repo"))
+	target := domain.HashContent([]byte("ref-only-push-target"))
+	negotiateCalls, refCalls := 0, 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/push/negotiate"):
+			negotiateCalls++
+			http.Error(w, "unexpected object negotiation", http.StatusInternalServerError)
+		case r.Method == http.MethodPut && strings.Contains(r.URL.Path, "/refs/branch/main"):
+			refCalls++
+			_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	c := NewBackendClient(func() string { return ts.URL }, func() string { return "" }, domain.TeamIdentity{})
+	ref := domain.Ref{Kind: domain.RefBranch, Name: "main", RepoID: string(repoID), Target: target}
+	if err := c.Push(context.Background(), string(repoID), nil, nil, []domain.Ref{ref}, false, false); err != nil {
+		t.Fatal(err)
+	}
+	if negotiateCalls != 0 || refCalls != 1 {
+		t.Fatalf("calls negotiate=%d refs=%d", negotiateCalls, refCalls)
+	}
+}
+
 func TestPushFallsBackToFullDocForChunkAwareV1Server(t *testing.T) {
 	repoID := domain.HashContent([]byte("legacy-chunk-push-repo"))
 	doc, plan := makeChunkedClientDoc(t, 2)

--- a/cli/internal/app/stash_dedup_test.go
+++ b/cli/internal/app/stash_dedup_test.go
@@ -39,7 +39,7 @@ func TestCollectObjectsIncludesReachableStash(t *testing.T) {
 		Refs:          []domain.Ref{{Kind: domain.RefBranch, Name: "main", RepoID: "repo-1", Target: c}},
 		SnapshotIndex: []domain.ContentHash{a, sMid, c, p},
 	}
-	snaps, _, err := svc.collectObjects(ctx, "repo-1", man)
+	snaps, err := svc.collectSnapshots(ctx, "repo-1", man)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cli/internal/app/sync_push_negotiation_test.go
+++ b/cli/internal/app/sync_push_negotiation_test.go
@@ -1,0 +1,170 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/wnsdy95/cxthub/cli/internal/adapters/storage"
+	"github.com/wnsdy95/cxthub/cli/internal/domain"
+	"github.com/wnsdy95/cxthub/cli/internal/ports/inbound"
+	"github.com/wnsdy95/cxthub/cli/internal/ports/outbound"
+)
+
+type docReadCountingStore struct {
+	outbound.SessionStore
+	reads []domain.ContentHash
+}
+
+func (s *docReadCountingStore) GetDoc(ctx context.Context, hash domain.ContentHash) (domain.SessionDoc, error) {
+	s.reads = append(s.reads, hash)
+	return s.SessionStore.GetDoc(ctx, hash)
+}
+
+type lazyPushRemote struct {
+	outbound.RemoteSync
+	wants           outbound.PushObjectWants
+	snapshotHaves   []domain.ContentHash
+	docHaves        []domain.ContentHash
+	objectCalls     int
+	refCalls        int
+	objectSnapshots []domain.Snapshot
+	objectDocs      []domain.SessionDoc
+}
+
+func (r *lazyPushRemote) NegotiatePushObjects(_ context.Context, _ string, snapshotHaves, docHaves []domain.ContentHash) (outbound.PushObjectWants, error) {
+	r.snapshotHaves = append([]domain.ContentHash(nil), snapshotHaves...)
+	r.docHaves = append([]domain.ContentHash(nil), docHaves...)
+	return r.wants, nil
+}
+
+func (r *lazyPushRemote) Push(_ context.Context, _ string, snapshots []domain.Snapshot, docs []domain.SessionDoc, refs []domain.Ref, _, _ bool) error {
+	if len(snapshots) > 0 || len(docs) > 0 {
+		r.objectCalls++
+		r.objectSnapshots = append(r.objectSnapshots, snapshots...)
+		r.objectDocs = append(r.objectDocs, docs...)
+	}
+	if len(refs) > 0 {
+		r.refCalls++
+	}
+	return nil
+}
+
+func (r *lazyPushRemote) DeleteUnsyncRemote(context.Context, string, string) error { return nil }
+
+func lazyPushFixture(t *testing.T) (*storage.FileStore, string, []domain.ContentHash) {
+	t.Helper()
+	ctx := context.Background()
+	store := storage.NewFileStore(t.TempDir())
+	repoID := string(domain.HashContent([]byte("lazy-push-repo")))
+	var ids []domain.ContentHash
+	var parents []domain.ContentHash
+	for _, marker := range []string{"first", "second"} {
+		doc := domain.SessionDoc{CIR: domain.CIRDocument{
+			Envelope: domain.Envelope{CIRVersion: "1", SourceProvider: domain.ProviderCodex, SessionOriginID: marker},
+			Events: []domain.Event{{
+				Kind: domain.EventMessage, Seq: 0, Role: "user",
+				Blocks: []domain.ContentBlock{{Type: "text", Text: marker}},
+			}},
+		}}
+		id, err := store.PutDoc(ctx, doc)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := store.PutSnapshot(ctx, domain.Snapshot{
+			ID: id, RepoID: repoID, Branch: "main", Parents: parents, DocHash: id,
+		}); err != nil {
+			t.Fatal(err)
+		}
+		ids = append(ids, id)
+		parents = []domain.ContentHash{id}
+	}
+	if err := store.PutRef(ctx, domain.Ref{
+		Kind: domain.RefBranch, Name: "main", RepoID: repoID, Target: ids[len(ids)-1],
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return store, repoID, ids
+}
+
+func TestPushLoadsOnlyServerRequestedDocuments(t *testing.T) {
+	tests := []struct {
+		name          string
+		wants         func([]domain.ContentHash) outbound.PushObjectWants
+		wantDocReads  int
+		wantSnapshots int
+		wantDocs      int
+	}{
+		{
+			name:  "no-op",
+			wants: func([]domain.ContentHash) outbound.PushObjectWants { return outbound.PushObjectWants{} },
+		},
+		{
+			name: "doc-only repair",
+			wants: func(ids []domain.ContentHash) outbound.PushObjectWants {
+				return outbound.PushObjectWants{Docs: []domain.ContentHash{ids[0]}}
+			},
+			wantDocReads: 1, wantDocs: 1,
+		},
+		{
+			name: "snapshot-only repair",
+			wants: func(ids []domain.ContentHash) outbound.PushObjectWants {
+				return outbound.PushObjectWants{Snapshots: []domain.ContentHash{ids[1]}}
+			},
+			wantSnapshots: 1,
+		},
+		{
+			name: "new repository",
+			wants: func(ids []domain.ContentHash) outbound.PushObjectWants {
+				return outbound.PushObjectWants{Snapshots: ids, Docs: ids}
+			},
+			wantDocReads: 2, wantSnapshots: 2, wantDocs: 2,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			base, repoID, ids := lazyPushFixture(t)
+			counting := &docReadCountingStore{SessionStore: base}
+			remote := &lazyPushRemote{wants: test.wants(ids)}
+			out, err := NewSyncRepoService(counting, remote, nil).Push(context.Background(), inbound.SyncInput{RepoID: repoID})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(counting.reads) != test.wantDocReads {
+				t.Fatalf("GetDoc calls=%v, want %d", counting.reads, test.wantDocReads)
+			}
+			if len(remote.snapshotHaves) != 2 || len(remote.docHaves) != 2 {
+				t.Fatalf("inventory snapshots=%v docs=%v", remote.snapshotHaves, remote.docHaves)
+			}
+			if len(remote.objectSnapshots) != test.wantSnapshots || len(remote.objectDocs) != test.wantDocs {
+				t.Fatalf("objects snapshots=%d docs=%d, want %d/%d", len(remote.objectSnapshots), len(remote.objectDocs), test.wantSnapshots, test.wantDocs)
+			}
+			wantObjectCalls := 0
+			if test.wantSnapshots > 0 || test.wantDocs > 0 {
+				wantObjectCalls = 1
+			}
+			if remote.objectCalls != wantObjectCalls || remote.refCalls != 1 {
+				t.Fatalf("calls objects=%d refs=%d, want %d/1", remote.objectCalls, remote.refCalls, wantObjectCalls)
+			}
+			if out.Pushed != test.wantSnapshots {
+				t.Fatalf("reported pushed=%d, want %d", out.Pushed, test.wantSnapshots)
+			}
+		})
+	}
+}
+
+func TestPushRejectsWantOutsideAdvertisedInventoryBeforeDocRead(t *testing.T) {
+	base, repoID, _ := lazyPushFixture(t)
+	counting := &docReadCountingStore{SessionStore: base}
+	remote := &lazyPushRemote{wants: outbound.PushObjectWants{
+		Docs: []domain.ContentHash{domain.HashContent([]byte("not advertised"))},
+	}}
+	_, err := NewSyncRepoService(counting, remote, nil).Push(context.Background(), inbound.SyncInput{RepoID: repoID})
+	if !errors.Is(err, domain.ErrHashMismatch) {
+		t.Fatalf("push error=%v, want hash mismatch", err)
+	}
+	if len(counting.reads) != 0 || remote.objectCalls != 0 || remote.refCalls != 0 {
+		t.Fatalf("untrusted wants caused reads/publication: reads=%v objects=%d refs=%d", counting.reads, remote.objectCalls, remote.refCalls)
+	}
+}

--- a/cli/internal/app/sync_push_order_test.go
+++ b/cli/internal/app/sync_push_order_test.go
@@ -18,9 +18,11 @@ func (g pushOrderGit) CurrentBranch(context.Context, string) (string, error)    
 
 type pushOrderRemote struct {
 	outbound.RemoteSync
-	events    []string
-	grafted   bool
-	failGraft error
+	events          []string
+	objectSnapshots int
+	objectDocs      int
+	grafted         bool
+	failGraft       error
 }
 
 func (r *pushOrderRemote) RegisterRepo(_ context.Context, repo domain.Repo) (domain.Repo, error) {
@@ -33,6 +35,8 @@ func (r *pushOrderRemote) Push(_ context.Context, _ string, snaps []domain.Snaps
 		if len(refs) > 0 {
 			return errors.New("objects and refs were published in one phase")
 		}
+		r.objectSnapshots += len(snaps)
+		r.objectDocs += len(docs)
 		r.events = append(r.events, "objects")
 	case len(refs) > 0:
 		if !r.grafted {
@@ -102,6 +106,9 @@ func TestPushPublishesObjectsThenGraftsThenRefs(t *testing.T) {
 		if remote.events[i] != want[i] {
 			t.Fatalf("publish order=%v want=%v", remote.events, want)
 		}
+	}
+	if remote.objectSnapshots != 2 || remote.objectDocs != 2 {
+		t.Fatalf("legacy negotiator fallback snapshots=%d docs=%d, want 2/2", remote.objectSnapshots, remote.objectDocs)
 	}
 }
 

--- a/cli/internal/app/sync_repo.go
+++ b/cli/internal/app/sync_repo.go
@@ -275,7 +275,11 @@ func (s *SyncRepoService) Push(ctx context.Context, in inbound.SyncInput) (inbou
 		return inbound.SyncOutput{}, err
 	}
 
-	snaps, docs, err := s.collectObjects(ctx, repoID, man)
+	snaps, err := s.collectSnapshots(ctx, repoID, man)
+	if err != nil {
+		return inbound.SyncOutput{}, err
+	}
+	pushSnaps, pushDocs, err := s.selectPushObjects(ctx, repoID, snaps)
 	if err != nil {
 		return inbound.SyncOutput{}, err
 	}
@@ -344,8 +348,10 @@ func (s *SyncRepoService) Push(ctx context.Context, in inbound.SyncInput) (inbou
 	}
 
 	// Publish order is object → graft overlay → ref. New snapshots arrive without server-owned graft metadata. Publishing refs first would make sibling-session histories that depend on the queued graft appear non-fast-forward. Call RemoteSync.Push twice to make the protocol boundary explicit: objects first, refs last.
-	if err := s.remote.Push(ctx, repoID, snaps, docs, nil, false, false); err != nil {
-		return inbound.SyncOutput{}, err
+	if len(pushSnaps) > 0 || len(pushDocs) > 0 {
+		if err := s.remote.Push(ctx, repoID, pushSnaps, pushDocs, nil, false, false); err != nil {
+			return inbound.SyncOutput{}, err
+		}
 	}
 	for _, plan := range memoryPlans {
 		// Another terminal or machine already advanced this snapshot's memory.
@@ -394,7 +400,7 @@ func (s *SyncRepoService) Push(ctx context.Context, in inbound.SyncInput) (inbou
 			_ = s.remote.DeleteUnsyncRemote(ctx, repoID, r.Name)
 		}
 	}
-	return inbound.SyncOutput{Pushed: len(snaps), NewRefs: refs}, nil
+	return inbound.SyncOutput{Pushed: len(pushSnaps), NewRefs: refs}, nil
 }
 
 // flushPromotions flushes the <repoRoot>/.cxt/promotions.json queue to the server, removing successful items.
@@ -749,16 +755,17 @@ func (s *SyncRepoService) AppendBranch(ctx context.Context, in inbound.SyncInput
 	return s.store.PutRef(ctx, ref)
 }
 
-// collectObjects gathers push target objects (snapshots+docs) for Push/Shadow Sync.
+// collectSnapshots gathers push target metadata for Push/Shadow Sync without
+// opening cumulative document bodies.
 // Stash is local-only (like git), so it is excluded, but the determination is based on ref reachability, not labels.
 // Content-hash deduplication ensures that if the same session content is stored in both stash and commits, one "(stash)" label object can be part of the commit history.
 // Removing the label alone can lead to parent loss (fsck corruption) and permanent ref advancement blockage (stash-dedup trap).
-func (s *SyncRepoService) collectObjects(ctx context.Context, repoID string, man domain.Manifest) ([]domain.Snapshot, []domain.SessionDoc, error) {
+func (s *SyncRepoService) collectSnapshots(ctx context.Context, repoID string, man domain.Manifest) ([]domain.Snapshot, error) {
 	byID := make(map[domain.ContentHash]domain.Snapshot, len(man.SnapshotIndex))
 	for _, id := range man.SnapshotIndex {
 		snap, err := s.store.GetSnapshot(ctx, id)
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 		byID[id] = snap
 	}
@@ -785,8 +792,6 @@ func (s *SyncRepoService) collectObjects(ctx context.Context, repoID string, man
 		stack = append(stack, snap.ReachabilityParents()...)
 	}
 	var snaps []domain.Snapshot
-	var docs []domain.SessionDoc
-	seenDoc := map[domain.ContentHash]bool{}
 	for _, id := range man.SnapshotIndex {
 		snap := byID[id]
 		if snap.Branch == domain.StashBranchLabel && !reachable[id] {
@@ -794,16 +799,92 @@ func (s *SyncRepoService) collectObjects(ctx context.Context, repoID string, man
 		}
 		snap.RepoID = repoID // Normalize to current origin-derived repoID (remote redirection)
 		snaps = append(snaps, snap)
-		if snap.DocHash != "" && !seenDoc[snap.DocHash] {
-			doc, err := s.store.GetDoc(ctx, snap.DocHash)
-			if err != nil {
-				return nil, nil, err
-			}
-			docs = append(docs, doc)
-			seenDoc[snap.DocHash] = true
+	}
+	return snaps, nil
+}
+
+// selectPushObjects asks the server which independent snapshot/doc objects it
+// lacks before opening any cumulative SessionDoc body. A server can retain a
+// snapshot while losing its doc (or vice versa), so manifest snapshot indexes
+// are not a sufficient repair proof. Optional capability fallback preserves
+// compatibility with non-HTTP remotes and older adapters.
+func (s *SyncRepoService) selectPushObjects(ctx context.Context, repoID string, snaps []domain.Snapshot) ([]domain.Snapshot, []domain.SessionDoc, error) {
+	negotiator, ok := s.remote.(outbound.PushObjectNegotiator)
+	if !ok {
+		docs, err := s.loadPushDocs(ctx, snaps, nil)
+		return snaps, docs, err
+	}
+
+	snapshotHaves := make([]domain.ContentHash, 0, len(snaps))
+	docHaves := make([]domain.ContentHash, 0, len(snaps))
+	seenDocs := map[domain.ContentHash]bool{}
+	for _, snap := range snaps {
+		snapshotHaves = append(snapshotHaves, snap.ID)
+		if snap.DocHash != "" && !seenDocs[snap.DocHash] {
+			seenDocs[snap.DocHash] = true
+			docHaves = append(docHaves, snap.DocHash)
 		}
 	}
-	return snaps, docs, nil
+	wants, err := negotiator.NegotiatePushObjects(ctx, repoID, snapshotHaves, docHaves)
+	if err != nil {
+		return nil, nil, err
+	}
+	wantSnaps, err := negotiatedWantSet(snapshotHaves, wants.Snapshots)
+	if err != nil {
+		return nil, nil, err
+	}
+	wantDocs, err := negotiatedWantSet(docHaves, wants.Docs)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	pushSnaps := make([]domain.Snapshot, 0, len(wantSnaps))
+	for _, snap := range snaps {
+		if wantSnaps[snap.ID] {
+			pushSnaps = append(pushSnaps, snap)
+		}
+	}
+	pushDocs, err := s.loadPushDocs(ctx, snaps, wantDocs)
+	if err != nil {
+		return nil, nil, err
+	}
+	return pushSnaps, pushDocs, nil
+}
+
+func negotiatedWantSet(haves, wants []domain.ContentHash) (map[domain.ContentHash]bool, error) {
+	offered := make(map[domain.ContentHash]bool, len(haves))
+	for _, hash := range haves {
+		offered[hash] = true
+	}
+	out := make(map[domain.ContentHash]bool, len(wants))
+	for _, hash := range wants {
+		if err := domain.ValidateContentHash(hash); err != nil {
+			return nil, err
+		}
+		if !offered[hash] || out[hash] {
+			return nil, domain.ErrHashMismatch
+		}
+		out[hash] = true
+	}
+	return out, nil
+}
+
+func (s *SyncRepoService) loadPushDocs(ctx context.Context, snaps []domain.Snapshot, wanted map[domain.ContentHash]bool) ([]domain.SessionDoc, error) {
+	var docs []domain.SessionDoc
+	seen := map[domain.ContentHash]bool{}
+	for _, snap := range snaps {
+		hash := snap.DocHash
+		if hash == "" || seen[hash] || (wanted != nil && !wanted[hash]) {
+			continue
+		}
+		doc, err := s.store.GetDoc(ctx, hash)
+		if err != nil {
+			return nil, err
+		}
+		docs = append(docs, doc)
+		seen[hash] = true
+	}
+	return docs, nil
 }
 
 // SyncPendings reflects in-progress context pointers to the server (detached helper path).
@@ -939,9 +1020,14 @@ func (s *SyncRepoService) SyncPendings(ctx context.Context, in inbound.SyncInput
 			ahead = append(ahead, r)
 		}
 		if len(ahead) > 0 {
-			if snaps, docs, cerr := s.collectObjects(ctx, repoID, man); cerr == nil {
+			if snaps, cerr := s.collectSnapshots(ctx, repoID, man); cerr == nil {
 				if serr := s.pushSettingsObjects(ctx, repoID, snaps); serr == nil {
-					if perr := s.remote.Push(ctx, repoID, snaps, docs, nil, false, false); perr == nil {
+					pushSnaps, pushDocs, perr := s.selectPushObjects(ctx, repoID, snaps)
+					objectsReady := perr == nil
+					if objectsReady && (len(pushSnaps) > 0 || len(pushDocs) > 0) {
+						objectsReady = s.remote.Push(ctx, repoID, pushSnaps, pushDocs, nil, false, false) == nil
+					}
+					if objectsReady {
 						for _, r := range ahead {
 							if uerr := s.remote.PushUnsync(ctx, repoID, domain.Unsync{
 								RepoID: repoID, Branch: r.Name, Target: r.Target, UpdatedAt: time.Now().UTC(),

--- a/cli/internal/ports/outbound/ports.go
+++ b/cli/internal/ports/outbound/ports.go
@@ -220,6 +220,26 @@ type RemoteSync interface {
 	DeleteUnsyncRemote(ctx context.Context, repoID string, branch string) error
 }
 
+// PushObjectWants is the server-proven missing subset of a local push
+// inventory. Snapshot metadata and document bodies are independent objects: a
+// damaged server may have one without the other, so both sets remain explicit.
+type PushObjectWants struct {
+	Snapshots []domain.ContentHash
+	Docs      []domain.ContentHash
+}
+
+// PushObjectNegotiator is an optional preflight capability for RemoteSync.
+// It lets the application advertise only content hashes before opening large
+// cumulative session documents. Chunk hashes are intentionally deferred: once
+// a missing document is selected and opened, RemoteSync.Push performs its
+// normal document/chunk negotiation and resumes any partially staged upload.
+// Remotes without this capability retain the safe legacy behavior of loading
+// and passing the full reachable object set to RemoteSync.Push, whose own
+// negotiation still prevents redundant transfer.
+type PushObjectNegotiator interface {
+	NegotiatePushObjects(ctx context.Context, repoID string, snapshotHaves, docHaves []domain.ContentHash) (PushObjectWants, error)
+}
+
 // MemorySource is a port that absorbs provider native memory (compatibility rules).
 //
 // Absorb if available: Claude MEMORY.md, Codex rollout_summary, etc. Input source for native-first strategy.

--- a/scripts/e2e-sync.sh
+++ b/scripts/e2e-sync.sh
@@ -113,6 +113,8 @@ expect "repo1 push after server main exists" "$([ -n "$HEAD_A" ] && echo yes)" y
 [ -z "$HEAD_A" ] && exit 1
 cxt memorize >/dev/null 2>&1
 cxt push >/dev/null 2>&1
+NOOP_PUSH=$(cxt push 2>&1)
+expect "no-op push offers zero snapshots after preflight" "$(echo "$NOOP_PUSH" | grep -c 'pushed 0 snapshot(s)')" 1
 
 echo "── B. repo2 (without pull): independent session B push → hook auto-append"
 git clone -q "$TMP/bare.git" "$TMP/repo2"


### PR DESCRIPTION
## Root cause\n\n`SyncRepoService.Push` opened every reachable cumulative session document before the HTTP client negotiated what the server lacked. A no-op push therefore decompressed, canonicalized, and chunk-planned the entire local history even though no object crossed the network.\n\n## Fix\n\n- advertise snapshot/doc hashes before reading document bodies\n- load only the server-requested documents\n- preserve snapshot-only and doc-only repair independently\n- perform normal chunk negotiation after selected docs are loaded\n- validate server wants as unique subsets at both adapter and app boundaries\n- preserve a full-load compatibility fallback for alternate remotes\n- skip the redundant object negotiation on ref-only publication\n- assert a repeated E2E push reports zero snapshots\n\n## Evidence\n\nReal dogfood repository (300 snapshots, ~92 MiB compressed `.cxt`):\n\n- before: 39.87s, 300 snapshots loaded/reported\n- after: 0.92s, 0 snapshots loaded/reported\n\nValidated with full CLI tests, vet, race detector, sync E2E, and public preflight.\n\nCloses #70