### PR TITLE
fix(memory): bound provider projections

### DIFF
--- a/cli/internal/adapters/memory/claude_memory.go
+++ b/cli/internal/adapters/memory/claude_memory.go
@@ -20,7 +20,7 @@ func (s *ClaudeMemorySource) Provider() domain.ProviderKind { return domain.Prov
 
 // ReadNative reads ~/.claude/projects/<cwd-encoded>/memory/MEMORY.md.
 // A missing or inaccessible file returns found=false so the caller can fall back to CIR distillation.
-func (s *ClaudeMemorySource) ReadNative(_ context.Context, cwd string) (domain.NativeMemory, bool, error) {
+func (s *ClaudeMemorySource) ReadNative(_ context.Context, cwd, _ string) (domain.NativeMemory, bool, error) {
 	abs, err := filepath.Abs(cwd)
 	if err != nil {
 		abs = cwd
@@ -46,10 +46,11 @@ func NewClaudeMemorySink() *ClaudeMemorySink { return &ClaudeMemorySink{} }
 // Provider returns claude.
 func (s *ClaudeMemorySink) Provider() domain.ProviderKind { return domain.ProviderClaude }
 
-// Inject writes the digest to cwd/CLAUDE.md and returns the path (including cxt-managed marker).
+// Inject refreshes the bounded cxt-managed region in cwd/CLAUDE.md while
+// preserving user-authored content outside the markers.
 func (s *ClaudeMemorySink) Inject(_ context.Context, digest domain.MemoryDigest, cwd string) (string, error) {
 	path := filepath.Join(cwd, "CLAUDE.md")
-	if err := providerfs.WriteRegularFileAtomic(path, []byte(renderMemoryMarkdown(digest)), 0o644); err != nil {
+	if err := writeManagedMemory(path, digest); err != nil {
 		return "", err
 	}
 	return path, nil

--- a/cli/internal/adapters/memory/codex_memory.go
+++ b/cli/internal/adapters/memory/codex_memory.go
@@ -30,7 +30,7 @@ func (s *CodexMemorySource) Provider() domain.ProviderKind { return domain.Provi
 //
 // Reading uses the sqlite3 CLI (-readonly -json), keeping this module free of an embedded SQLite driver.
 // Absence of sqlite3, absence of DB, or absence of matching row results in found=false (no error) → CIR self-distillation fallback.
-func (s *CodexMemorySource) ReadNative(ctx context.Context, cwd string) (domain.NativeMemory, bool, error) {
+func (s *CodexMemorySource) ReadNative(ctx context.Context, cwd, sessionID string) (domain.NativeMemory, bool, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return domain.NativeMemory{}, false, nil
@@ -54,8 +54,25 @@ func (s *CodexMemorySource) ReadNative(ctx context.Context, cwd string) (domain.
 	if len(ids) == 0 {
 		return domain.NativeMemory{}, false, nil
 	}
+	if sessionID != "" {
+		if !isSafeThreadID(sessionID) {
+			return domain.NativeMemory{}, false, nil
+		}
+		quoted := "'" + sessionID + "'"
+		found := false
+		for _, id := range ids {
+			if id == quoted {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return domain.NativeMemory{}, false, nil
+		}
+		ids = []string{quoted}
+	}
 	query := fmt.Sprintf(
-		"SELECT thread_id, raw_memory, rollout_summary FROM stage1_outputs WHERE thread_id IN (%s) ORDER BY source_updated_at ASC;",
+		"SELECT thread_id, raw_memory, rollout_summary FROM stage1_outputs WHERE thread_id IN (%s) AND (TRIM(raw_memory) <> '' OR TRIM(rollout_summary) <> '') ORDER BY source_updated_at DESC, thread_id DESC LIMIT 1;",
 		strings.Join(ids, ","))
 	out, err := exec.CommandContext(ctx, sqlite, "-readonly", "-json", db, query).Output()
 	if err != nil || len(strings.TrimSpace(string(out))) == 0 {
@@ -69,8 +86,6 @@ func (s *CodexMemorySource) ReadNative(ctx context.Context, cwd string) (domain.
 	if err := json.Unmarshal(out, &rows); err != nil || len(rows) == 0 {
 		return domain.NativeMemory{}, false, nil
 	}
-	var parts []string
-	total := 0
 	for _, r := range rows {
 		text := strings.TrimSpace(r.RawMemory)
 		if text == "" {
@@ -79,19 +94,13 @@ func (s *CodexMemorySource) ReadNative(ctx context.Context, cwd string) (domain.
 		if text == "" {
 			continue
 		}
-		if total += len(text); total > 64<<10 {
-			break // distillation input limit — old excess is discarded (ASC sort, latest is last)
-		}
-		parts = append(parts, text)
+		return domain.NativeMemory{
+			Provider: domain.ProviderCodex,
+			Source:   "codex:memories_1.sqlite",
+			Text:     text,
+		}, true, nil
 	}
-	if len(parts) == 0 {
-		return domain.NativeMemory{}, false, nil
-	}
-	return domain.NativeMemory{
-		Provider: domain.ProviderCodex,
-		Source:   "codex:memories_1.sqlite",
-		Text:     strings.Join(parts, "\n\n---\n\n"),
-	}, true, nil
+	return domain.NativeMemory{}, false, nil
 }
 
 // threadIDFromRollout extracts the thread uuid from a rollout file name.
@@ -127,10 +136,11 @@ func NewCodexMemorySink() *CodexMemorySink { return &CodexMemorySink{} }
 // Provider returns codex.
 func (s *CodexMemorySink) Provider() domain.ProviderKind { return domain.ProviderCodex }
 
-// Inject records the digest to cwd/AGENTS.md and returns the path (includes cxt-managed marker).
+// Inject refreshes the bounded cxt-managed region in cwd/AGENTS.md while
+// preserving user-authored content outside the markers.
 func (s *CodexMemorySink) Inject(_ context.Context, digest domain.MemoryDigest, cwd string) (string, error) {
 	path := filepath.Join(cwd, "AGENTS.md")
-	if err := providerfs.WriteRegularFileAtomic(path, []byte(renderMemoryMarkdown(digest)), 0o644); err != nil {
+	if err := writeManagedMemory(path, digest); err != nil {
 		return "", err
 	}
 	return path, nil

--- a/cli/internal/adapters/memory/codex_memory_test.go
+++ b/cli/internal/adapters/memory/codex_memory_test.go
@@ -2,11 +2,13 @@ package memory
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
+	"unicode/utf8"
 )
 
 // TestCodexReadNative verifies the reading of memories_1.sqlite and rollout files from a fake HOME directory, matching cwd to thread_id, reading from SQLite, and assembling NativeMemory.
@@ -55,7 +57,7 @@ func TestCodexReadNative(t *testing.T) {
 		t.Fatalf("fixture db: %v %s", err, out)
 	}
 
-	native, found, err := NewCodexMemorySource().ReadNative(context.Background(), repo)
+	native, found, err := NewCodexMemorySource().ReadNative(context.Background(), repo, mine)
 	if err != nil {
 		t.Fatalf("ReadNative: %v", err)
 	}
@@ -76,7 +78,7 @@ func TestCodexReadNative(t *testing.T) {
 	if out, err := exec.Command("sqlite3", db, "UPDATE stage1_outputs SET raw_memory='' WHERE thread_id='"+mine+"'").CombinedOutput(); err != nil {
 		t.Fatalf("update: %v %s", err, out)
 	}
-	native, found, _ = NewCodexMemorySource().ReadNative(context.Background(), repo)
+	native, found, _ = NewCodexMemorySource().ReadNative(context.Background(), repo, mine)
 	if !found || !strings.Contains(native.Text, "summary A") {
 		t.Errorf("expected rollout_summary fallback, got found=%v %q", found, native.Text)
 	}
@@ -85,8 +87,72 @@ func TestCodexReadNative(t *testing.T) {
 // TestCodexReadNativeAbsent ensures a silent fallback with found=false when the DB is absent.
 func TestCodexReadNativeAbsent(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
-	_, found, err := NewCodexMemorySource().ReadNative(context.Background(), t.TempDir())
+	_, found, err := NewCodexMemorySource().ReadNative(context.Background(), t.TempDir(), "")
 	if err != nil || found {
 		t.Fatalf("expected silent fallback, got found=%v err=%v", found, err)
+	}
+}
+
+func TestCodexReadNativeKeepsNewestRowFullAndSupportsExactSession(t *testing.T) {
+	if _, err := exec.LookPath("sqlite3"); err != nil {
+		t.Skip("sqlite3 CLI not available")
+	}
+	home := t.TempDir()
+	repo := t.TempDir()
+	t.Setenv("HOME", home)
+	dateDir := filepath.Join(home, ".codex", "sessions", "2026", "08", "27")
+	if err := os.MkdirAll(dateDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	oldID := "0198aaaa-bbbb-4ccc-8ddd-eeeeffff0001"
+	newID := "0198aaaa-bbbb-4ccc-8ddd-eeeeffff0002"
+	for _, id := range []string{oldID, newID} {
+		line := `{"timestamp":"2026-08-27T00:00:00Z","type":"session_meta","payload":{"id":"` + id + `","cwd":"` + repo + `"}}` + "\n"
+		path := filepath.Join(dateDir, "rollout-2026-08-27T00-00-00-"+id+".jsonl")
+		if err := os.WriteFile(path, []byte(line), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	db := filepath.Join(home, ".codex", "memories_1.sqlite")
+	schema := `CREATE TABLE stage1_outputs (
+		thread_id TEXT PRIMARY KEY,
+		source_updated_at INTEGER NOT NULL,
+		raw_memory TEXT NOT NULL,
+		rollout_summary TEXT NOT NULL,
+		generated_at INTEGER NOT NULL,
+		selected_for_phase2 INTEGER NOT NULL DEFAULT 0);`
+	if out, err := exec.Command("sqlite3", db, schema).CombinedOutput(); err != nil {
+		t.Fatalf("fixture db: %v %s", err, out)
+	}
+	oldText := "OLDEST-ROW " + strings.Repeat("o", 40<<10)
+	newText := strings.Repeat("é", 30<<10) + " NEWEST-ROW"
+	for _, row := range []struct {
+		id   string
+		at   int
+		text string
+	}{{oldID, 1, oldText}, {newID, 2, newText}} {
+		insert := fmt.Sprintf(`INSERT INTO stage1_outputs (thread_id,source_updated_at,raw_memory,rollout_summary,generated_at) VALUES ('%s',%d,'%s','',%d);`, row.id, row.at, row.text, row.at)
+		cmd := exec.Command("sqlite3", db, insert)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("insert memory row: %v %s", err, out)
+		}
+	}
+
+	native, found, err := NewCodexMemorySource().ReadNative(context.Background(), repo, "")
+	if err != nil || !found {
+		t.Fatalf("ReadNative found=%v err=%v", found, err)
+	}
+	if !strings.Contains(native.Text, "NEWEST-ROW") || strings.Contains(native.Text, "OLDEST-ROW") {
+		t.Fatalf("native selection kept stale rows: prefix=%q", native.Text[:min(len(native.Text), 80)])
+	}
+	if len(native.Text) != len(newText) || !utf8.ValidString(native.Text) {
+		t.Fatalf("native bytes=%d want=%d valid=%v", len(native.Text), len(newText), utf8.ValidString(native.Text))
+	}
+	exact, found, err := NewCodexMemorySource().ReadNative(context.Background(), repo, oldID)
+	if err != nil || !found || !strings.Contains(exact.Text, "OLDEST-ROW") || strings.Contains(exact.Text, "NEWEST-ROW") {
+		t.Fatalf("exact-session native selection=%q found=%v err=%v", exact.Text[:min(len(exact.Text), 80)], found, err)
+	}
+	if _, found, err := NewCodexMemorySource().ReadNative(context.Background(), repo, "0198aaaa-bbbb-4ccc-8ddd-eeeeffff9999"); err != nil || found {
+		t.Fatalf("unknown exact session found=%v err=%v", found, err)
 	}
 }

--- a/cli/internal/adapters/memory/distiller.go
+++ b/cli/internal/adapters/memory/distiller.go
@@ -70,7 +70,10 @@ func (d *RuleDistiller) Distill(_ context.Context, cir domain.CIRDocument, nativ
 		}
 		// Source marker ("native memory: …") is not added to KeyFacts — native memory is loaded by agent at session start (review P2).
 		return domain.MemoryDigest{
-			Summary:  truncate(compactSummary, 16000),
+			// Provider-written compaction memory is already the authoritative
+			// distilled state. Keep it byte-for-byte in the immutable digest;
+			// seed and instruction-file renderers apply their own prompt budgets.
+			Summary:  compactSummary,
 			KeyFacts: facts,
 			// When structure extraction succeeds, this list becomes the merge authority (parent completion not inherited).
 			OpenTasks:          tasks,

--- a/cli/internal/adapters/memory/distiller_test.go
+++ b/cli/internal/adapters/memory/distiller_test.go
@@ -131,6 +131,16 @@ func TestDistillUnstructuredSummaryFallsBack(t *testing.T) {
 	}
 }
 
+func TestDistillPreservesFullAgentCompactionSummary(t *testing.T) {
+	summary := "OLDEST-COMPACTION-HEAD\n" + strings.Repeat("é", 20_000) + "\nNEWEST-COMPACTION-TAIL"
+	d := distillWithSummary(t, summary)
+
+	if d.Summary != summary {
+		t.Fatalf("agent compaction summary was truncated: bytes=%d want=%d tail=%v",
+			len(d.Summary), len(summary), strings.Contains(d.Summary, "NEWEST-COMPACTION-TAIL"))
+	}
+}
+
 // TestDistillNoProvenanceMarkerInFacts ensures that the source marker ("native memory: …") does not mix with KeyFacts — the source is not a fact (review P2). Native memory is loaded by the agent at session start, so it has no information value.
 func TestDistillNoProvenanceMarkerInFacts(t *testing.T) {
 	cir := domain.CIRDocument{}

--- a/cli/internal/adapters/memory/managed_file.go
+++ b/cli/internal/adapters/memory/managed_file.go
@@ -1,0 +1,76 @@
+package memory
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/wnsdy95/cxthub/cli/internal/adapters/providerfs"
+	"github.com/wnsdy95/cxthub/cli/internal/domain"
+)
+
+// writeManagedMemory preserves user-owned instructions and replaces only one
+// well-formed cxt region. Malformed or duplicate markers fail closed: guessing
+// a replacement range would risk deleting user content.
+func writeManagedMemory(path string, digest domain.MemoryDigest) error {
+	managed := renderMemoryMarkdown(digest)
+	existing, err := providerfs.ReadRegularFile(path)
+	perm := os.FileMode(0o644)
+	switch {
+	case err == nil:
+		info, statErr := os.Lstat(path)
+		if statErr != nil {
+			return statErr
+		}
+		perm = info.Mode().Perm()
+	case os.IsNotExist(err):
+		existing = nil
+	default:
+		return err
+	}
+	merged, err := mergeManagedMemory(string(existing), managed)
+	if err != nil {
+		return err
+	}
+	return providerfs.WriteRegularFileAtomic(path, []byte(merged), perm)
+}
+
+func mergeManagedMemory(existing, managed string) (string, error) {
+	starts := strings.Count(existing, managedMemoryBegin)
+	ends := strings.Count(existing, managedMemoryEnd)
+	if starts == 0 && ends == 0 {
+		separator := ""
+		if existing != "" {
+			switch {
+			case strings.HasSuffix(existing, "\n\n"):
+			case strings.HasSuffix(existing, "\n"):
+				separator = "\n"
+			default:
+				separator = "\n\n"
+			}
+		}
+		return existing + separator + managed, nil
+	}
+	if starts != 1 || ends != 1 {
+		return "", fmt.Errorf("malformed cxt managed memory markers: begin=%d end=%d", starts, ends)
+	}
+	start := strings.Index(existing, managedMemoryBegin)
+	end := strings.Index(existing, managedMemoryEnd)
+	if start < 0 || end < start+len(managedMemoryBegin) || !markerIsWholeLine(existing, start, len(managedMemoryBegin)) || !markerIsWholeLine(existing, end, len(managedMemoryEnd)) {
+		return "", fmt.Errorf("malformed cxt managed memory marker placement")
+	}
+	replaceEnd := end + len(managedMemoryEnd)
+	if strings.HasPrefix(existing[replaceEnd:], "\r\n") {
+		replaceEnd += 2
+	} else if strings.HasPrefix(existing[replaceEnd:], "\n") {
+		replaceEnd++
+	}
+	return existing[:start] + managed + existing[replaceEnd:], nil
+}
+
+func markerIsWholeLine(text string, start, length int) bool {
+	beforeOK := start == 0 || text[start-1] == '\n'
+	after := start + length
+	afterOK := after == len(text) || text[after] == '\n' || text[after] == '\r'
+	return beforeOK && afterOK
+}

--- a/cli/internal/adapters/memory/managed_sink_test.go
+++ b/cli/internal/adapters/memory/managed_sink_test.go
@@ -1,0 +1,131 @@
+package memory
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/wnsdy95/cxthub/cli/internal/domain"
+)
+
+const (
+	testManagedMemoryBegin = "<!-- cxt:begin managed memory (do not edit inside markers) -->"
+	testManagedMemoryEnd   = "<!-- cxt:end managed memory -->"
+)
+
+func TestMemorySinkPreservesUserContentAndRefreshesManagedBlock(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		filename string
+		inject   func(context.Context, domain.MemoryDigest, string) (string, error)
+	}{
+		{name: "claude", filename: "CLAUDE.md", inject: NewClaudeMemorySink().Inject},
+		{name: "codex", filename: "AGENTS.md", inject: NewCodexMemorySink().Inject},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := t.TempDir()
+			path := filepath.Join(repo, tt.filename)
+			before := "# User instructions\nkeep-before\n\n"
+			after := "\nkeep-after\n"
+			oldManaged := renderMemoryMarkdown(domain.MemoryDigest{Summary: "old managed memory"})
+			original := before + oldManaged + after
+			if err := os.WriteFile(path, []byte(original), 0o600); err != nil {
+				t.Fatal(err)
+			}
+
+			if _, err := tt.inject(context.Background(), domain.MemoryDigest{Summary: "new managed memory"}, repo); err != nil {
+				t.Fatal(err)
+			}
+			got, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			text := string(got)
+			if !strings.HasPrefix(text, before) || !strings.HasSuffix(text, after) {
+				t.Fatalf("user content changed:\n%s", text)
+			}
+			if strings.Contains(text, "old managed memory") || !strings.Contains(text, "new managed memory") {
+				t.Fatalf("managed block was not refreshed:\n%s", text)
+			}
+			if strings.Count(text, testManagedMemoryBegin) != 1 || strings.Count(text, testManagedMemoryEnd) != 1 {
+				t.Fatalf("managed marker count changed:\n%s", text)
+			}
+			info, err := os.Stat(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if info.Mode().Perm() != 0o600 {
+				t.Fatalf("mode=%v, want 0600", info.Mode().Perm())
+			}
+		})
+	}
+}
+
+func TestMemorySinkAppendsOneManagedBlock(t *testing.T) {
+	repo := t.TempDir()
+	path := filepath.Join(repo, "AGENTS.md")
+	user := "# Team instructions\nNever rewrite this text."
+	if err := os.WriteFile(path, []byte(user), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, summary := range []string{"first projection", "second projection"} {
+		if _, err := NewCodexMemorySink().Inject(context.Background(), domain.MemoryDigest{Summary: summary}, repo); err != nil {
+			t.Fatal(err)
+		}
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(got)
+	if !strings.HasPrefix(text, user) || strings.Count(text, testManagedMemoryBegin) != 1 || strings.Count(text, testManagedMemoryEnd) != 1 {
+		t.Fatalf("managed append overwrote or duplicated user content:\n%s", text)
+	}
+	if strings.Contains(text, "first projection") || !strings.Contains(text, "second projection") {
+		t.Fatalf("managed append did not refresh in place:\n%s", text)
+	}
+}
+
+func TestMemorySinkRejectsMalformedMarkersWithoutWrite(t *testing.T) {
+	for _, body := range []string{
+		"user\n" + testManagedMemoryBegin + "\nunterminated\n",
+		testManagedMemoryBegin + "\na\n" + testManagedMemoryEnd + "\n" + testManagedMemoryBegin + "\nb\n" + testManagedMemoryEnd + "\n",
+	} {
+		repo := t.TempDir()
+		path := filepath.Join(repo, "CLAUDE.md")
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := NewClaudeMemorySink().Inject(context.Background(), domain.MemoryDigest{Summary: "replacement"}, repo); err == nil {
+			t.Fatal("malformed managed markers were accepted")
+		}
+		got, err := os.ReadFile(path)
+		if err != nil || string(got) != body {
+			t.Fatalf("malformed file changed: %q err=%v", got, err)
+		}
+	}
+}
+
+func TestRenderedManagedMemoryIsBoundedAndKeepsNewestState(t *testing.T) {
+	digest := domain.MemoryDigest{
+		SnapshotID: domain.HashContent([]byte("managed-memory-snapshot")),
+		Summary:    "OLDEST-SUMMARY\n" + strings.Repeat("é", 80<<10) + "\nNEWEST-SUMMARY",
+		KeyFacts:   []string{strings.Repeat("old-fact ", 12<<10), "NEWEST-FACT"},
+		OpenTasks:  []string{strings.Repeat("old-task ", 12<<10), "NEWEST-TASK"},
+	}
+	got := renderMemoryMarkdown(digest)
+	if len(got) > 64<<10 || !utf8.ValidString(got) {
+		t.Fatalf("managed memory bytes=%d valid=%v", len(got), utf8.ValidString(got))
+	}
+	for _, want := range []string{"NEWEST-SUMMARY", "NEWEST-FACT", "NEWEST-TASK", string(digest.SnapshotID)} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("bounded managed memory lost %q", want)
+		}
+	}
+	if strings.Count(got, testManagedMemoryBegin) != 1 || strings.Count(got, testManagedMemoryEnd) != 1 {
+		t.Fatalf("invalid managed block:\n%s", got)
+	}
+}

--- a/cli/internal/adapters/memory/render.go
+++ b/cli/internal/adapters/memory/render.go
@@ -2,37 +2,109 @@ package memory
 
 import (
 	"strings"
+	"unicode/utf8"
 
 	"github.com/wnsdy95/cxthub/cli/internal/domain"
 )
 
+const (
+	managedMemoryBegin    = "<!-- cxt:begin managed memory (do not edit inside markers) -->"
+	managedMemoryEnd      = "<!-- cxt:end managed memory -->"
+	maxManagedMemoryBytes = 64 << 10
+)
+
 // renderMemoryMarkdown renders MemoryDigest to markdown for provider memory files (CLAUDE.md/AGENTS.md).
-// Wrapped with cxt-managed marker to identify the region for merge/refresh.
+// Wrapped with cxt-managed markers to identify the region for merge/refresh.
+// The immutable digest remains full fidelity in cxt storage; only this
+// provider-facing projection is bounded so it cannot consume the next session's
+// context window before the user says anything.
 func renderMemoryMarkdown(d domain.MemoryDigest) string {
+	header := managedMemoryBegin + "\n# cxt memory\n\n"
+	footer := ""
+	if d.SnapshotID != "" && domain.ValidateContentHash(d.SnapshotID) == nil {
+		footer = "<!-- cxt:snapshot " + string(d.SnapshotID) + " -->\n"
+	}
+	footer += managedMemoryEnd + "\n"
+	available := maxManagedMemoryBytes - len(header) - len(footer)
+	if available < 0 {
+		available = 0
+	}
+
+	// Structured state receives fixed reservations before narrative. Lists are
+	// selected newest-first but rendered in their original order.
+	facts := renderMemoryListTail("Key facts", d.KeyFacts, available/6)
+	tasks := renderMemoryListTail("Open tasks", d.OpenTasks, available/4)
+	remaining := available - len(facts) - len(tasks)
+	summary := ""
+	if text := strings.TrimSpace(d.Summary); text != "" && remaining > 2 {
+		summary = truncateMemoryTail(text, remaining-2) + "\n\n"
+	}
+	return header + summary + facts + tasks + footer
+}
+
+func renderMemoryListTail(title string, items []string, maxBytes int) string {
+	header := "## " + title + "\n"
+	if maxBytes <= len(header)+3 || len(items) == 0 {
+		return ""
+	}
+	remaining := maxBytes - len(header) - 1 // final section newline
+	selected := make([]string, 0, len(items))
+	for i := len(items) - 1; i >= 0; i-- {
+		item := strings.TrimSpace(items[i])
+		if item == "" {
+			continue
+		}
+		line := "- " + item + "\n"
+		if len(line) > remaining {
+			if len(selected) == 0 && remaining > 3 {
+				line = "- " + truncateMemoryPrefix(item, remaining-3) + "\n"
+				selected = append(selected, line)
+			}
+			break
+		}
+		selected = append(selected, line)
+		remaining -= len(line)
+	}
+	if len(selected) == 0 {
+		return ""
+	}
 	var b strings.Builder
-	b.WriteString("<!-- cxt:begin managed memory (do not edit inside markers) -->\n")
-	b.WriteString("# cxt memory\n\n")
-	if d.Summary != "" {
-		b.WriteString(d.Summary)
-		b.WriteString("\n\n")
+	b.WriteString(header)
+	for i := len(selected) - 1; i >= 0; i-- {
+		b.WriteString(selected[i])
 	}
-	if len(d.KeyFacts) > 0 {
-		b.WriteString("## Key facts\n")
-		for _, f := range d.KeyFacts {
-			b.WriteString("- " + f + "\n")
-		}
-		b.WriteString("\n")
-	}
-	if len(d.OpenTasks) > 0 {
-		b.WriteString("## Open tasks\n")
-		for _, t := range d.OpenTasks {
-			b.WriteString("- " + t + "\n")
-		}
-		b.WriteString("\n")
-	}
-	if d.SnapshotID != "" {
-		b.WriteString("<!-- cxt:snapshot " + string(d.SnapshotID) + " -->\n")
-	}
-	b.WriteString("<!-- cxt:end managed memory -->\n")
+	b.WriteByte('\n')
 	return b.String()
+}
+
+func truncateMemoryPrefix(text string, maxBytes int) string {
+	if maxBytes <= 0 {
+		return ""
+	}
+	if len(text) <= maxBytes {
+		return text
+	}
+	end := maxBytes
+	for end > 0 && !utf8.ValidString(text[:end]) {
+		end--
+	}
+	return text[:end]
+}
+
+func truncateMemoryTail(text string, maxBytes int) string {
+	if maxBytes <= 0 {
+		return ""
+	}
+	if len(text) <= maxBytes {
+		return text
+	}
+	const marker = "[... earlier memory omitted ...]\n"
+	if maxBytes <= len(marker) {
+		return truncateMemoryPrefix(marker, maxBytes)
+	}
+	start := len(text) - (maxBytes - len(marker))
+	for start < len(text) && !utf8.RuneStart(text[start]) {
+		start++
+	}
+	return marker + text[start:]
 }

--- a/cli/internal/app/load_session.go
+++ b/cli/internal/app/load_session.go
@@ -34,7 +34,7 @@ import (
 //     c. LoadOutput{WrittenPath: sessionPath, ResumeCmd, Fidelity: full/reconstructed}
 //     d. **Fallback to memory mode automatically on Materialize failure** (Fidelity downgrade → memory).
 //     memory:
-//     a. MemorySource[TargetProvider].ReadNative(Cwd) → (native, found)
+//     a. For same-provider or legacy replay, MemorySource[TargetProvider].ReadNative(Cwd, SessionOriginID) → (native, found)
 //     b. MemoryDistiller.Distill(cir, native) → MemoryDigest (native==nil fallback to CIR distillation)
 //     c. digest.SnapshotID = snap.ID (app layer injection)
 //     d. MemorySink[TargetProvider].Inject(digest, Cwd) → writtenPath
@@ -627,8 +627,9 @@ func (s *LoadSessionService) prependTrimDigestWithStatus(ctx context.Context, om
 		}
 	}
 	// Skip native-memory duplicates when the summary repeats the ingested native memory verbatim.
-	if src, ok := s.memSources[target]; ok && digest.Summary != "" {
-		if nm, found, _ := src.ReadNative(ctx, cwd); found &&
+	if src, ok := s.memSources[target]; ok && digest.Summary != "" &&
+		(omitted.Envelope.SourceProvider == "" || target == omitted.Envelope.SourceProvider) {
+		if nm, found, _ := src.ReadNative(ctx, cwd, omitted.Envelope.SessionOriginID); found &&
 			strings.TrimSpace(digest.Summary) == strings.TrimSpace(nm.Text) {
 			digest.Summary = ""
 		}
@@ -803,8 +804,9 @@ func seedWorthyFacts(facts []string) []string {
 // loadMemory performs memory-form restoration: native-first ingestion → distillation → provider memory file injection.
 func (s *LoadSessionService) loadMemory(ctx context.Context, cir domain.CIRDocument, snap domain.Snapshot, target domain.ProviderKind, cwd string) (inbound.LoadOutput, error) {
 	var native *domain.NativeMemory
-	if src, ok := s.memSources[target]; ok {
-		if nm, found, _ := src.ReadNative(ctx, cwd); found {
+	if src, ok := s.memSources[target]; ok &&
+		(cir.Envelope.SourceProvider == "" || target == cir.Envelope.SourceProvider) {
+		if nm, found, _ := src.ReadNative(ctx, cwd, cir.Envelope.SessionOriginID); found {
 			native = &nm
 		}
 	}

--- a/cli/internal/app/memorize.go
+++ b/cli/internal/app/memorize.go
@@ -20,7 +20,7 @@ import (
 //  1. GitContext.CurrentRepo/CurrentBranch(Cwd) → repoID, branch confirmed.
 //  2. CaptureSource[Provider].LocateActiveSession+ReadSession → raw session.
 //  3. ProviderCodec[Provider].Decode(raw) → CIRDocument.
-//  4. MemorySource[Provider].ReadNative(Cwd) → (native, found). Native priority.
+//  4. MemorySource[Provider].ReadNative(Cwd, SessionOriginID) → (native, found). Native priority.
 //  5. MemoryDistiller.Distill(cir, native) → MemoryDigest (native==nil fallback to CIR distillation).
 //  6. SessionStore.PutMemory(digest) → MemoryHash.
 //  7. Attach MemoryHash to current branch HEAD snapshot (snapshot holds raw+memory, invariant 1).
@@ -60,9 +60,6 @@ func NewMemorizeService(
 // Push carries the attached memory with the raw document (compatibility rules).
 func (s *MemorizeService) Memorize(ctx context.Context, in inbound.MemorizeInput) (inbound.MemorizeOutput, error) {
 	provider := in.Provider
-	if provider == "" {
-		provider = domain.ProviderClaude
-	}
 	repo, err := s.gitCtx.CurrentRepo(ctx, in.Cwd)
 	if err != nil {
 		return inbound.MemorizeOutput{}, err
@@ -94,11 +91,22 @@ func (s *MemorizeService) Memorize(ctx context.Context, in inbound.MemorizeInput
 	if err != nil {
 		return inbound.MemorizeOutput{}, err
 	}
+	sourceProvider := doc.CIR.Envelope.SourceProvider
+	if sourceProvider != "" {
+		if provider != "" && provider != sourceProvider {
+			return inbound.MemorizeOutput{}, fmt.Errorf("snapshot provider %q does not match requested memory provider %q", sourceProvider, provider)
+		}
+		provider = sourceProvider
+	} else if provider == "" {
+		// Legacy documents predate SourceProvider. Preserve the original default
+		// only when the snapshot itself cannot identify its native-memory source.
+		provider = domain.ProviderClaude
+	}
 
 	// Absorb native memory (e.g., CLAUDE.md/MEMORY.md) first — fallback to CIR distillation if not present.
 	var nativePtr *domain.NativeMemory
 	if src, ok := s.memSources[provider]; ok {
-		if native, found, nerr := src.ReadNative(ctx, in.Cwd); nerr == nil && found {
+		if native, found, nerr := src.ReadNative(ctx, in.Cwd, doc.CIR.Envelope.SessionOriginID); nerr == nil && found {
 			nativePtr = &native
 		}
 	}

--- a/cli/internal/app/restore_test.go
+++ b/cli/internal/app/restore_test.go
@@ -3,11 +3,13 @@ package app
 import (
 	"context"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/wnsdy95/cxthub/cli/internal/adapters/codec"
 	"github.com/wnsdy95/cxthub/cli/internal/adapters/memory"
+	"github.com/wnsdy95/cxthub/cli/internal/adapters/providerfs"
 	"github.com/wnsdy95/cxthub/cli/internal/adapters/session"
 	"github.com/wnsdy95/cxthub/cli/internal/adapters/storage"
 	"github.com/wnsdy95/cxthub/cli/internal/domain"
@@ -314,11 +316,24 @@ func TestLoadFullPinsCodexReplacementWhileTrimmingLongSuffix(t *testing.T) {
 
 // Memory mode: inject digest into CLAUDE.md.
 func TestLoadMemoryMode(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	home := t.TempDir()
+	t.Setenv("HOME", home)
 	ctx := context.Background()
 	store := storage.NewFileStore(t.TempDir())
 	seedClaudeSnapshot(t, store)
 	cwd := t.TempDir()
+	userInstructions := "# User-owned instructions\nPreserve this exactly."
+	if err := os.WriteFile(filepath.Join(cwd, "CLAUDE.md"), []byte(userInstructions), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	nativeText := "OLDEST-NATIVE\n" + strings.Repeat("é", 80<<10) + "\nNEWEST-NATIVE"
+	nativePath := filepath.Join(home, ".claude", "projects", providerfs.EncodeCwd(cwd), "memory", "MEMORY.md")
+	if err := os.MkdirAll(filepath.Dir(nativePath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(nativePath, []byte(nativeText), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	out, err := newLoadSvc(store).Load(ctx, inbound.LoadInput{Ref: "main", TargetProvider: domain.ProviderClaude, Mode: domain.FidelityMemory, Cwd: cwd})
 	if err != nil {
@@ -330,9 +345,26 @@ func TestLoadMemoryMode(t *testing.T) {
 	if !strings.HasSuffix(out.WrittenPath, "CLAUDE.md") {
 		t.Fatalf("memory sink should write CLAUDE.md, got %s", out.WrittenPath)
 	}
-	data, _ := os.ReadFile(out.WrittenPath)
-	if !strings.Contains(string(data), "cxt memory") {
-		t.Fatalf("CLAUDE.md should contain injected memory")
+	data, err := os.ReadFile(out.WrittenPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(string(data), userInstructions) || !strings.Contains(string(data), "cxt memory") || !strings.Contains(string(data), "NEWEST-NATIVE") {
+		t.Fatalf("CLAUDE.md did not preserve user instructions and bounded latest memory")
+	}
+	if len(data) > len(userInstructions)+(64<<10)+2 {
+		t.Fatalf("CLAUDE.md bytes=%d exceeds user content + managed budget", len(data))
+	}
+	info, err := os.Stat(out.WrittenPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("CLAUDE.md mode=%v, want 0600", info.Mode().Perm())
+	}
+	storedNative, err := os.ReadFile(nativePath)
+	if err != nil || string(storedNative) != nativeText {
+		t.Fatalf("provider native memory was mutated: bytes=%d err=%v", len(storedNative), err)
 	}
 }
 

--- a/cli/internal/app/seed_digest_test.go
+++ b/cli/internal/app/seed_digest_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/wnsdy95/cxthub/cli/internal/adapters/storage"
 	"github.com/wnsdy95/cxthub/cli/internal/domain"
+	"github.com/wnsdy95/cxthub/cli/internal/ports/inbound"
 	"github.com/wnsdy95/cxthub/cli/internal/ports/outbound"
 )
 
@@ -26,8 +27,119 @@ func (failingDistiller) Distill(_ context.Context, _ domain.CIRDocument, _ *doma
 type stubMemSource struct{ text string }
 
 func (s stubMemSource) Provider() domain.ProviderKind { return domain.ProviderClaude }
-func (s stubMemSource) ReadNative(_ context.Context, _ string) (domain.NativeMemory, bool, error) {
+func (s stubMemSource) ReadNative(_ context.Context, _, _ string) (domain.NativeMemory, bool, error) {
 	return domain.NativeMemory{Source: "claude:MEMORY.md", Text: s.text}, s.text != "", nil
+}
+
+type recordingSessionMemSource struct {
+	provider             domain.ProviderKind
+	calls                int
+	gotCwd, gotSessionID string
+}
+
+func (s *recordingSessionMemSource) Provider() domain.ProviderKind { return s.provider }
+func (s *recordingSessionMemSource) ReadNative(_ context.Context, cwd, sessionID string) (domain.NativeMemory, bool, error) {
+	s.calls++
+	s.gotCwd = cwd
+	s.gotSessionID = sessionID
+	return domain.NativeMemory{Source: "codex:rollout_summary", Text: "exact session memory"}, true, nil
+}
+
+type recordingMemorySink struct{ provider domain.ProviderKind }
+
+func (s recordingMemorySink) Provider() domain.ProviderKind { return s.provider }
+func (s recordingMemorySink) Inject(_ context.Context, _ domain.MemoryDigest, cwd string) (string, error) {
+	return cwd + "/managed-memory", nil
+}
+
+func TestMemorizeReadsNativeMemoryForExactProviderSession(t *testing.T) {
+	ctx := context.Background()
+	store := storage.NewFileStore(t.TempDir())
+	cwd := t.TempDir()
+	repo := domain.Repo{ID: "repo-exact-native-memory", LocalPath: cwd, DefaultBranch: "main"}
+	docHash, err := store.PutDoc(ctx, domain.SessionDoc{CIR: domain.CIRDocument{
+		Envelope: domain.Envelope{
+			CIRVersion:      domain.CIRVersionV2,
+			SourceProvider:  domain.ProviderCodex,
+			SessionOriginID: "codex-session-exact",
+		},
+		Events: []domain.Event{{Kind: domain.EventMessage, Role: "user", Seq: 0}},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.PutSnapshot(ctx, domain.Snapshot{
+		ID: docHash, DocHash: docHash, RepoID: repo.ID, Branch: "main",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.PutRef(ctx, domain.Ref{
+		Kind: domain.RefBranch, Name: "main", RepoID: repo.ID, Target: docHash,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	source := &recordingSessionMemSource{provider: domain.ProviderCodex}
+	service := NewMemorizeService(
+		branchSeedGit{repo: repo}, nil, nil,
+		map[domain.ProviderKind]outbound.MemorySource{domain.ProviderCodex: source},
+		stubDistiller{d: domain.MemoryDigest{Summary: "fresh exact-session memory"}}, store,
+	)
+	if _, err := service.Memorize(ctx, inbound.MemorizeInput{Cwd: cwd}); err != nil {
+		t.Fatal(err)
+	}
+	if source.calls != 1 || source.gotCwd != cwd || source.gotSessionID != "codex-session-exact" {
+		t.Fatalf("native memory lookup calls=%d cwd=%q session=%q", source.calls, source.gotCwd, source.gotSessionID)
+	}
+	mismatched := &recordingSessionMemSource{provider: domain.ProviderClaude}
+	service = NewMemorizeService(
+		branchSeedGit{repo: repo}, nil, nil,
+		map[domain.ProviderKind]outbound.MemorySource{domain.ProviderClaude: mismatched},
+		stubDistiller{d: domain.MemoryDigest{Summary: "must not be attached"}}, store,
+	)
+	if _, err := service.Memorize(ctx, inbound.MemorizeInput{Cwd: cwd, Provider: domain.ProviderClaude}); err == nil || !strings.Contains(err.Error(), "does not match") {
+		t.Fatalf("mismatched provider error=%v", err)
+	}
+	if mismatched.calls != 0 {
+		t.Fatalf("mismatched provider read unrelated native memory %d time(s)", mismatched.calls)
+	}
+}
+
+func TestLoadMemoryScopesNativeLookupToSameProviderSession(t *testing.T) {
+	ctx := context.Background()
+	cwd := t.TempDir()
+	cir := domain.CIRDocument{Envelope: domain.Envelope{
+		CIRVersion:      domain.CIRVersionV2,
+		SourceProvider:  domain.ProviderCodex,
+		SessionOriginID: "codex-session-exact",
+	}}
+	snap := domain.Snapshot{ID: domain.HashContent([]byte("load-memory-session-scope"))}
+
+	for _, tc := range []struct {
+		name        string
+		target      domain.ProviderKind
+		wantCalls   int
+		wantSession string
+	}{
+		{name: "same provider", target: domain.ProviderCodex, wantCalls: 1, wantSession: "codex-session-exact"},
+		{name: "cross provider", target: domain.ProviderClaude, wantCalls: 0, wantSession: ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			source := &recordingSessionMemSource{provider: tc.target}
+			service := NewLoadSessionService(
+				storage.NewFileStore(t.TempDir()), nil, nil,
+				map[domain.ProviderKind]outbound.MemorySource{tc.target: source},
+				stubDistiller{d: domain.MemoryDigest{Summary: "loaded memory"}},
+				map[domain.ProviderKind]outbound.MemorySink{tc.target: recordingMemorySink{provider: tc.target}},
+			)
+			if _, err := service.loadMemory(ctx, cir, snap, tc.target, cwd); err != nil {
+				t.Fatal(err)
+			}
+			if source.calls != tc.wantCalls || source.gotSessionID != tc.wantSession {
+				t.Fatalf("native memory lookup calls=%d session=%q, want calls=%d session=%q", source.calls, source.gotSessionID, tc.wantCalls, tc.wantSession)
+			}
+		})
+	}
 }
 
 // TestPrependTrimDigestCompactSummary enforces a cycle-breaking contract for seed summary injection:

--- a/cli/internal/ports/inbound/ports.go
+++ b/cli/internal/ports/inbound/ports.go
@@ -368,7 +368,8 @@ type CheckoutOutput struct {
 type MemorizeInput struct {
 	// Cwd is the working directory for detecting the active session target for distillation.
 	Cwd string
-	// Provider is the distillation target provider (claude|codex).
+	// Provider is an optional native-memory source hint for legacy snapshots.
+	// For modern snapshots it must match CIR.Envelope.SourceProvider.
 	Provider domain.ProviderKind
 	// Ref is the distillation target snapshot specification (branch name/snapshot ID, default to current branch head).
 	// It is needed in the memorize at the point where head already points to a different location, similar to a checkpoint (branch save just before transition).

--- a/cli/internal/ports/outbound/ports.go
+++ b/cli/internal/ports/outbound/ports.go
@@ -250,9 +250,10 @@ type MemorySource interface {
 	// Provider returns the provider this source is responsible for (claude|codex).
 	Provider() domain.ProviderKind
 
-	// ReadNative reads provider native memory based on the current working directory (cwd).
-	// Returns found=false if not found (no error).
-	ReadNative(ctx context.Context, cwd string) (native domain.NativeMemory, found bool, err error)
+	// ReadNative reads provider native memory for the exact provider session when
+	// sessionID is available. An empty sessionID falls back to the newest memory
+	// associated with cwd. Returns found=false if not found (no error).
+	ReadNative(ctx context.Context, cwd, sessionID string) (native domain.NativeMemory, found bool, err error)
 }
 
 // MemoryDistiller is a port that generates MemoryDigest (summary memory) (compatibility rules).

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -285,6 +285,12 @@ The mode priority is:
 3. the authenticated account preference from the server; and
 4. `full`.
 
+`memory` keeps the full immutable digest in cxt storage but injects at most a
+64 KiB projection into the target provider's instruction file. cxt appends or
+refreshes one marked region in `CLAUDE.md` or `AGENTS.md`; text and permissions
+outside that region are preserved. Malformed or duplicate cxt markers fail
+closed instead of guessing a destructive replacement range.
+
 ### `cxt memorize` and `cxt memory`
 
 ```text
@@ -294,7 +300,10 @@ cxt memory [<ref>] [--provider <claude|codex>]
 
 Distills a snapshot into reusable memory and attaches it for the next push.
 With no ref, uses the current branch head. `memory` is an alias for
-`memorize`; there is no `cxt memory save` subcommand.
+`memorize`; there is no `cxt memory save` subcommand. Modern snapshots select
+their recorded source provider automatically. An explicit `--provider` must
+match it; cxt never imports unrelated native memory from another provider or
+terminal into that snapshot.
 
 ## Synchronization
 

--- a/scripts/e2e-sync.sh
+++ b/scripts/e2e-sync.sh
@@ -312,8 +312,19 @@ expect "Invalid value 422" "$(ccurl -sb "$J" -o /dev/null -w '%{http_code}' -X P
 # CLI consumption: switching an authenticated repo1 to an existing branch uses the server's memory fidelity setting.
 cd "$TMP/repo1"
 git checkout -qb tmp-z >/dev/null 2>&1
+cat > CLAUDE.md <<'EOF'
+# User-owned instructions
+Preserve this text and its file mode.
+EOF
+chmod 600 CLAUDE.md
 git checkout -q main >"$TMP/pref.out" 2>&1
 expect "Switch load uses server personal settings(memory)" "$(grep -c 'fidelity: memory' "$TMP/pref.out")" 1
+cxt load main --provider claude --mode memory >/dev/null 2>&1
+cxt load main --provider claude --mode memory >/dev/null 2>&1
+expect "memory load preserves user instructions" "$(python3 -c "from pathlib import Path; print('yes' if Path('CLAUDE.md').read_text().startswith('# User-owned instructions\nPreserve this text and its file mode.\n') else 'no')")" yes
+expect "memory load refreshes one managed block" "$(grep -c '^<!-- cxt:begin managed memory' CLAUDE.md)" 1
+expect "memory managed block stays within 64 KiB" "$(python3 -c "from pathlib import Path; b=Path('CLAUDE.md').read_bytes(); s=b.index(b'<!-- cxt:begin managed memory'); e=b.index(b'<!-- cxt:end managed memory -->', s)+len(b'<!-- cxt:end managed memory -->')+1; print('yes' if e-s <= 64*1024 else 'no')")" yes
+expect "memory load preserves instruction file mode" "$(python3 -c "from pathlib import Path; print(oct(Path('CLAUDE.md').stat().st_mode & 0o777))")" 0o600
 ccurl -sb "$J" -X PATCH "$B/me" -H 'Content-Type: application/json' -d '{"load_mode":""}' >/dev/null
 
 echo "── I. Web fork connection: git branch = align+connect / switch -c = seed priority"


### PR DESCRIPTION
## Summary
- preserve full native and provider-written compaction memory in immutable storage while bounding only provider-facing managed blocks to 64 KiB
- preserve user-owned CLAUDE.md and AGENTS.md content and modes, refreshing exactly one fail-closed managed region
- scope Codex native memory to the exact provider session, avoid cross-provider terminal mixing, and select one full newest legacy row
- verify the behavior through focused regressions and real-binary sync E2E

## Validation
- go test ./...
- go vet ./...
- go test -race ./...
- make e2e
- make e2e-sync
- make public-check

Closes #80