### PR TITLE
fix(cli): make subcommand help side-effect free

### DIFF
--- a/cli/cmd/cxt/main.go
+++ b/cli/cmd/cxt/main.go
@@ -42,10 +42,6 @@ import (
 var version = "dev"
 
 func main() {
-	if len(os.Args) > 1 && (os.Args[1] == "version" || os.Args[1] == "--version") {
-		fmt.Println("cxt", version)
-		return
-	}
 	if err := run(os.Args); err != nil {
 		fmt.Fprintf(os.Stderr, "cxt: %v\n", err)
 		os.Exit(1)
@@ -54,6 +50,15 @@ func main() {
 
 // run parses arguments and branches to the appropriate entry point.
 func run(args []string) error {
+	// Help and usage errors must return before adapter construction: some
+	// commands materialize provider sessions or contact the remote immediately.
+	if handled, err := delivcli.PreflightArgs(args); handled || err != nil {
+		return err
+	}
+	if args[1] == "version" || args[1] == "--version" {
+		fmt.Println("cxt", version)
+		return nil
+	}
 	// config is the execution settings for the cxt client.
 	// TODO: Replace with actual config file parsing (repoRoot/.cxt/config or XDG).
 	cfg := loadConfig()

--- a/cli/cmd/cxt/main_test.go
+++ b/cli/cmd/cxt/main_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunHelpAndUsageErrorsBeforeComposition(t *testing.T) {
+	root := t.TempDir()
+	t.Chdir(root)
+	t.Setenv("HOME", filepath.Join(root, "home"))
+
+	for _, args := range [][]string{
+		{"cxt", "load", "--help"},
+		{"cxt", "save", "-h"},
+		{"cxt", "mcp", "--help"},
+		{"cxt", "hook", "--help"},
+		{"cxt", "version", "--help"},
+	} {
+		if err := run(args); err != nil {
+			t.Fatalf("run(%v): %v", args, err)
+		}
+	}
+
+	for _, args := range [][]string{
+		{"cxt", "load", "--unknown"},
+		{"cxt", "save", "--unknown"},
+		{"cxt", "mcp", "--unknown"},
+		{"cxt", "hook", "--unknown"},
+		{"cxt", "version", "--unknown"},
+	} {
+		if err := run(args); err == nil || !strings.Contains(err.Error(), "unknown flag") {
+			t.Fatalf("run(%v) error = %v", args, err)
+		}
+	}
+
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("help/usage preflight mutated cwd: %+v", entries)
+	}
+}

--- a/cli/internal/adapters/delivery/cli/args.go
+++ b/cli/internal/adapters/delivery/cli/args.go
@@ -1,0 +1,211 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+)
+
+type commandFlagKind uint8
+
+const (
+	commandBoolFlag commandFlagKind = iota
+	commandValueFlag
+)
+
+type commandArgSpec struct {
+	usage       string
+	flags       map[string]commandFlagKind
+	passthrough bool
+}
+
+func commandFlags(valueFlags, boolFlags []string) map[string]commandFlagKind {
+	out := make(map[string]commandFlagKind, len(valueFlags)+len(boolFlags))
+	for _, name := range valueFlags {
+		out[name] = commandValueFlag
+	}
+	for _, name := range boolFlags {
+		out[name] = commandBoolFlag
+	}
+	return out
+}
+
+var commandArgSpecs = map[string]commandArgSpec{
+	"setup":     {usage: "cxt setup [remote-url] [--no-login]", flags: commandFlags(nil, []string{"--no-login"})},
+	"init":      {usage: "cxt init [--no-hooks] [--remote <url>]", flags: commandFlags([]string{"--remote"}, []string{"--no-hooks"})},
+	"repo":      {usage: "cxt repo create <url>"},
+	"claude":    {usage: "cxt claude [claude-arguments...]", passthrough: true},
+	"codex":     {usage: "cxt codex [codex-arguments...]", passthrough: true},
+	"remote":    {usage: "cxt remote [-v] | add <name> <url> | remove <name>", flags: commandFlags(nil, []string{"-v"})},
+	"repack":    {usage: "cxt repack"},
+	"add":       {usage: "cxt add [claude|codex|.]..."},
+	"commit":    {usage: "cxt commit [-m <message>]", flags: commandFlags([]string{"-m"}, nil)},
+	"switch":    {usage: "cxt switch [<branch>] [-c <new>] [--mode full|reconstructed|memory]", flags: commandFlags([]string{"-c", "--mode"}, nil)},
+	"config":    {usage: "cxt config <key> [value]"},
+	"login":     {usage: "cxt login [token] | -t <token>", flags: commandFlags([]string{"-t"}, nil)},
+	"logout":    {usage: "cxt logout"},
+	"fsck":      {usage: "cxt fsck"},
+	"reflog":    {usage: "cxt reflog"},
+	"secrets":   {usage: "cxt secrets push|pull [-p <passphrase>] [--remember] [--rotate]", flags: commandFlags([]string{"-p"}, []string{"--remember", "--rotate"})},
+	"settings":  {usage: "cxt settings pull|list|restore [n]"},
+	"hooks":     {usage: "cxt hooks install|uninstall"},
+	"save":      {usage: "cxt save [-m <message>] [--provider claude|codex]", flags: commandFlags([]string{"-m", "--provider"}, nil)},
+	"list":      {usage: "cxt list [--branch <branch>]", flags: commandFlags([]string{"--branch"}, nil)},
+	"log":       {usage: "cxt log [--branch <branch>]", flags: commandFlags([]string{"--branch"}, nil)},
+	"checkout":  {usage: "cxt checkout [<ref>] [-b <new>] [--provider claude|codex] [--mode full|reconstructed|memory]", flags: commandFlags([]string{"-b", "--provider", "--mode"}, nil)},
+	"fork":      {usage: "cxt fork <ref> --as <branch> [--provider claude|codex] [--mode full|reconstructed|memory]", flags: commandFlags([]string{"--as", "--provider", "--mode"}, nil)},
+	"load":      {usage: "cxt load [<ref>] [--provider claude|codex] [--mode full|reconstructed|memory]", flags: commandFlags([]string{"--provider", "--mode"}, nil)},
+	"push":      {usage: "cxt push [--force|-f|--append]", flags: commandFlags(nil, []string{"--force", "-f", "--append"})},
+	"pull":      {usage: "cxt pull [--force|-f]", flags: commandFlags(nil, []string{"--force", "-f"})},
+	"stash":     {usage: "cxt stash [push [-m <message>]|pop|list]", flags: commandFlags([]string{"-m"}, nil)},
+	"memorize":  {usage: "cxt memorize [<ref>] [--provider claude|codex]", flags: commandFlags([]string{"--provider"}, nil)},
+	"memory":    {usage: "cxt memory [<ref>] [--provider claude|codex]", flags: commandFlags([]string{"--provider"}, nil)},
+	"tag":       {usage: "cxt tag [<name> [ref]]"},
+	"mcp":       {usage: "cxt mcp"},
+	"hook":      {usage: "cxt hook --provider claude|codex --event <event>", flags: commandFlags([]string{"--provider", "--event"}, nil)},
+	"version":   {usage: "cxt version"},
+	"--version": {usage: "cxt --version"},
+}
+
+// PreflightArgs handles help and validates flags before the composition root
+// creates adapters or any command can touch filesystem, network, refs, or
+// provider sessions. The boolean reports that help was printed and execution
+// must stop successfully.
+func PreflightArgs(args []string) (bool, error) {
+	if len(args) < 2 {
+		printUsage()
+		return true, nil
+	}
+	cmd := args[1]
+	if cmd == "-h" || cmd == "--help" {
+		printUsage()
+		return true, nil
+	}
+	if cmd == "help" {
+		if len(args) == 2 {
+			printUsage()
+			return true, nil
+		}
+		if len(args) != 3 {
+			return false, fmt.Errorf("usage: cxt help [command]")
+		}
+		return printSubcommandUsage(args[2])
+	}
+	if cmd == "git-hook" { // internal Git integration owns its event-specific arguments
+		return false, nil
+	}
+
+	spec, ok := commandArgSpecs[cmd]
+	if !ok {
+		return false, unknownCommandError(cmd)
+	}
+	rest := args[2:]
+	if helpRequested(rest) {
+		fmt.Printf("usage: %s\n", spec.usage)
+		return true, nil
+	}
+	if spec.passthrough {
+		return false, nil
+	}
+	if err := validateCommandFlags(cmd, rest, spec); err != nil {
+		return false, err
+	}
+	return false, nil
+}
+
+func printSubcommandUsage(cmd string) (bool, error) {
+	if cmd == "help" {
+		printUsage()
+		return true, nil
+	}
+	spec, ok := commandArgSpecs[cmd]
+	if !ok {
+		return false, unknownCommandError(cmd)
+	}
+	fmt.Printf("usage: %s\n", spec.usage)
+	return true, nil
+}
+
+func helpRequested(args []string) bool {
+	for _, arg := range args {
+		if arg == "--" {
+			return false
+		}
+		if arg == "-h" || arg == "--help" {
+			return true
+		}
+	}
+	return false
+}
+
+func validateCommandFlags(cmd string, args []string, spec commandArgSpec) error {
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if !strings.HasPrefix(arg, "-") {
+			continue
+		}
+		name, inlineValue, hasInlineValue := splitFlagValue(arg)
+		kind, ok := spec.flags[name]
+		if !ok {
+			return fmt.Errorf("%s: unknown flag %q\nusage: %s", cmd, arg, spec.usage)
+		}
+		if hasInlineValue {
+			if kind != commandValueFlag {
+				return fmt.Errorf("%s: flag %q does not take a value\nusage: %s", cmd, name, spec.usage)
+			}
+			if inlineValue == "" {
+				return fmt.Errorf("%s: flag %q requires a value\nusage: %s", cmd, name, spec.usage)
+			}
+			continue
+		}
+		if kind != commandValueFlag {
+			continue
+		}
+		if i+1 >= len(args) || args[i+1] == "" || strings.HasPrefix(args[i+1], "-") {
+			return fmt.Errorf("%s: flag %q requires a value\nusage: %s", cmd, name, spec.usage)
+		}
+		i++
+	}
+
+	pos := positionals(args)
+	switch cmd {
+	case "remote":
+		if flagPresent(args, "-v") && len(pos) > 0 {
+			return fmt.Errorf("remote: flag %q is only valid when listing remotes\nusage: %s", "-v", spec.usage)
+		}
+	case "secrets":
+		if flagPresent(args, "--rotate") && (len(pos) == 0 || pos[0] != "push") {
+			return fmt.Errorf("secrets: flag %q is only valid with push\nusage: %s", "--rotate", spec.usage)
+		}
+	case "stash":
+		if flagVal(args, "-m") != "" && len(pos) > 0 && pos[0] != "push" {
+			return fmt.Errorf("stash: flag %q is only valid with push\nusage: %s", "-m", spec.usage)
+		}
+	}
+	return nil
+}
+
+func splitFlagValue(arg string) (name, value string, inline bool) {
+	name, value, inline = strings.Cut(arg, "=")
+	return name, value, inline
+}
+
+func unknownCommandError(cmd string) error {
+	return fmt.Errorf("%q: unknown command. Supported: %s", cmd, strings.Join(publicCommandNames, "|"))
+}
+
+func flagConsumesValue(name string) bool {
+	name, _, _ = splitFlagValue(name)
+	for _, spec := range commandArgSpecs {
+		if spec.flags[name] == commandValueFlag {
+			return true
+		}
+	}
+	return false
+}
+
+func providerPassthroughArgs(args []string) []string {
+	if len(args) > 0 && args[0] == "--" {
+		return args[1:]
+	}
+	return args
+}

--- a/cli/internal/adapters/delivery/cli/root.go
+++ b/cli/internal/adapters/delivery/cli/root.go
@@ -66,16 +66,10 @@ type Container struct {
 
 // Run is the CLI entry point. Parses args(=os.Args) to execute the corresponding subcommand.
 func Run(c *Container, args []string) error {
-	if len(args) < 2 {
-		printUsage()
-		return nil
+	if handled, err := PreflightArgs(args); handled || err != nil {
+		return err
 	}
 	cmd := args[1]
-	switch cmd {
-	case "-h", "--help", "help":
-		printUsage()
-		return nil
-	}
 
 	ctx := context.Background()
 	rest := args[2:]
@@ -125,7 +119,7 @@ func Run(c *Container, args []string) error {
 
 	case "claude", "codex":
 		// Agent wrapper (default execution path): fresh start seeds the current branch context, and automatically restarts with the seed session on context switch.
-		return runAgentWrapper(ctx, c, cwd, cmd, rest)
+		return runAgentWrapper(ctx, c, cwd, cmd, providerPassthroughArgs(rest))
 
 	case "remote":
 		return runRemote(ctx, c, cwd, rest)
@@ -790,7 +784,7 @@ func Run(c *Container, args []string) error {
 		return nil
 
 	default:
-		return fmt.Errorf("%q: unknown command. Supported: %s", cmd, strings.Join(publicCommandNames, "|"))
+		return unknownCommandError(cmd)
 	}
 }
 
@@ -941,7 +935,10 @@ func positionals(args []string) []string {
 	var out []string
 	for i := 0; i < len(args); i++ {
 		if strings.HasPrefix(args[i], "-") {
-			i++ // skip flag value
+			_, _, inline := splitFlagValue(args[i])
+			if flagConsumesValue(args[i]) && !inline {
+				i++
+			}
 			continue
 		}
 		out = append(out, args[i])
@@ -951,12 +948,8 @@ func positionals(args []string) []string {
 
 // firstPositional returns the first argument that is not a flag (e.g., checkout <ref>).
 func firstPositional(args []string) string {
-	for i := 0; i < len(args); i++ {
-		if strings.HasPrefix(args[i], "-") {
-			i++ // skip flag value
-			continue
-		}
-		return args[i]
+	if pos := positionals(args); len(pos) > 0 {
+		return pos[0]
 	}
 	return ""
 }
@@ -1045,8 +1038,15 @@ func modeOr(cwd string, rest []string) string {
 }
 
 func flagVal(args []string, name string) string {
-	for i := 0; i < len(args)-1; i++ {
+	for i := 0; i < len(args); i++ {
+		flagName, inlineValue, inline := splitFlagValue(args[i])
+		if flagName == name && inline {
+			return inlineValue
+		}
 		if args[i] == name {
+			if i+1 >= len(args) {
+				return ""
+			}
 			return args[i+1]
 		}
 	}
@@ -1055,10 +1055,8 @@ func flagVal(args []string, name string) string {
 
 // lastPositional returns the last argument that is not a flag (e.g., repo create <url> returns url).
 func lastPositional(args []string) string {
-	for i := len(args) - 1; i >= 0; i-- {
-		if !strings.HasPrefix(args[i], "-") {
-			return args[i]
-		}
+	if pos := positionals(args); len(pos) > 0 {
+		return pos[len(pos)-1]
 	}
 	return ""
 }

--- a/cli/internal/adapters/delivery/cli/root_help_test.go
+++ b/cli/internal/adapters/delivery/cli/root_help_test.go
@@ -31,6 +31,152 @@ func TestGlobalHelpAliasesReturnSuccessWithoutContainer(t *testing.T) {
 	}
 }
 
+func TestEveryPublicSubcommandHelpReturnsBeforeContainer(t *testing.T) {
+	for _, command := range publicCommandNames {
+		if command == "help" {
+			continue
+		}
+		for _, help := range []string{"-h", "--help"} {
+			t.Run(command+"/"+help, func(t *testing.T) {
+				// A nil container is deliberate: any command dispatch would panic.
+				if err := Run(nil, []string{"cxt", command, help}); err != nil {
+					t.Fatalf("Run(%q, %q) returned error: %v", command, help, err)
+				}
+			})
+		}
+	}
+}
+
+func TestEveryPublicCommandHasAnArgumentSpec(t *testing.T) {
+	for _, command := range publicCommandNames {
+		if command == "help" {
+			continue
+		}
+		if spec, ok := commandArgSpecs[command]; !ok || spec.usage == "" {
+			t.Errorf("public command %q has no argument/usage spec", command)
+		}
+	}
+}
+
+func TestUnknownFlagsAreRejectedBeforeCommandDispatch(t *testing.T) {
+	for command, spec := range commandArgSpecs {
+		if spec.passthrough {
+			continue
+		}
+		t.Run(command, func(t *testing.T) {
+			err := Run(nil, []string{"cxt", command, "--definitely-unknown"})
+			if err == nil || !strings.Contains(err.Error(), "unknown flag") {
+				t.Fatalf("unknown flag error = %v", err)
+			}
+		})
+	}
+}
+
+func TestValueFlagsRejectMissingValues(t *testing.T) {
+	tests := [][]string{
+		{"cxt", "init", "--remote"},
+		{"cxt", "commit", "-m"},
+		{"cxt", "save", "--provider"},
+		{"cxt", "load", "--mode"},
+		{"cxt", "hook", "--event"},
+	}
+	for _, args := range tests {
+		t.Run(strings.Join(args[1:], "/"), func(t *testing.T) {
+			err := Run(nil, args)
+			if err == nil || !strings.Contains(err.Error(), "requires a value") {
+				t.Fatalf("missing-value error = %v", err)
+			}
+		})
+	}
+}
+
+func TestValueFlagsSupportInlineValues(t *testing.T) {
+	tests := []struct {
+		args []string
+		name string
+		want string
+	}{
+		{args: []string{"-m=-starts-with-hyphen"}, name: "-m", want: "-starts-with-hyphen"},
+		{args: []string{"--provider=codex"}, name: "--provider", want: "codex"},
+		{args: []string{"-p=-secret"}, name: "-p", want: "-secret"},
+	}
+	for _, tt := range tests {
+		if got := flagVal(tt.args, tt.name); got != tt.want {
+			t.Errorf("flagVal(%v, %q) = %q, want %q", tt.args, tt.name, got, tt.want)
+		}
+		if got := positionals(tt.args); len(got) != 0 {
+			t.Errorf("positionals(%v) = %v", tt.args, got)
+		}
+	}
+
+	if handled, err := PreflightArgs([]string{"cxt", "commit", "-m=-starts-with-hyphen"}); handled || err != nil {
+		t.Fatalf("inline value preflight = handled %v, err %v", handled, err)
+	}
+	if handled, err := PreflightArgs([]string{"cxt", "push", "--force=true"}); handled || err == nil || !strings.Contains(err.Error(), "does not take a value") {
+		t.Fatalf("boolean inline value = handled %v, err %v", handled, err)
+	}
+	if handled, err := PreflightArgs([]string{"cxt", "commit", "-m="}); handled || err == nil || !strings.Contains(err.Error(), "requires a value") {
+		t.Fatalf("empty inline value = handled %v, err %v", handled, err)
+	}
+}
+
+func TestProviderWrapperPassThroughRequiresDoubleDashForProviderHelp(t *testing.T) {
+	for _, command := range []string{"claude", "codex"} {
+		handled, err := PreflightArgs([]string{"cxt", command, "--provider-owned-flag"})
+		if err != nil || handled {
+			t.Fatalf("%s pass-through = handled %v, err %v", command, handled, err)
+		}
+		handled, err = PreflightArgs([]string{"cxt", command, "--", "--help"})
+		if err != nil || handled {
+			t.Fatalf("%s -- --help pass-through = handled %v, err %v", command, handled, err)
+		}
+		if got := providerPassthroughArgs([]string{"--", "exec", "--help"}); len(got) != 2 || got[0] != "exec" || got[1] != "--help" {
+			t.Fatalf("%s delimiter stripping = %v", command, got)
+		}
+		handled, err = PreflightArgs([]string{"cxt", command, "--help"})
+		if err != nil || !handled {
+			t.Fatalf("%s cxt help = handled %v, err %v", command, handled, err)
+		}
+	}
+}
+
+func TestInternalGitHookKeepsEventSpecificArgumentOwnership(t *testing.T) {
+	handled, err := PreflightArgs([]string{"cxt", "git-hook", "post-commit", "--resolve", "session-id"})
+	if err != nil || handled {
+		t.Fatalf("internal git-hook preflight = handled %v, err %v", handled, err)
+	}
+}
+
+func TestBooleanFlagsDoNotConsumeFollowingPositionals(t *testing.T) {
+	if got := firstPositional([]string{"--no-login", "https://example.test/alice/work"}); got != "https://example.test/alice/work" {
+		t.Fatalf("first positional after boolean flag = %q", got)
+	}
+	if got := firstPositional([]string{"--remember", "push", "-p", "secret"}); got != "push" {
+		t.Fatalf("first positional around mixed flags = %q", got)
+	}
+}
+
+func TestSubcommandSpecificFlagRestrictions(t *testing.T) {
+	tests := [][]string{
+		{"cxt", "remote", "add", "origin", "https://example.test/a/b", "-v"},
+		{"cxt", "secrets", "pull", "--rotate"},
+		{"cxt", "stash", "pop", "-m", "message"},
+	}
+	for _, args := range tests {
+		t.Run(strings.Join(args[1:], "/"), func(t *testing.T) {
+			if handled, err := PreflightArgs(args); handled || err == nil {
+				t.Fatalf("restricted flag = handled %v, err %v", handled, err)
+			}
+		})
+	}
+}
+
+func TestHelpCommandTargetsSubcommands(t *testing.T) {
+	if handled, err := PreflightArgs([]string{"cxt", "help", "load"}); err != nil || !handled {
+		t.Fatalf("cxt help load = handled %v, err %v", handled, err)
+	}
+}
+
 func TestUnknownCommandUsesPublicCommandCatalog(t *testing.T) {
 	err := Run(nil, []string{"cxt", "definitely-unknown"})
 	if err == nil {

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -30,6 +30,15 @@ For installation and first-run setup, see
   - `memory`: inject the distilled memory representation.
 - Git and provider hooks are fail-open: a capture or sync failure is reported
   but does not block the Git or agent operation.
+- Every public command supports `-h` and `--help`. Help and usage errors are
+  resolved before cxt creates adapters, contacts a remote, or changes local
+  context state. Unknown flags and missing flag values are rejected. Value
+  flags also accept `--flag=value` (or `-m=value`) when the value itself starts
+  with a hyphen.
+- `cxt claude` and `cxt codex` pass provider-owned arguments through. Use a
+  `--` separator when the provider itself should receive a help flag, for
+  example `cxt codex -- --help`; without the separator, `--help` describes the
+  cxt wrapper command.
 
 ## Recommended onboarding
 


### PR DESCRIPTION
## What changed

- validate public-command flags before the composition root creates adapters
- make every `cxt <command> -h|--help` side-effect free
- reject unknown flags and missing values instead of silently dispatching
- preserve provider-owned arguments with an explicit `--` help delimiter
- keep internal `git-hook` arguments under the hook dispatcher
- fix boolean flags swallowing following positionals
- support `--flag=value` / `-m=value` for values beginning with a hyphen

## Root cause

The hand-written argument helpers only recognized top-level help and silently ignored unused flags. Some commands (`mcp`, `hook`, and `version`) were also intercepted by the composition root, so fixing only the delivery switch would still construct adapters or dispatch side effects.

## Verification

- `go test ./...`
- `go vet ./...`
- `go test -race ./...`
- `make e2e`
- `make e2e-sync`
- `make public-check`
- real built binary in an empty cwd and isolated HOME: `load --help` exits 0, unknown flag exits 1, zero files created

Closes #74