### PR TITLE
Fix O(history) snapshot metadata pulls

### DIFF
--- a/backend/internal/adapters/store/fs_store.go
+++ b/backend/internal/adapters/store/fs_store.go
@@ -1927,6 +1927,7 @@ func (s *FSStore) GetManifest(ctx context.Context, repoID domain.ContentHash) (d
 	}
 	var index []domain.ContentHash
 	memoryAttachments := map[domain.ContentHash]domain.ContentHash{}
+	snapshotStates := map[domain.ContentHash]domain.ContentHash{}
 	dir := filepath.Join(s.repoDir(repoID), "snapshots")
 	if entries, err := os.ReadDir(dir); err == nil {
 		for _, e := range entries {
@@ -1945,6 +1946,11 @@ func (s *FSStore) GetManifest(ctx context.Context, repoID domain.ContentHash) (d
 			if snap.MemoryHash != "" {
 				memoryAttachments[id] = snap.MemoryHash
 			}
+			state, err := domain.SnapshotStateHash(snap)
+			if err != nil {
+				return domain.Manifest{}, err
+			}
+			snapshotStates[id] = state
 		}
 	} else if !os.IsNotExist(err) {
 		return domain.Manifest{}, err
@@ -1954,6 +1960,7 @@ func (s *FSStore) GetManifest(ctx context.Context, repoID domain.ContentHash) (d
 		Refs:              refs,
 		SnapshotIndex:     index,
 		MemoryAttachments: memoryAttachments,
+		SnapshotStates:    snapshotStates,
 		Version:           len(index),
 		UpdatedAt:         time.Now().UTC(),
 	}, nil

--- a/backend/internal/adapters/store/fs_store_promote_test.go
+++ b/backend/internal/adapters/store/fs_store_promote_test.go
@@ -51,3 +51,24 @@ func TestFSPutSnapshotPromotesStashLabel(t *testing.T) {
 		t.Fatalf("Commit label promoted by stash re-save: branch=%q message=%q", got2.Branch, got2.Message)
 	}
 }
+
+func TestFSManifestAdvertisesSnapshotState(t *testing.T) {
+	ctx := context.Background()
+	st := NewFSStore(t.TempDir())
+	repo, id := ph("manifest-repo"), ph("manifest-snapshot")
+	snap := domain.Snapshot{ID: id, RepoID: repo, Branch: "main", DocHash: id, Message: "commit", GraftSeq: 2}
+	if err := st.PutSnapshot(ctx, snap); err != nil {
+		t.Fatal(err)
+	}
+	manifest, err := st.GetManifest(ctx, repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, err := domain.SnapshotStateHash(snap)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(manifest.SnapshotStates) != 1 || manifest.SnapshotStates[id] != want {
+		t.Fatalf("snapshot states = %+v, want %s=%s", manifest.SnapshotStates, id, want)
+	}
+}

--- a/backend/internal/adapters/store/postgres_smoke_test.go
+++ b/backend/internal/adapters/store/postgres_smoke_test.go
@@ -119,6 +119,21 @@ func TestPGSmoke(t *testing.T) {
 	if err := st.CompareAndSwapSnapshotMemory(ctx, repoID, snapID, "", memoryHash); err != nil {
 		t.Fatalf("attach memory: %v", err)
 	}
+	attached, err := st.GetSnapshot(ctx, repoID, snapID)
+	if err != nil {
+		t.Fatalf("get attached snapshot: %v", err)
+	}
+	repoManifest, err := st.GetManifest(ctx, repoID)
+	if err != nil {
+		t.Fatalf("manifest snapshot state: %v", err)
+	}
+	wantState, err := domain.SnapshotStateHash(attached)
+	if err != nil {
+		t.Fatalf("snapshot state hash: %v", err)
+	}
+	if len(repoManifest.SnapshotStates) != 1 || repoManifest.SnapshotStates[snapID] != wantState {
+		t.Fatalf("manifest snapshot states = %+v, want %s=%s", repoManifest.SnapshotStates, snapID, wantState)
+	}
 	// Two database clients racing from the same causal parent must serialize on
 	// SELECT ... FOR UPDATE: exactly one advances and the stale writer conflicts.
 	contenderHashes := make([]domain.ContentHash, 0, 2)
@@ -156,7 +171,7 @@ func TestPGSmoke(t *testing.T) {
 	if memoryCASSuccesses != 1 || memoryCASConflicts != 1 {
 		t.Fatalf("concurrent memory CAS: successes=%d conflicts=%d", memoryCASSuccesses, memoryCASConflicts)
 	}
-	attached, err := st.GetSnapshot(ctx, repoID, snapID)
+	attached, err = st.GetSnapshot(ctx, repoID, snapID)
 	if err != nil {
 		t.Fatalf("snapshot after concurrent memory CAS: %v", err)
 	}
@@ -374,9 +389,9 @@ func TestPGSmoke(t *testing.T) {
 			t.Fatalf("legacy owner fixture: %v", err)
 		}
 	}
-	manifest, err := st.GetDocManifest(ctx, repoID, legacyHash)
-	if err != nil || manifest.Format != domain.ChunkFormatV2 || len(manifest.Chunks) < 2 {
-		t.Fatalf("legacy manifest=%+v err=%v", manifest, err)
+	docManifest, err := st.GetDocManifest(ctx, repoID, legacyHash)
+	if err != nil || docManifest.Format != domain.ChunkFormatV2 || len(docManifest.Chunks) < 2 {
+		t.Fatalf("legacy manifest=%+v err=%v", docManifest, err)
 	}
 	for _, owner := range []domain.ContentHash{repoID, repo2} {
 		got, err := st.GetDoc(ctx, owner, legacyHash)

--- a/backend/internal/adapters/store/postgres_store.go
+++ b/backend/internal/adapters/store/postgres_store.go
@@ -739,32 +739,52 @@ func (s *PostgresStore) GetManifest(ctx context.Context, repoID domain.ContentHa
 	if err != nil {
 		return domain.Manifest{}, err
 	}
-	rows, err := s.pool.Query(ctx, `SELECT id, COALESCE(memory_hash,'') FROM snapshots WHERE repo_id=$1`, string(repoID))
+	rows, err := s.pool.Query(ctx, `
+		SELECT id, branch, COALESCE(memory_hash,''), message, grafted,
+		       COALESCE(graft_parents,'{}'), COALESCE(graft_seq,0)
+		  FROM snapshots WHERE repo_id=$1`, string(repoID))
 	if err != nil {
 		return domain.Manifest{}, err
 	}
 	defer rows.Close()
 	var index []domain.ContentHash
 	memoryAttachments := map[domain.ContentHash]domain.ContentHash{}
+	snapshotStates := map[domain.ContentHash]domain.ContentHash{}
 	for rows.Next() {
-		var id, memoryHash string
-		if err := rows.Scan(&id, &memoryHash); err != nil {
+		var id, branch, memoryHash, message string
+		var grafted bool
+		var graftParents []string
+		var graftSeq uint64
+		if err := rows.Scan(&id, &branch, &memoryHash, &message, &grafted, &graftParents, &graftSeq); err != nil {
 			return domain.Manifest{}, err
 		}
-		hash := domain.ContentHash(id)
-		if err := domain.ValidateContentHash(hash); err != nil {
+		snap := domain.Snapshot{
+			ID: domain.ContentHash(id), Branch: branch, MemoryHash: domain.ContentHash(memoryHash), Message: message,
+			Grafted: grafted, GraftParents: hashes(graftParents), GraftSeq: graftSeq,
+		}
+		if err := domain.ValidateContentHash(snap.ID); err != nil {
 			return domain.Manifest{}, err
 		}
-		index = append(index, hash)
-		if memoryHash != "" {
-			memory := domain.ContentHash(memoryHash)
-			if err := domain.ValidateContentHash(memory); err != nil {
-				return domain.Manifest{}, err
-			}
-			memoryAttachments[hash] = memory
+		if err := domain.ValidateOptionalContentHash(snap.MemoryHash); err != nil {
+			return domain.Manifest{}, err
 		}
+		if err := validateHashes(snap.GraftParents...); err != nil {
+			return domain.Manifest{}, err
+		}
+		if snap.GraftSeq > domain.MaxGraftSeq {
+			return domain.Manifest{}, domain.ErrIntegrity
+		}
+		index = append(index, snap.ID)
+		if snap.MemoryHash != "" {
+			memoryAttachments[snap.ID] = snap.MemoryHash
+		}
+		state, err := domain.SnapshotStateHash(snap)
+		if err != nil {
+			return domain.Manifest{}, err
+		}
+		snapshotStates[snap.ID] = state
 	}
-	return domain.Manifest{RepoID: repoID, Refs: refs, SnapshotIndex: index, MemoryAttachments: memoryAttachments, Version: len(index)}, rows.Err()
+	return domain.Manifest{RepoID: repoID, Refs: refs, SnapshotIndex: index, MemoryAttachments: memoryAttachments, SnapshotStates: snapshotStates, Version: len(index)}, rows.Err()
 }
 
 // --- Memory Meta ---

--- a/backend/internal/domain/entities.go
+++ b/backend/internal/domain/entities.go
@@ -230,6 +230,7 @@ type Manifest struct {
 	Refs              []Ref                       `json:"refs"`
 	SnapshotIndex     []ContentHash               `json:"snapshot_index"`
 	MemoryAttachments map[ContentHash]ContentHash `json:"memory_attachments"`
+	SnapshotStates    map[ContentHash]ContentHash `json:"snapshot_states,omitempty"`
 	Version           int                         `json:"version"`
 	UpdatedAt         time.Time                   `json:"updated_at"`
 }

--- a/backend/internal/domain/snapshot_state.go
+++ b/backend/internal/domain/snapshot_state.go
@@ -1,0 +1,46 @@
+package domain
+
+import "encoding/json"
+
+// SnapshotStateHash fingerprints the mutable snapshot projection replicated
+// after object creation. Snapshot.ID detects new immutable objects; this token
+// detects metadata-only changes to branch/message promotion, memory attachment,
+// and the versioned graft register.
+//
+// Immutable fields are deliberately excluded. In particular, PostgreSQL may
+// assign CreatedAt at insert time, so hashing the whole wire object would make
+// equivalent replicas appear changed forever.
+func SnapshotStateHash(s Snapshot) (ContentHash, error) {
+	state := snapshotStateWire{
+		ID:           string(s.ID),
+		Branch:       s.Branch,
+		MemoryHash:   string(s.MemoryHash),
+		Message:      s.Message,
+		Grafted:      s.Grafted,
+		GraftParents: snapshotStateHashes(s.GraftParents),
+		GraftSeq:     s.GraftSeq,
+	}
+	raw, err := json.Marshal(state)
+	if err != nil {
+		return "", err
+	}
+	return HashContent(raw), nil
+}
+
+type snapshotStateWire struct {
+	ID           string   `json:"id"`
+	Branch       string   `json:"branch"`
+	MemoryHash   string   `json:"memory_hash"`
+	Message      string   `json:"message"`
+	Grafted      bool     `json:"grafted"`
+	GraftParents []string `json:"graft_parents"`
+	GraftSeq     uint64   `json:"graft_seq"`
+}
+
+func snapshotStateHashes(in []ContentHash) []string {
+	out := make([]string, len(in))
+	for i, hash := range in {
+		out[i] = string(hash)
+	}
+	return out
+}

--- a/backend/internal/domain/snapshot_state_test.go
+++ b/backend/internal/domain/snapshot_state_test.go
@@ -1,0 +1,97 @@
+package domain
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSnapshotStateHashParityAndMutableMetadata(t *testing.T) {
+	base := Snapshot{
+		ID: HashContent([]byte("snapshot")), RepoID: HashContent([]byte("repo")), Branch: "main",
+		Parents: []ContentHash{HashContent([]byte("parent"))}, DocHash: HashContent([]byte("snapshot")),
+		MemoryHash: HashContent([]byte("memory")), ClaudeSettings: HashContent([]byte("claude")),
+		AgentsSettings: HashContent([]byte("agents")), CodexSettings: HashContent([]byte("codex")),
+		Provider: ProviderCodex, Fidelity: FidelityFull, Message: "[git abc123] commit",
+		Author:    TeamIdentity{Name: "J", Email: "j@example.test", Team: "core"},
+		CreatedAt: time.Date(2026, 8, 27, 1, 2, 3, 4, time.FixedZone("KST", 9*60*60)),
+		Grafted:   true, GraftParents: []ContentHash{HashContent([]byte("graft"))}, GraftSeq: 7,
+		SessionID: "session-1", Models: []string{"gpt-5", "gpt-5.3-codex"}, CompactionCount: 2,
+	}
+	got, err := SnapshotStateHash(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const want ContentHash = "sha256:e67fd0f252c9bf3ba8170a3d62a285976b44b6c719ecd9858598487debbc4736"
+	if got != want {
+		t.Fatalf("snapshot state hash = %s, want %s", got, want)
+	}
+
+	mutations := map[string]func(*Snapshot){
+		"branch":       func(s *Snapshot) { s.Branch = "feature" },
+		"message":      func(s *Snapshot) { s.Message = "promoted" },
+		"memory":       func(s *Snapshot) { s.MemoryHash = HashContent([]byte("memory-2")) },
+		"graft parent": func(s *Snapshot) { s.GraftParents = append(s.GraftParents, HashContent([]byte("graft-2"))) },
+		"graft seq":    func(s *Snapshot) { s.GraftSeq++ },
+	}
+	for name, mutate := range mutations {
+		t.Run(name, func(t *testing.T) {
+			changed := base
+			changed.Parents = append([]ContentHash{}, base.Parents...)
+			changed.GraftParents = append([]ContentHash{}, base.GraftParents...)
+			changed.Models = append([]string{}, base.Models...)
+			mutate(&changed)
+			hash, err := SnapshotStateHash(changed)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if hash == got {
+				t.Fatalf("%s mutation did not change state hash", name)
+			}
+		})
+	}
+}
+
+func TestSnapshotStateHashIgnoresImmutableReplicaDifferences(t *testing.T) {
+	base := Snapshot{ID: HashContent([]byte("snapshot")), DocHash: HashContent([]byte("snapshot")), Branch: "main", Message: "commit"}
+	changed := base
+	changed.RepoID = HashContent([]byte("repo"))
+	changed.Parents = []ContentHash{HashContent([]byte("parent"))}
+	changed.CodexSettings = HashContent([]byte("settings"))
+	changed.Provider = ProviderCodex
+	changed.Fidelity = FidelityFull
+	changed.Author = TeamIdentity{Name: "author"}
+	changed.CreatedAt = time.Now()
+	changed.SessionID = "session"
+	changed.Models = []string{"model"}
+	changed.CompactionCount = 3
+	left, err := SnapshotStateHash(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	right, err := SnapshotStateHash(changed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if left != right {
+		t.Fatalf("immutable replica fields changed state hash: %s != %s", left, right)
+	}
+}
+
+func TestSnapshotStateHashNormalizesNilSlices(t *testing.T) {
+	left := Snapshot{ID: HashContent([]byte("snapshot")), DocHash: HashContent([]byte("snapshot"))}
+	right := left
+	right.Parents = []ContentHash{}
+	right.GraftParents = []ContentHash{}
+	right.Models = []string{}
+	a, err := SnapshotStateHash(left)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := SnapshotStateHash(right)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a != b {
+		t.Fatalf("nil/empty state hashes differ: %s != %s", a, b)
+	}
+}

--- a/cli/internal/adapters/backendclient/backend_client.go
+++ b/cli/internal/adapters/backendclient/backend_client.go
@@ -620,6 +620,22 @@ func (c *BackendClient) RemoteManifest(ctx context.Context, repoID string) (doma
 			return domain.Manifest{}, domain.ErrHashMismatch
 		}
 	}
+	if m.SnapshotStates != nil {
+		if len(m.SnapshotStates) != len(index) {
+			return domain.Manifest{}, domain.ErrHashMismatch
+		}
+		for snapshotID, stateHash := range m.SnapshotStates {
+			if err := domain.ValidateContentHash(snapshotID); err != nil {
+				return domain.Manifest{}, err
+			}
+			if err := domain.ValidateContentHash(stateHash); err != nil {
+				return domain.Manifest{}, err
+			}
+			if !index[snapshotID] {
+				return domain.Manifest{}, domain.ErrHashMismatch
+			}
+		}
+	}
 	return m, nil
 }
 
@@ -867,11 +883,33 @@ func (c *BackendClient) UpdateRefRemote(ctx context.Context, repoID string, ref 
 	return c.do(ctx, http.MethodPut, path, putRefReq{Target: ref.Target, Symbolic: ref.Symbolic, Append: appendDiverged}, nil)
 }
 
-// Pulls manifest → pull/objects(snapshots) → pull/objects(docs) to fetch server objects.
+// Pulls manifest → changed pull/objects(snapshots) → missing pull/objects(docs)
+// to fetch server objects. Snapshot IDs hash only CIR, so the manifest's
+// snapshot state hash is the safe metadata delta token.
 // Local storage/ref merge is performed by the caller (SyncRepo).
-func (c *BackendClient) Pull(ctx context.Context, repoID string, docHaves []domain.ContentHash) ([]domain.Snapshot, []domain.SessionDoc, []domain.Ref, error) {
+func (c *BackendClient) Pull(
+	ctx context.Context,
+	repoID string,
+	snapshotStates map[domain.ContentHash]domain.ContentHash,
+	docHaves []domain.ContentHash,
+) ([]domain.Snapshot, []domain.SessionDoc, []domain.Ref, error) {
 	if err := domain.ValidateContentHash(domain.ContentHash(repoID)); err != nil {
 		return nil, nil, nil, err
+	}
+	for id, state := range snapshotStates {
+		if err := domain.ValidateContentHash(id); err != nil {
+			return nil, nil, nil, err
+		}
+		if err := domain.ValidateContentHash(state); err != nil {
+			return nil, nil, nil, err
+		}
+	}
+	haveDoc := make(map[domain.ContentHash]bool, len(docHaves))
+	for _, hash := range docHaves {
+		if err := domain.ValidateContentHash(hash); err != nil {
+			return nil, nil, nil, err
+		}
+		haveDoc[hash] = true
 	}
 	man, err := c.RemoteManifest(ctx, repoID)
 	if err != nil {
@@ -880,15 +918,23 @@ func (c *BackendClient) Pull(ctx context.Context, repoID string, docHaves []doma
 	if man.RepoID != repoID {
 		return nil, nil, nil, domain.ErrHashMismatch
 	}
+	legacyStates := man.SnapshotStates == nil
 	wantedSnapshots := make(map[domain.ContentHash]bool, len(man.SnapshotIndex))
+	var snapshotWants []domain.ContentHash
+	docWantSet := make(map[domain.ContentHash]bool, len(man.SnapshotIndex))
+	var docWants []domain.ContentHash
 	for _, id := range man.SnapshotIndex {
 		if err := domain.ValidateContentHash(id); err != nil {
 			return nil, nil, nil, err
 		}
-		if wantedSnapshots[id] {
-			return nil, nil, nil, domain.ErrHashMismatch
+		if !haveDoc[id] {
+			docWantSet[id] = true
+			docWants = append(docWants, id)
 		}
-		wantedSnapshots[id] = true
+		if legacyStates || snapshotStates[id] != man.SnapshotStates[id] || !haveDoc[id] {
+			wantedSnapshots[id] = true
+			snapshotWants = append(snapshotWants, id)
+		}
 	}
 	for _, ref := range man.Refs {
 		if err := domain.ValidateRef(ref); err != nil {
@@ -902,17 +948,12 @@ func (c *BackendClient) Pull(ctx context.Context, repoID string, docHaves []doma
 		return nil, nil, man.Refs, nil
 	}
 	var snapResp pullResp
-	if err := c.do(ctx, http.MethodPost, c.reposPath(repoID)+"/pull/objects", pullReq{SnapshotWants: man.SnapshotIndex, CIRVersionsSupported: domain.SupportedCIRVersions()}, &snapResp); err != nil {
-		return nil, nil, nil, err
-	}
-	// Delta reception: Does not request doc(docHaves) already in local storage — eliminates waste by re-receiving entire body (snapshot meta is received fully — graft/memory sync).
-	haveDoc := make(map[domain.ContentHash]bool, len(docHaves))
-	for _, h := range docHaves {
-		haveDoc[h] = true
+	if len(snapshotWants) > 0 {
+		if err := c.do(ctx, http.MethodPost, c.reposPath(repoID)+"/pull/objects", pullReq{SnapshotWants: snapshotWants, CIRVersionsSupported: domain.SupportedCIRVersions()}, &snapResp); err != nil {
+			return nil, nil, nil, err
+		}
 	}
 	seenSnapshots := make(map[domain.ContentHash]bool, len(snapResp.Snapshots))
-	docWantSet := make(map[domain.ContentHash]bool, len(snapResp.Snapshots))
-	var docWants []domain.ContentHash
 	for _, s := range snapResp.Snapshots {
 		if err := validateSnapshotObject(s); err != nil {
 			return nil, nil, nil, err
@@ -921,9 +962,11 @@ func (c *BackendClient) Pull(ctx context.Context, repoID string, docHaves []doma
 			return nil, nil, nil, domain.ErrHashMismatch
 		}
 		seenSnapshots[s.ID] = true
-		if !haveDoc[s.DocHash] && !docWantSet[s.DocHash] {
-			docWantSet[s.DocHash] = true
-			docWants = append(docWants, s.DocHash)
+		if man.SnapshotStates != nil {
+			state, serr := domain.SnapshotStateHash(s)
+			if serr != nil || state != man.SnapshotStates[s.ID] {
+				return nil, nil, nil, domain.ErrHashMismatch
+			}
 		}
 	}
 	if len(seenSnapshots) != len(wantedSnapshots) {

--- a/cli/internal/adapters/backendclient/backend_client_test.go
+++ b/cli/internal/adapters/backendclient/backend_client_test.go
@@ -109,6 +109,183 @@ func makeChunkedClientDoc(t *testing.T, events int) (domain.SessionDoc, chunkcas
 	return doc, plan
 }
 
+func makePullClientDoc(t *testing.T, repoID string) (domain.Snapshot, domain.SessionDoc) {
+	t.Helper()
+	cir := domain.CIRDocument{
+		Envelope: domain.Envelope{CIRVersion: "1", SourceProvider: domain.ProviderCodex, Fidelity: domain.FidelityFull, GitBranch: "main"},
+		Events:   []domain.Event{{Kind: domain.EventMessage, Seq: 0, Role: "user", Blocks: []domain.ContentBlock{{Type: "text", Text: "pull delta"}}}},
+	}
+	canonical, err := domain.CanonicalBytes(cir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	doc := domain.SessionDoc{Hash: domain.HashContent(canonical), CIR: cir}
+	snap := domain.Snapshot{ID: doc.Hash, RepoID: repoID, Branch: "main", DocHash: doc.Hash, Provider: domain.ProviderCodex, Fidelity: domain.FidelityFull, Message: "commit"}
+	return snap, doc
+}
+
+func TestPullSkipsUnchangedSnapshotMetadata(t *testing.T) {
+	repoID := string(domain.HashContent([]byte("delta-pull-repo")))
+	const snapshotCount = 301
+	index := make([]domain.ContentHash, 0, snapshotCount)
+	states := make(map[domain.ContentHash]domain.ContentHash, snapshotCount)
+	for i := 0; i < snapshotCount; i++ {
+		id := domain.HashContent([]byte{byte(i >> 8), byte(i)})
+		snap := domain.Snapshot{ID: id, RepoID: repoID, Branch: "main", DocHash: id, Provider: domain.ProviderCodex, Fidelity: domain.FidelityFull, Message: "commit"}
+		state, err := domain.SnapshotStateHash(snap)
+		if err != nil {
+			t.Fatal(err)
+		}
+		index = append(index, id)
+		states[id] = state
+	}
+	ref := domain.Ref{Kind: domain.RefBranch, Name: "main", RepoID: repoID, Target: index[len(index)-1]}
+	objectCalls := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/manifest"):
+			_ = json.NewEncoder(w).Encode(domain.Manifest{
+				RepoID: repoID, SnapshotIndex: index, SnapshotStates: states, Refs: []domain.Ref{ref},
+			})
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/pull/objects"):
+			objectCalls++
+			http.Error(w, "unchanged pull requested objects", http.StatusInternalServerError)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	c := NewBackendClient(func() string { return ts.URL }, func() string { return "" }, domain.TeamIdentity{})
+	snaps, docs, refs, err := c.Pull(context.Background(), repoID, states, index)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if objectCalls != 0 || len(snaps) != 0 || len(docs) != 0 || len(refs) != 1 || refs[0].Target != ref.Target {
+		t.Fatalf("calls=%d snapshots=%d docs=%d refs=%+v", objectCalls, len(snaps), len(docs), refs)
+	}
+}
+
+func TestPullFetchesChangedStateAndVerifiesManifestToken(t *testing.T) {
+	repoID := string(domain.HashContent([]byte("changed-pull-repo")))
+	snap, _ := makePullClientDoc(t, repoID)
+	snap.Grafted = true
+	snap.GraftParents = []domain.ContentHash{domain.HashContent([]byte("graft-parent"))}
+	snap.GraftSeq = 3
+	state, err := domain.SnapshotStateHash(snap)
+	if err != nil {
+		t.Fatal(err)
+	}
+	localState := domain.HashContent([]byte("old-state"))
+	var wants []domain.ContentHash
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/manifest"):
+			_ = json.NewEncoder(w).Encode(domain.Manifest{RepoID: repoID, SnapshotIndex: []domain.ContentHash{snap.ID}, SnapshotStates: map[domain.ContentHash]domain.ContentHash{snap.ID: state}})
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/pull/objects"):
+			var req pullReq
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			wants = append(wants, req.SnapshotWants...)
+			_ = json.NewEncoder(w).Encode(pullResp{Snapshots: []domain.Snapshot{snap}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	c := NewBackendClient(func() string { return ts.URL }, func() string { return "" }, domain.TeamIdentity{})
+	snaps, docs, _, err := c.Pull(context.Background(), repoID, map[domain.ContentHash]domain.ContentHash{snap.ID: localState}, []domain.ContentHash{snap.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(wants) != 1 || wants[0] != snap.ID || len(snaps) != 1 || len(docs) != 0 {
+		t.Fatalf("wants=%v snapshots=%d docs=%d", wants, len(snaps), len(docs))
+	}
+
+	// A state catalog is an integrity commitment, not merely a cache hint.
+	snap.Message = "tampered after manifest"
+	if _, _, _, err := c.Pull(context.Background(), repoID, map[domain.ContentHash]domain.ContentHash{snap.ID: localState}, []domain.ContentHash{snap.ID}); !errors.Is(err, domain.ErrHashMismatch) {
+		t.Fatalf("mismatched state response error = %v", err)
+	}
+}
+
+func TestPullLegacyManifestFallsBackAndMissingDocForcesSnapshot(t *testing.T) {
+	repoID := string(domain.HashContent([]byte("legacy-pull-repo")))
+	snap, doc := makePullClientDoc(t, repoID)
+	state, err := domain.SnapshotStateHash(snap)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, modern := range []bool{false, true} {
+		t.Run(map[bool]string{false: "legacy", true: "missing-doc"}[modern], func(t *testing.T) {
+			snapshotCalls, docCalls := 0, 0
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/manifest"):
+					manifest := domain.Manifest{RepoID: repoID, SnapshotIndex: []domain.ContentHash{snap.ID}}
+					if modern {
+						manifest.SnapshotStates = map[domain.ContentHash]domain.ContentHash{snap.ID: state}
+					}
+					_ = json.NewEncoder(w).Encode(manifest)
+				case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/pull/objects"):
+					var req pullReq
+					_ = json.NewDecoder(r.Body).Decode(&req)
+					switch {
+					case len(req.SnapshotWants) > 0:
+						snapshotCalls++
+						_ = json.NewEncoder(w).Encode(pullResp{Snapshots: []domain.Snapshot{snap}})
+					case len(req.DocManifestWants) > 0:
+						docCalls++
+						_ = json.NewEncoder(w).Encode(pullResp{Docs: []domain.SessionDoc{doc}})
+					default:
+						http.Error(w, "unexpected pull request", http.StatusBadRequest)
+					}
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			defer ts.Close()
+
+			c := NewBackendClient(func() string { return ts.URL }, func() string { return "" }, domain.TeamIdentity{})
+			localStates := map[domain.ContentHash]domain.ContentHash{snap.ID: state}
+			docHaves := []domain.ContentHash{snap.ID}
+			if modern {
+				docHaves = nil
+			}
+			snaps, docs, _, err := c.Pull(context.Background(), repoID, localStates, docHaves)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if snapshotCalls != 1 || len(snaps) != 1 {
+				t.Fatalf("snapshot calls=%d snapshots=%d", snapshotCalls, len(snaps))
+			}
+			if modern && (docCalls != 1 || len(docs) != 1) {
+				t.Fatalf("missing-doc repair calls=%d docs=%d", docCalls, len(docs))
+			}
+			if !modern && (docCalls != 0 || len(docs) != 0) {
+				t.Fatalf("legacy existing-doc calls=%d docs=%d", docCalls, len(docs))
+			}
+		})
+	}
+}
+
+func TestRemoteManifestRejectsPartialSnapshotStates(t *testing.T) {
+	repoID := string(domain.HashContent([]byte("partial-state-repo")))
+	a := domain.HashContent([]byte("a"))
+	b := domain.HashContent([]byte("b"))
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(domain.Manifest{
+			RepoID: repoID, SnapshotIndex: []domain.ContentHash{a, b},
+			SnapshotStates: map[domain.ContentHash]domain.ContentHash{a: domain.HashContent([]byte("state-a"))},
+		})
+	}))
+	defer ts.Close()
+	c := NewBackendClient(func() string { return ts.URL }, func() string { return "" }, domain.TeamIdentity{})
+	if _, err := c.RemoteManifest(context.Background(), repoID); !errors.Is(err, domain.ErrHashMismatch) {
+		t.Fatalf("partial state catalog error = %v", err)
+	}
+}
+
 func TestChunkUploadBatchesEnforceRawAndCountBounds(t *testing.T) {
 	countChunks := make([]chunkObjWire, maxChunkWireObjects+1)
 	for i := range countChunks {

--- a/cli/internal/adapters/storage/file_store.go
+++ b/cli/internal/adapters/storage/file_store.go
@@ -760,6 +760,7 @@ func (s *FileStore) Manifest(ctx context.Context, repoID string) (domain.Manifes
 	}
 	var index []domain.ContentHash
 	memoryAttachments := map[domain.ContentHash]domain.ContentHash{}
+	snapshotStates := map[domain.ContentHash]domain.ContentHash{}
 	dir := filepath.Join(s.storeDir(), "objects", "snapshots")
 	if entries, err := readCxtDir(dir); err == nil {
 		for _, e := range entries {
@@ -778,6 +779,11 @@ func (s *FileStore) Manifest(ctx context.Context, repoID string) (domain.Manifes
 			if snap.MemoryHash != "" {
 				memoryAttachments[id] = snap.MemoryHash
 			}
+			state, err := domain.SnapshotStateHash(snap)
+			if err != nil {
+				return domain.Manifest{}, err
+			}
+			snapshotStates[id] = state
 		}
 	} else if !os.IsNotExist(err) {
 		return domain.Manifest{}, err
@@ -787,6 +793,7 @@ func (s *FileStore) Manifest(ctx context.Context, repoID string) (domain.Manifes
 		Refs:              refs,
 		SnapshotIndex:     index,
 		MemoryAttachments: memoryAttachments,
+		SnapshotStates:    snapshotStates,
 		Version:           0,
 		UpdatedAt:         time.Now().UTC(),
 	}, nil

--- a/cli/internal/adapters/storage/file_store_test.go
+++ b/cli/internal/adapters/storage/file_store_test.go
@@ -136,6 +136,13 @@ func TestSnapshotAndRefs(t *testing.T) {
 	if len(man.SnapshotIndex) != 1 || len(man.Refs) < 2 {
 		t.Fatalf("Manifest contents: idx=%d refs=%d", len(man.SnapshotIndex), len(man.Refs))
 	}
+	wantState, err := domain.SnapshotStateHash(got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(man.SnapshotStates) != 1 || man.SnapshotStates[h] != wantState {
+		t.Fatalf("Manifest snapshot states: %+v, want %s=%s", man.SnapshotStates, h, wantState)
+	}
 }
 
 func TestPutSnapshotEqualVersionUsesServerProjection(t *testing.T) {

--- a/cli/internal/app/sync_memory_test.go
+++ b/cli/internal/app/sync_memory_test.go
@@ -29,7 +29,7 @@ type causalPullRemote struct {
 	objectReads []domain.ContentHash
 }
 
-func (r *causalPullRemote) Pull(context.Context, string, []domain.ContentHash) ([]domain.Snapshot, []domain.SessionDoc, []domain.Ref, error) {
+func (r *causalPullRemote) Pull(context.Context, string, map[domain.ContentHash]domain.ContentHash, []domain.ContentHash) ([]domain.Snapshot, []domain.SessionDoc, []domain.Ref, error) {
 	return []domain.Snapshot{r.snapshot}, []domain.SessionDoc{r.doc}, []domain.Ref{{
 		Kind: domain.RefBranch, Name: "main", RepoID: r.snapshot.RepoID, Target: r.snapshot.ID,
 	}}, nil

--- a/cli/internal/app/sync_pull_integrity_test.go
+++ b/cli/internal/app/sync_pull_integrity_test.go
@@ -77,7 +77,56 @@ type corruptMemoryRemote struct {
 	memory domain.MemoryDigest
 }
 
-func (r *corruptMemoryRemote) Pull(context.Context, string, []domain.ContentHash) ([]domain.Snapshot, []domain.SessionDoc, []domain.Ref, error) {
+type inventoryPullRemote struct {
+	outbound.RemoteSync
+	states   map[domain.ContentHash]domain.ContentHash
+	docHaves []domain.ContentHash
+	refs     []domain.Ref
+}
+
+func (r *inventoryPullRemote) Pull(_ context.Context, _ string, states map[domain.ContentHash]domain.ContentHash, docHaves []domain.ContentHash) ([]domain.Snapshot, []domain.SessionDoc, []domain.Ref, error) {
+	r.states = states
+	r.docHaves = append([]domain.ContentHash{}, docHaves...)
+	return nil, nil, r.refs, nil
+}
+
+func TestSyncPullAdvertisesSnapshotStatesAndVerifiedDocs(t *testing.T) {
+	ctx := context.Background()
+	repo := string(domain.HashContent([]byte("pull-inventory-repo")))
+	doc := pullDoc(t, "already synchronized")
+	snap := domain.Snapshot{ID: doc.Hash, DocHash: doc.Hash, RepoID: repo, Branch: "main", Message: "commit", GraftSeq: 2}
+	st := storage.NewFileStore(t.TempDir())
+	if _, err := st.PutDoc(ctx, doc); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.PutSnapshot(ctx, snap); err != nil {
+		t.Fatal(err)
+	}
+	ref := domain.Ref{Kind: domain.RefBranch, Name: "main", RepoID: repo, Target: snap.ID}
+	if err := st.PutRef(ctx, ref); err != nil {
+		t.Fatal(err)
+	}
+	remote := &inventoryPullRemote{refs: []domain.Ref{ref}}
+	out, err := NewSyncRepoService(st, remote, nil).Pull(ctx, inbound.SyncInput{RepoID: repo, FetchOnly: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantState, err := domain.SnapshotStateHash(snap)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(remote.states) != 1 || remote.states[snap.ID] != wantState {
+		t.Fatalf("advertised states = %+v, want %s=%s", remote.states, snap.ID, wantState)
+	}
+	if len(remote.docHaves) != 1 || remote.docHaves[0] != doc.Hash {
+		t.Fatalf("advertised docs = %v", remote.docHaves)
+	}
+	if out.Pulled != 0 || len(out.RemoteAhead) != 0 {
+		t.Fatalf("unchanged pull output = %+v", out)
+	}
+}
+
+func (r *corruptMemoryRemote) Pull(context.Context, string, map[domain.ContentHash]domain.ContentHash, []domain.ContentHash) ([]domain.Snapshot, []domain.SessionDoc, []domain.Ref, error) {
 	return []domain.Snapshot{r.snap}, []domain.SessionDoc{r.doc}, []domain.Ref{r.ref}, nil
 }
 

--- a/cli/internal/app/sync_repo.go
+++ b/cli/internal/app/sync_repo.go
@@ -1079,22 +1079,21 @@ func (s *SyncRepoService) Pull(ctx context.Context, in inbound.SyncInput) (inbou
 	if err := domain.ValidateContentHash(domain.ContentHash(repoID)); err != nil {
 		return inbound.SyncOutput{}, err
 	}
-	// Delta pull: Does not re-receive documents that already exist locally. Existence is confirmed by checking DocHash in the local snapshot index (body not loaded — cheap negotiation).
+	// Delta pull advertises the verified local metadata and document inventory.
+	// Snapshot IDs equal DocHash, so document existence needs only a cheap stat;
+	// opening every cumulative session body or re-reading snapshots a second time
+	// would make the post-merge hook O(total history).
+	var snapshotStates map[domain.ContentHash]domain.ContentHash
 	var docHaves []domain.ContentHash
 	if man, merr := s.store.Manifest(ctx, repoID); merr == nil {
-		seen := map[domain.ContentHash]bool{}
+		snapshotStates = man.SnapshotStates
 		for _, id := range man.SnapshotIndex {
-			snap, gerr := s.store.GetSnapshot(ctx, id)
-			if gerr != nil || snap.DocHash == "" || seen[snap.DocHash] {
-				continue
-			}
-			seen[snap.DocHash] = true
-			if ok, herr := s.store.HasDoc(ctx, snap.DocHash); herr == nil && ok {
-				docHaves = append(docHaves, snap.DocHash)
+			if ok, herr := s.store.HasDoc(ctx, id); herr == nil && ok {
+				docHaves = append(docHaves, id)
 			}
 		}
 	}
-	snaps, docs, refs, err := s.remote.Pull(ctx, repoID, docHaves)
+	snaps, docs, refs, err := s.remote.Pull(ctx, repoID, snapshotStates, docHaves)
 	if err != nil {
 		return inbound.SyncOutput{}, err
 	}

--- a/cli/internal/domain/entities.go
+++ b/cli/internal/domain/entities.go
@@ -447,6 +447,9 @@ type Manifest struct {
 	// MemoryAttachments is the server/local current memory ref per snapshot.
 	// Nil means a legacy peer that does not advertise causal attachment state.
 	MemoryAttachments map[ContentHash]ContentHash `json:"memory_attachments,omitempty"`
+	// SnapshotStates fingerprints the mutable replicated projection keyed by
+	// snapshot ID. Nil means a legacy peer and requires a full metadata pull.
+	SnapshotStates map[ContentHash]ContentHash `json:"snapshot_states,omitempty"`
 	// Version is an optimistic lock monotonically increasing version.
 	Version int `json:"version"`
 	// UpdatedAt is the last time this manifest was updated.

--- a/cli/internal/domain/snapshot_state.go
+++ b/cli/internal/domain/snapshot_state.go
@@ -1,0 +1,46 @@
+package domain
+
+import "encoding/json"
+
+// SnapshotStateHash fingerprints the mutable snapshot projection replicated
+// after object creation. Snapshot.ID detects new immutable objects; this token
+// detects metadata-only changes to branch/message promotion, memory attachment,
+// and the versioned graft register.
+//
+// Immutable fields are deliberately excluded. In particular, PostgreSQL may
+// assign CreatedAt at insert time, so hashing the whole wire object would make
+// equivalent replicas appear changed forever.
+func SnapshotStateHash(s Snapshot) (ContentHash, error) {
+	state := snapshotStateWire{
+		ID:           string(s.ID),
+		Branch:       s.Branch,
+		MemoryHash:   string(s.MemoryHash),
+		Message:      s.Message,
+		Grafted:      s.Grafted,
+		GraftParents: snapshotStateHashes(s.GraftParents),
+		GraftSeq:     s.GraftSeq,
+	}
+	raw, err := json.Marshal(state)
+	if err != nil {
+		return "", err
+	}
+	return HashContent(raw), nil
+}
+
+type snapshotStateWire struct {
+	ID           string   `json:"id"`
+	Branch       string   `json:"branch"`
+	MemoryHash   string   `json:"memory_hash"`
+	Message      string   `json:"message"`
+	Grafted      bool     `json:"grafted"`
+	GraftParents []string `json:"graft_parents"`
+	GraftSeq     uint64   `json:"graft_seq"`
+}
+
+func snapshotStateHashes(in []ContentHash) []string {
+	out := make([]string, len(in))
+	for i, hash := range in {
+		out[i] = string(hash)
+	}
+	return out
+}

--- a/cli/internal/domain/snapshot_state_test.go
+++ b/cli/internal/domain/snapshot_state_test.go
@@ -1,0 +1,97 @@
+package domain
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSnapshotStateHashParityAndMutableMetadata(t *testing.T) {
+	base := Snapshot{
+		ID: HashContent([]byte("snapshot")), RepoID: string(HashContent([]byte("repo"))), Branch: "main",
+		Parents: []ContentHash{HashContent([]byte("parent"))}, DocHash: HashContent([]byte("snapshot")),
+		MemoryHash: HashContent([]byte("memory")), ClaudeSettings: HashContent([]byte("claude")),
+		AgentsSettings: HashContent([]byte("agents")), CodexSettings: HashContent([]byte("codex")),
+		Provider: ProviderCodex, Fidelity: FidelityFull, Message: "[git abc123] commit",
+		Author:    TeamIdentity{Name: "J", Email: "j@example.test", Team: "core"},
+		CreatedAt: time.Date(2026, 8, 27, 1, 2, 3, 4, time.FixedZone("KST", 9*60*60)),
+		Grafted:   true, GraftParents: []ContentHash{HashContent([]byte("graft"))}, GraftSeq: 7,
+		SessionID: "session-1", Models: []string{"gpt-5", "gpt-5.3-codex"}, CompactionCount: 2,
+	}
+	got, err := SnapshotStateHash(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const want ContentHash = "sha256:e67fd0f252c9bf3ba8170a3d62a285976b44b6c719ecd9858598487debbc4736"
+	if got != want {
+		t.Fatalf("snapshot state hash = %s, want %s", got, want)
+	}
+
+	mutations := map[string]func(*Snapshot){
+		"branch":       func(s *Snapshot) { s.Branch = "feature" },
+		"message":      func(s *Snapshot) { s.Message = "promoted" },
+		"memory":       func(s *Snapshot) { s.MemoryHash = HashContent([]byte("memory-2")) },
+		"graft parent": func(s *Snapshot) { s.GraftParents = append(s.GraftParents, HashContent([]byte("graft-2"))) },
+		"graft seq":    func(s *Snapshot) { s.GraftSeq++ },
+	}
+	for name, mutate := range mutations {
+		t.Run(name, func(t *testing.T) {
+			changed := base
+			changed.Parents = append([]ContentHash{}, base.Parents...)
+			changed.GraftParents = append([]ContentHash{}, base.GraftParents...)
+			changed.Models = append([]string{}, base.Models...)
+			mutate(&changed)
+			hash, err := SnapshotStateHash(changed)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if hash == got {
+				t.Fatalf("%s mutation did not change state hash", name)
+			}
+		})
+	}
+}
+
+func TestSnapshotStateHashIgnoresImmutableReplicaDifferences(t *testing.T) {
+	base := Snapshot{ID: HashContent([]byte("snapshot")), DocHash: HashContent([]byte("snapshot")), Branch: "main", Message: "commit"}
+	changed := base
+	changed.RepoID = string(HashContent([]byte("repo")))
+	changed.Parents = []ContentHash{HashContent([]byte("parent"))}
+	changed.CodexSettings = HashContent([]byte("settings"))
+	changed.Provider = ProviderCodex
+	changed.Fidelity = FidelityFull
+	changed.Author = TeamIdentity{Name: "author"}
+	changed.CreatedAt = time.Now()
+	changed.SessionID = "session"
+	changed.Models = []string{"model"}
+	changed.CompactionCount = 3
+	left, err := SnapshotStateHash(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	right, err := SnapshotStateHash(changed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if left != right {
+		t.Fatalf("immutable replica fields changed state hash: %s != %s", left, right)
+	}
+}
+
+func TestSnapshotStateHashNormalizesNilSlices(t *testing.T) {
+	left := Snapshot{ID: HashContent([]byte("snapshot")), DocHash: HashContent([]byte("snapshot"))}
+	right := left
+	right.Parents = []ContentHash{}
+	right.GraftParents = []ContentHash{}
+	right.Models = []string{}
+	a, err := SnapshotStateHash(left)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := SnapshotStateHash(right)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a != b {
+		t.Fatalf("nil/empty state hashes differ: %s != %s", a, b)
+	}
+}

--- a/cli/internal/ports/outbound/ports.go
+++ b/cli/internal/ports/outbound/ports.go
@@ -168,8 +168,11 @@ type RemoteSync interface {
 	// Push uploads local (snapshot, ref) to the central server. Can call object-only/ref-only steps by passing nil objects or refs. Normal SyncRepo push splits into two steps to ensure object -> queued graft -> ref order, avoiding hash duplication on the server. Sends both raw doc (Snapshot.DocHash) and memory (Snapshot.MemoryHash). (compatibility rules: Snapshots hold and propagate raw+memory). Force moves non-fast-forward refs to the server (git push --force). AppendDiverged appends diverged pushes to the server head (cxt push --append — grafts head onto incoming lineage; no history loss).
 	Push(ctx context.Context, repoID string, snapshots []domain.Snapshot, docs []domain.SessionDoc, refs []domain.Ref, force, appendDiverged bool) error
 
-	// Pull downloads (snapshot, doc body, ref) from the central server. Merge/conflict handling (local storage + ref merge) is performed by the caller (SyncRepo use-case). docHaves are local doc hashes — the server requests only missing (partial) ones. (Snapshot metadata is always fully received: graft overlay and memory pointer updates are propagated.)
-	Pull(ctx context.Context, repoID string, docHaves []domain.ContentHash) (snapshots []domain.Snapshot, docs []domain.SessionDoc, refs []domain.Ref, err error)
+	// Pull downloads (snapshot metadata, doc body, ref) from the central server.
+	// snapshotStates are local state hashes keyed by snapshot ID; a modern peer
+	// returns only new or changed metadata, while a legacy manifest safely falls
+	// back to all snapshots. docHaves are verified local document hashes.
+	Pull(ctx context.Context, repoID string, snapshotStates map[domain.ContentHash]domain.ContentHash, docHaves []domain.ContentHash) (snapshots []domain.Snapshot, docs []domain.SessionDoc, refs []domain.Ref, err error)
 
 	// RemoteManifest queries the server-side repo catalog. Used in push/pull negotiation step 1 to calculate what to send/receive.
 	RemoteManifest(ctx context.Context, repoID string) (domain.Manifest, error)

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -7,7 +7,7 @@ cxt keeps `cli/` and `backend/` in separate Go modules with independent domain t
 | File | Role |
 |---|---|
 | `cir.schema.json` | CIR v1/v2, the provider-independent canonical intermediate representation decoded from raw Claude and Codex JSONL. v2 adds explicit compaction replay state, multi-agent messages, and bounded provider replay metadata. Changes require compatibility review. |
-| `manifest.schema.json` | Manifest v1: repository refs, `snapshot_index`, and optional causal `memory_attachments` pointers used for push/pull have-want negotiation. Changes require compatibility review. |
+| `manifest.schema.json` | Manifest v1: repository refs, `snapshot_index`, optional causal `memory_attachments`, and optional mutable `snapshot_states` hashes used for incremental push/pull have-want negotiation. Changes require compatibility review. |
 | `openapi.yaml` | OpenAPI 3.1 REST contract shared by CLI, backend, and frontend. Route and field drift tests keep it aligned with the server. |
 | `db/migrations/*.sql` | Ordered PostgreSQL migrations through 0036, covering repository objects, identity/workspaces, pending state, reflog, compaction, graft overlays, transcript/memory chunk storage, and scoped session refs. |
 

--- a/schemas/manifest.schema.json
+++ b/schemas/manifest.schema.json
@@ -27,6 +27,12 @@
       "propertyNames": { "$ref": "#/$defs/contentHash" },
       "additionalProperties": { "$ref": "#/$defs/contentHash" }
     },
+    "snapshot_states": {
+      "type": "object",
+      "description": "Deterministic hash of mutable replicated state (branch/message promotion, memory attachment, and graft register) keyed by snapshot ID. A complete map enables incremental metadata pulls; omission means a legacy peer and requires a full metadata pull.",
+      "propertyNames": { "$ref": "#/$defs/contentHash" },
+      "additionalProperties": { "$ref": "#/$defs/contentHash" }
+    },
     "version": {
       "type": "integer",
       "minimum": 0,

--- a/schemas/openapi.yaml
+++ b/schemas/openapi.yaml
@@ -310,6 +310,13 @@ components:
             pattern: '^sha256:[0-9a-f]{64}$'
           additionalProperties:
             $ref: "#/components/schemas/ContentHash"
+        snapshot_states:
+          type: object
+          description: "Deterministic hash of mutable replicated state (branch/message promotion, memory attachment, and graft register) keyed by snapshot ID. A complete map enables incremental metadata pulls; absence means a legacy peer and requires a full metadata pull."
+          propertyNames:
+            pattern: '^sha256:[0-9a-f]{64}$'
+          additionalProperties:
+            $ref: "#/components/schemas/ContentHash"
         version:
           type: integer
           minimum: 0
@@ -767,7 +774,8 @@ paths:
       operationId: getManifest
       summary: Server Manifest retrieval (push/pull negotiation phase 1)
       description: |
-        Returns a list of refs held by the server + the entire snapshot_index.
+        Returns refs, the snapshot index, memory attachments, and snapshot state
+        hashes used to negotiate incremental metadata pulls.
         `RemoteSync.RemoteManifest` port is called. Start point of push/pull negotiation.
         Schema template: schemas/manifest.schema.json.
       tags: [manifest]

--- a/scripts/e2e-sync.sh
+++ b/scripts/e2e-sync.sh
@@ -196,6 +196,12 @@ expect "subsequent prompt emits no briefing" "$([ -z "$BRIEF2" ] && echo yes)" y
 REPEAT_HOOKOUT=$(TERM_SESSION_ID="$PULL_TERM" cxt git-hook post-merge 0 2>&1)
 expect "same remote tip is not briefed again" "$(echo "$REPEAT_HOOKOUT" | grep -c 'briefed to the agent')" 0
 expect "repeat pull leaves no briefing queue" "$(find .cxt/briefings -maxdepth 1 -type f -name '*.json' | wc -l | tr -d ' ')" 0
+expect "repeat fetch negotiates zero snapshot metadata" "$(echo "$REPEAT_HOOKOUT" | grep -c 'fetched .*snapshot')" 0
+MANIFEST_STATE=$(curl -sb "$J" "$B/repos/$RID/manifest" | python3 -c "
+import json,sys
+m=json.load(sys.stdin); print('complete' if len(m.get('snapshot_states') or {})==len(m.get('snapshot_index') or []) else 'partial')
+")
+expect "manifest advertises complete snapshot state catalog" "$MANIFEST_STATE" complete
 
 echo "── F. repo1: both-moved diverge push → automatic rebase-graft"
 HEAD_PREV=$(main_head)


### PR DESCRIPTION
## Summary
- advertise deterministic mutable snapshot state hashes in manifests
- request only new, changed, or missing-document snapshot metadata
- preserve full-pull compatibility with legacy peers and verify returned state against the manifest
- optimize PostgreSQL manifest generation and lock the 301-snapshot regression in tests/E2E

## Evidence
- unchanged real-data post-merge: 301 metadata objects / 41.72s before, 0 objects / 0.11s after
- one changed object: 1 object / 0.23s, then 0 on the next pull
- CLI/backend test + vet + race
- PostgreSQL-tagged tests
- basic and sync real-binary E2E
- public preflight

Closes #78