### PR TITLE
fix(cli): collapse recursive load seeds

### DIFF
--- a/cli/internal/app/load_session.go
+++ b/cli/internal/app/load_session.go
@@ -576,6 +576,16 @@ const seedSummaryPrefix = "[cxt] This session was resumed from a branch context 
 //   - If the digest summary matches the original native memory (e.g., MEMORY.md) of the target provider, it is omitted — the agent loads context itself at session start, so context re-injection is redundant.
 //   - KeyFacts noise such as whitespace-free tool tokens and legacy ingestion markers ("native memory:"/"absorbed from") is excluded from seed content.
 func (s *LoadSessionService) prependTrimDigest(ctx context.Context, omitted, seed domain.CIRDocument, snap domain.Snapshot, target domain.ProviderKind, cwd string) domain.CIRDocument {
+	out, _, _ := s.prependTrimDigestWithStatus(ctx, omitted, seed, snap, target, cwd, nil)
+	return out
+}
+
+// prependTrimDigestWithStatus reports both whether a new bounded digest was
+// synthesized and whether it safely supersedes prior cxt seeds. Callers must
+// retain an old seed unless its meaning came from stored memory or was folded
+// into a normalized projection; otherwise that seed can be the sole surviving
+// representation of earlier context.
+func (s *LoadSessionService) prependTrimDigestWithStatus(ctx context.Context, omitted, seed domain.CIRDocument, snap domain.Snapshot, target domain.ProviderKind, cwd string, priorSeeds []domain.Event) (domain.CIRDocument, bool, bool) {
 	digest, derr := s.distiller.Distill(ctx, omitted, nil)
 	digest.SnapshotID = snap.ID
 	if derr != nil {
@@ -593,11 +603,28 @@ func (s *LoadSessionService) prependTrimDigest(ctx context.Context, omitted, see
 			stored, hasStored = d, true
 		}
 	}
+	storedUsable := false
 	if hasStored {
-		digest = domain.MergeDigests(stored, digest)
+		// Stored memory is immutable archival state and can contain a full native
+		// memory or legacy cxt seed generations. Loading it into a provider prompt
+		// is an inherited projection, so apply the same recursion filter and carry
+		// bounds used by branch/memorize inheritance. The original object remains
+		// untouched and the fresh digest below still contributes recent conversation.
+		stored = boundCarriedDigest(stored)
+		storedUsable = memoryDigestHasProjection(stored)
+		if storedUsable {
+			digest = domain.MergeDigests(stored, digest)
+		}
 	}
-	if derr != nil && !hasStored {
-		return seed
+	if derr != nil && !storedUsable {
+		return seed, false, false
+	}
+	seedProjected := false
+	if !storedUsable {
+		if carried, ok := syntheticSeedMemoryProjection(priorSeeds, snap.ID); ok {
+			digest = domain.MergeDigests(carried, digest)
+			seedProjected = true
+		}
 	}
 	// Skip native-memory duplicates when the summary repeats the ingested native memory verbatim.
 	if src, ok := s.memSources[target]; ok && digest.Summary != "" {
@@ -624,7 +651,11 @@ func (s *LoadSessionService) prependTrimDigest(ctx context.Context, omitted, see
 	}
 	out := seed
 	out.Events = append([]domain.Event{ev}, tail...)
-	return out
+	return out, true, len(priorSeeds) == 0 || storedUsable || seedProjected
+}
+
+func memoryDigestHasProjection(d domain.MemoryDigest) bool {
+	return strings.TrimSpace(d.Summary) != "" || len(d.KeyFacts) > 0 || len(d.OpenTasks) > 0 || len(d.Fragments) > 0
 }
 
 func (s *LoadSessionService) insertTrimDigestAfterPrefix(ctx context.Context, omitted, seed domain.CIRDocument, prefixCount int, snap domain.Snapshot, target domain.ProviderKind, cwd string) domain.CIRDocument {
@@ -632,9 +663,32 @@ func (s *LoadSessionService) insertTrimDigestAfterPrefix(ctx context.Context, om
 		return s.prependTrimDigest(ctx, omitted, seed, snap, target, cwd)
 	}
 	prefix := append([]domain.Event{}, seed.Events[:prefixCount]...)
+	priorSeeds := make([]domain.Event, 0, 1)
+	for _, ev := range prefix {
+		if isSeedSummaryEvent(ev) {
+			priorSeeds = append(priorSeeds, ev)
+		}
+	}
 	tail := seed
 	tail.Events = seed.Events[prefixCount:]
-	tail = s.prependTrimDigest(ctx, omitted, tail, snap, target, cwd)
+	var inserted, replacesPriorSeeds bool
+	tail, inserted, replacesPriorSeeds = s.prependTrimDigestWithStatus(ctx, omitted, tail, snap, target, cwd, priorSeeds)
+	if inserted && replacesPriorSeeds {
+		// A prior cxt seed is semantic projection, not provider-owned replay
+		// state. Keeping it beside the replacement digest recursively embeds
+		// every earlier seed generation and was measured at 40 nested copies in
+		// one Codex replay. Real messages and opaque compaction state remain
+		// pinned; only the successfully superseded synthetic projection is
+		// removed.
+		filtered := prefix[:0]
+		for _, ev := range prefix {
+			if isSeedSummaryEvent(ev) {
+				continue
+			}
+			filtered = append(filtered, ev)
+		}
+		prefix = filtered
+	}
 	out := seed
 	out.Events = make([]domain.Event, 0, len(prefix)+len(tail.Events))
 	out.Events = append(out.Events, prefix...)
@@ -643,6 +697,91 @@ func (s *LoadSessionService) insertTrimDigestAfterPrefix(ctx context.Context, om
 		out.Events[i].Seq = i
 	}
 	return out
+}
+
+// syntheticSeedMemoryProjection makes a bounded carried digest from legacy
+// cxt seed text when no attached/ancestor memory exists. The first header is
+// replaced by the new seed's header, while embedded headers are neutralized so
+// the next load cannot recognize and recursively re-ingest generations. Raw
+// seed events remain immutable in their source snapshots.
+func syntheticSeedMemoryProjection(events []domain.Event, source domain.ContentHash) (domain.MemoryDigest, bool) {
+	if source == "" {
+		return domain.MemoryDigest{}, false
+	}
+	var summaries []string
+	for _, ev := range events {
+		if !isSeedSummaryEvent(ev) {
+			continue
+		}
+		text := strings.TrimSpace(ev.Blocks[0].Text)
+		if newline := strings.IndexByte(text, '\n'); newline >= 0 {
+			text = text[newline+1:]
+		} else {
+			text = ""
+		}
+		text = strings.ReplaceAll(text, seedSummaryPrefix, "[prior cxt context]")
+		text = strings.ReplaceAll(text, "[cxt seed] Branch-switch context:", "[prior branch context]")
+		if text = strings.TrimSpace(text); text != "" {
+			summaries = append(summaries, text)
+		}
+	}
+	if len(summaries) == 0 {
+		return domain.MemoryDigest{}, false
+	}
+	summary := strings.Join(summaries, "\n\n")
+	facts, tasks, tasksAuthoritative := syntheticSeedStructuredProjection(summary)
+	return boundCarriedDigest(domain.MemoryDigest{
+		SnapshotID:         source,
+		Summary:            summary,
+		KeyFacts:           facts,
+		OpenTasks:          tasks,
+		TasksAuthoritative: tasksAuthoritative,
+	}), true
+}
+
+// syntheticSeedStructuredProjection recovers the newest rendered cxt bullet
+// sections before narrative tail truncation. These headings are emitted by
+// renderSeedDigest itself, so exact heading matching avoids interpreting
+// arbitrary prose as structure.
+func syntheticSeedStructuredProjection(text string) (facts, tasks []string, tasksAuthoritative bool) {
+	const (
+		sectionNone = iota
+		sectionFacts
+		sectionTasks
+	)
+	section := sectionNone
+	for _, line := range strings.Split(text, "\n") {
+		trimmed := strings.TrimSpace(line)
+		switch trimmed {
+		case "Key facts:":
+			facts = nil // latest rendered section wins
+			section = sectionFacts
+			continue
+		case "Open tasks:":
+			tasks = nil // an empty latest section is authoritative
+			tasksAuthoritative = true
+			section = sectionTasks
+			continue
+		}
+		if trimmed == "" {
+			continue
+		}
+		if !strings.HasPrefix(trimmed, "- ") {
+			section = sectionNone
+			continue
+		}
+		item := strings.TrimSpace(trimmed[2:])
+		if item == "" {
+			continue
+		}
+		switch section {
+		case sectionFacts:
+			facts = append(facts, item)
+		case sectionTasks:
+			tasks = append(tasks, item)
+		}
+	}
+	return facts, tasks, tasksAuthoritative
 }
 
 // seedWorthyFacts retains only KeyFacts that are worth placing in the seed header. The distillation now

--- a/cli/internal/app/restore_test.go
+++ b/cli/internal/app/restore_test.go
@@ -204,6 +204,7 @@ func TestLoadFullPinsCodexReplacementWhileTrimmingLongSuffix(t *testing.T) {
 			{
 				Kind: domain.EventCompaction, Seq: 1, ReplacementComplete: true,
 				Replacement: []domain.Event{
+					{Kind: domain.EventMessage, Seq: 0, Role: "user", CompactSummary: true, Blocks: []domain.ContentBlock{{Type: "text", Text: seedSummaryPrefix + " 1126 events were omitted\n" + strings.Repeat(seedSummaryPrefix+" nested inherited generation\n", 20)}}},
 					{Kind: domain.EventMessage, Seq: 0, Role: "developer", Blocks: []domain.ContentBlock{{Type: "text", Text: "pinned runtime contract"}}},
 					{Kind: domain.EventMessage, Seq: 1, Role: "user", Blocks: []domain.ContentBlock{{Type: "text", Text: "pinned compacted memory"}}},
 					{Kind: domain.EventCompaction, Seq: 2, Locked: &domain.LockedBlob{Provider: domain.ProviderCodex, Scheme: "encrypted_content", Blob: "PINNED-ENC"}},
@@ -250,20 +251,64 @@ func TestLoadFullPinsCodexReplacementWhileTrimmingLongSuffix(t *testing.T) {
 		t.Fatal(err)
 	}
 	active := restored.EffectiveContext()
-	lockedAt, digestAt, recentAt := -1, -1, -1
+	lockedAt, digestAt, recentAt, digestCount := -1, -1, -1, 0
 	for i, ev := range active.Events {
 		if ev.Kind == domain.EventCompaction && ev.Locked != nil && ev.Locked.Blob == "PINNED-ENC" {
 			lockedAt = i
 		}
 		if ev.Kind == domain.EventMessage && len(ev.Blocks) > 0 && strings.HasPrefix(ev.Blocks[0].Text, seedSummaryPrefix) {
 			digestAt = i
+			digestCount++
 		}
 		if ev.Kind == domain.EventMessage && len(ev.Blocks) > 0 && ev.Blocks[0].Text == "recent request retained" {
 			recentAt = i
 		}
 	}
+	if digestCount != 1 {
+		t.Fatalf("active replay contains %d synthetic seed generations, want exactly one", digestCount)
+	}
+	if strings.Count(active.Events[digestAt].Blocks[0].Text, seedSummaryPrefix) != 1 {
+		t.Fatalf("replacement digest recursively contains prior seed generations:\n%s", active.Events[digestAt].Blocks[0].Text)
+	}
 	if !(lockedAt >= 0 && lockedAt < digestAt && digestAt < recentAt) {
 		t.Fatalf("replay order is not replacement → digest → recent tail: locked=%d digest=%d recent=%d events=%+v", lockedAt, digestAt, recentAt, active.Events)
+	}
+
+	// Loading the already-bounded replay again must be idempotent: no new trim
+	// digest and no reintroduction of a prior synthetic generation.
+	replayHash, err := store.PutDoc(ctx, domain.SessionDoc{CIR: restored})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.PutSnapshot(ctx, domain.Snapshot{ID: replayHash, Branch: "main", DocHash: replayHash, Provider: domain.ProviderCodex, Fidelity: domain.FidelityFull}); err != nil {
+		t.Fatal(err)
+	}
+	second, err := newLoadSvc(store).Load(ctx, inbound.LoadInput{Ref: string(replayHash), TargetProvider: domain.ProviderCodex, Mode: domain.FidelityFull, Cwd: t.TempDir()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second.TrimmedEvents != 0 {
+		t.Fatalf("already-bounded replay was trimmed again: %d events", second.TrimmedEvents)
+	}
+	secondRaw, err := os.ReadFile(second.WrittenPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondDoc, err := codec.NewCodexCodec().Decode(ctx, secondRaw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondSeedCount := 0
+	for _, ev := range secondDoc.EffectiveContext().Events {
+		if isSeedSummaryEvent(ev) {
+			secondSeedCount++
+			if strings.Count(ev.Blocks[0].Text, seedSummaryPrefix) != 1 {
+				t.Fatalf("second load recursively expanded the seed:\n%s", ev.Blocks[0].Text)
+			}
+		}
+	}
+	if secondSeedCount != 1 {
+		t.Fatalf("second load contains %d synthetic seeds, want one", secondSeedCount)
 	}
 }
 

--- a/cli/internal/app/seed_digest_test.go
+++ b/cli/internal/app/seed_digest_test.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -14,6 +15,12 @@ type stubDistiller struct{ d domain.MemoryDigest }
 
 func (s stubDistiller) Distill(_ context.Context, _ domain.CIRDocument, _ *domain.NativeMemory) (domain.MemoryDigest, error) {
 	return s.d, nil
+}
+
+type failingDistiller struct{}
+
+func (failingDistiller) Distill(_ context.Context, _ domain.CIRDocument, _ *domain.NativeMemory) (domain.MemoryDigest, error) {
+	return domain.MemoryDigest{}, errors.New("distillation unavailable")
 }
 
 type stubMemSource struct{ text string }
@@ -82,5 +89,170 @@ func TestPrependTrimDigestCompactSummary(t *testing.T) {
 	out = svc.prependTrimDigest(ctx, full, seed, domain.Snapshot{}, domain.ProviderClaude, t.TempDir())
 	if strings.Contains(out.Events[0].Blocks[0].Text, "MEMROOT") {
 		t.Fatalf("Native memory text re-injected into seed: %q", out.Events[0].Blocks[0].Text)
+	}
+}
+
+func TestPrependTrimDigestProjectsStoredMemoryWithoutSeedRecursion(t *testing.T) {
+	ctx := context.Background()
+	st := storage.NewFileStore(t.TempDir())
+	snapshotID := domain.HashContent([]byte("snapshot-with-recursive-memory"))
+	recursiveSummary := "project history before recursion\n" + seedSummaryPrefix +
+		" 99 events were omitted\n" + strings.Repeat("recursive inherited seed\n", 200)
+	memoryHash, err := st.PutMemory(ctx, domain.MemoryDigest{
+		SnapshotID: snapshotID,
+		Summary:    recursiveSummary,
+		KeyFacts:   []string{"stored structured fact remains available"},
+		Fragments: []domain.MemoryFragment{{
+			SourceSnapshot: snapshotID,
+			Summary:        recursiveSummary,
+			KeyFacts:       []string{"stored structured fact remains available"},
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	snap := domain.Snapshot{ID: snapshotID, DocHash: snapshotID, MemoryHash: memoryHash, Branch: "main"}
+	if err := st.PutSnapshot(ctx, snap); err != nil {
+		t.Fatal(err)
+	}
+	svc := NewLoadSessionService(st, nil, nil, nil, stubDistiller{d: domain.MemoryDigest{
+		Summary: "fresh omitted conversation",
+	}}, nil)
+	omitted := domain.CIRDocument{Events: []domain.Event{
+		{Kind: domain.EventMessage, Role: "user", Blocks: []domain.ContentBlock{{Type: "text", Text: "real old request"}}},
+	}}
+	seed := domain.CIRDocument{Events: []domain.Event{
+		{Kind: domain.EventMessage, Role: "user", Seq: 1, Blocks: []domain.ContentBlock{{Type: "text", Text: "latest request"}}},
+	}}
+
+	out := svc.prependTrimDigest(ctx, omitted, seed, snap, domain.ProviderCodex, t.TempDir())
+	if len(out.Events) != 2 || len(out.Events[0].Blocks) == 0 {
+		t.Fatalf("projected seed = %+v", out.Events)
+	}
+	text := out.Events[0].Blocks[0].Text
+	if count := strings.Count(text, seedSummaryPrefix); count != 1 {
+		t.Fatalf("trim digest contains %d cxt generations, want only its own header:\n%s", count, text)
+	}
+	for _, forbidden := range []string{"recursive inherited seed", "project history before recursion"} {
+		if strings.Contains(text, forbidden) {
+			t.Fatalf("stored recursive summary leaked into prompt: %q", forbidden)
+		}
+	}
+	for _, want := range []string{"fresh omitted conversation", "stored structured fact remains available"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("prompt projection lost %q:\n%s", want, text)
+		}
+	}
+}
+
+func TestInsertTrimDigestKeepsExistingSeedWhenReplacementFails(t *testing.T) {
+	ctx := context.Background()
+	st := storage.NewFileStore(t.TempDir())
+	svc := NewLoadSessionService(st, nil, nil, nil, failingDistiller{}, nil)
+	oldSeed := seedSummaryPrefix + " 50 events were omitted\nsole surviving project memory"
+	seed := domain.CIRDocument{Events: []domain.Event{
+		{Kind: domain.EventMessage, Role: "user", CompactSummary: true, Blocks: []domain.ContentBlock{{Type: "text", Text: oldSeed}}},
+		{Kind: domain.EventCompaction, Locked: &domain.LockedBlob{Provider: domain.ProviderCodex, Scheme: "encrypted_content", Blob: "PINNED"}},
+		{Kind: domain.EventMessage, Role: "user", Blocks: []domain.ContentBlock{{Type: "text", Text: "recent request"}}},
+	}}
+	omitted := domain.CIRDocument{Events: []domain.Event{
+		{Kind: domain.EventMessage, Role: "user", Blocks: []domain.ContentBlock{{Type: "text", Text: "older request"}}},
+	}}
+
+	out := svc.insertTrimDigestAfterPrefix(ctx, omitted, seed, 2, domain.Snapshot{}, domain.ProviderCodex, t.TempDir())
+	if len(out.Events) != len(seed.Events) || out.Events[0].Blocks[0].Text != oldSeed {
+		t.Fatalf("failed replacement discarded the existing seed: %+v", out.Events)
+	}
+	if out.Events[1].Locked == nil || out.Events[1].Locked.Blob != "PINNED" {
+		t.Fatalf("failed replacement changed provider state: %+v", out.Events[1])
+	}
+}
+
+func TestInsertTrimDigestProjectsExistingSeedWithoutStoredMemory(t *testing.T) {
+	ctx := context.Background()
+	st := storage.NewFileStore(t.TempDir())
+	svc := NewLoadSessionService(st, nil, nil, nil, stubDistiller{d: domain.MemoryDigest{
+		Summary: "fresh omitted conversation",
+	}}, nil)
+	snapshotID := domain.HashContent([]byte("memoryless-synthetic-seed"))
+	oldSeed := seedSummaryPrefix + " 50 events were omitted\nsole surviving project memory\n" +
+		seedSummaryPrefix + " nested generation that must not recur\n\n" +
+		"Key facts:\n- The sole-memory fallback must retain structured decisions.\n\n" +
+		"Open tasks:\n- Verify the memoryless replay path."
+	seed := domain.CIRDocument{Events: []domain.Event{
+		{Kind: domain.EventMessage, Role: "user", CompactSummary: true, Blocks: []domain.ContentBlock{{Type: "text", Text: oldSeed}}},
+		{Kind: domain.EventCompaction, Locked: &domain.LockedBlob{Provider: domain.ProviderCodex, Scheme: "encrypted_content", Blob: "PINNED"}},
+		{Kind: domain.EventMessage, Role: "user", Blocks: []domain.ContentBlock{{Type: "text", Text: "recent request"}}},
+	}}
+	omitted := domain.CIRDocument{Events: []domain.Event{
+		{Kind: domain.EventMessage, Role: "user", Blocks: []domain.ContentBlock{{Type: "text", Text: "older request"}}},
+	}}
+
+	out := svc.insertTrimDigestAfterPrefix(ctx, omitted, seed, 2, domain.Snapshot{ID: snapshotID}, domain.ProviderCodex, t.TempDir())
+	seedCount := 0
+	seedText := ""
+	for _, ev := range out.Events {
+		if isSeedSummaryEvent(ev) {
+			seedCount++
+			seedText = ev.Blocks[0].Text
+		}
+	}
+	if seedCount != 1 || strings.Count(seedText, seedSummaryPrefix) != 1 {
+		t.Fatalf("memoryless seed was not collapsed: count=%d\n%s", seedCount, seedText)
+	}
+	for _, want := range []string{
+		"sole surviving project memory",
+		"fresh omitted conversation",
+		"[prior cxt context]",
+		"The sole-memory fallback must retain structured decisions.",
+		"Verify the memoryless replay path.",
+	} {
+		if !strings.Contains(seedText, want) {
+			t.Fatalf("memoryless projection lost %q:\n%s", want, seedText)
+		}
+	}
+	if out.Events[0].Locked == nil || out.Events[0].Locked.Blob != "PINNED" {
+		t.Fatalf("memoryless projection changed provider state: %+v", out.Events)
+	}
+}
+
+func TestInsertTrimDigestFallsBackWhenStoredMemorySanitizesEmpty(t *testing.T) {
+	ctx := context.Background()
+	st := storage.NewFileStore(t.TempDir())
+	svc := NewLoadSessionService(st, nil, nil, nil, stubDistiller{d: domain.MemoryDigest{
+		Summary: "fresh omitted conversation",
+	}}, nil)
+	snapshotID := domain.HashContent([]byte("empty-sanitized-stored-memory"))
+	memoryHash, err := st.PutMemory(ctx, domain.MemoryDigest{
+		SnapshotID: snapshotID,
+		Summary:    seedSummaryPrefix + " recursively stored without structure",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldSeed := seedSummaryPrefix + " 50 events were omitted\nsole surviving fallback memory"
+	seed := domain.CIRDocument{Events: []domain.Event{
+		{Kind: domain.EventMessage, Role: "user", CompactSummary: true, Blocks: []domain.ContentBlock{{Type: "text", Text: oldSeed}}},
+		{Kind: domain.EventCompaction, Locked: &domain.LockedBlob{Provider: domain.ProviderCodex, Scheme: "encrypted_content", Blob: "PINNED"}},
+		{Kind: domain.EventMessage, Role: "user", Blocks: []domain.ContentBlock{{Type: "text", Text: "recent request"}}},
+	}}
+	omitted := domain.CIRDocument{Events: []domain.Event{
+		{Kind: domain.EventMessage, Role: "user", Blocks: []domain.ContentBlock{{Type: "text", Text: "older request"}}},
+	}}
+	snap := domain.Snapshot{ID: snapshotID, DocHash: snapshotID, MemoryHash: memoryHash}
+
+	out := svc.insertTrimDigestAfterPrefix(ctx, omitted, seed, 2, snap, domain.ProviderCodex, t.TempDir())
+	seedCount := 0
+	for _, ev := range out.Events {
+		if !isSeedSummaryEvent(ev) {
+			continue
+		}
+		seedCount++
+		if !strings.Contains(ev.Blocks[0].Text, "sole surviving fallback memory") {
+			t.Fatalf("empty stored projection displaced the only usable seed:\n%s", ev.Blocks[0].Text)
+		}
+	}
+	if seedCount != 1 {
+		t.Fatalf("fallback produced %d seed events, want one", seedCount)
 	}
 }


### PR DESCRIPTION
## Summary

- collapse prior cxt-generated seed events when a new Codex bounded replay digest safely supersedes them
- preserve provider-owned encrypted compaction state and real replay messages in order
- sanitize attached/ancestor memory before prompt inheritance
- recover a bounded narrative plus newest facts/tasks from legacy memoryless seeds
- keep the prior seed when distillation fails or no safe projection can be built

## Confirmed production reproduction

Before:
- rollout 476,523 bytes
- model-visible replacement 250,506 bytes
- two active synthetic seeds
- 40 nested markers inside the older seed

After:
- rollout 271,864 bytes
- model-visible replacement 174,183 bytes
- one active synthetic seed
- one encrypted compaction-state item
- one marker inside the current seed

Codex display companions still duplicate visible messages on disk by design; they do not add a second model-visible seed.

## Verification

- `go test ./...`
- `go vet ./...`
- `go test -race ./...`
- `make e2e`
- `make e2e-sync`
- `make public-check`
- real CIR v2 load measurement
- repeated-load idempotence regression
- stored-memory, memoryless legacy, unusable stored-memory, and distillation-failure regressions

Closes #75