### PR TITLE
fix(sync): stop repeated local-ahead metadata pulls

### DIFF
--- a/cli/internal/adapters/storage/remote_state_cursor.go
+++ b/cli/internal/adapters/storage/remote_state_cursor.go
@@ -1,0 +1,88 @@
+package storage
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+
+	"github.com/wnsdy95/cxthub/cli/internal/domain"
+	"github.com/wnsdy95/cxthub/cli/internal/ports/outbound"
+)
+
+const remoteSnapshotStateCursorVersion = 1
+
+type remoteSnapshotStateCursorFile struct {
+	Version int                                                          `json:"version"`
+	RepoID  string                                                       `json:"repo_id"`
+	Entries map[domain.ContentHash]domain.RemoteSnapshotStateCursorEntry `json:"entries"`
+}
+
+func (s *FileStore) remoteSnapshotStateCursorPath(repoID string) (string, error) {
+	id := domain.ContentHash(repoID)
+	if err := domain.ValidateContentHash(id); err != nil {
+		return "", err
+	}
+	return filepath.Join(s.storeDir(), "remote-state-cursors", hexOf(id)+".json"), nil
+}
+
+// LoadRemoteSnapshotStateCursor reads a validated, repo-bound pull hint. A
+// missing file is an empty cursor; malformed content is never trusted.
+func (s *FileStore) LoadRemoteSnapshotStateCursor(_ context.Context, repoID string) (map[domain.ContentHash]domain.RemoteSnapshotStateCursorEntry, error) {
+	path, err := s.remoteSnapshotStateCursorPath(repoID)
+	if err != nil {
+		return nil, err
+	}
+	raw, err := readCxtFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return map[domain.ContentHash]domain.RemoteSnapshotStateCursorEntry{}, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var file remoteSnapshotStateCursorFile
+	if json.Unmarshal(raw, &file) != nil || file.Version != remoteSnapshotStateCursorVersion || file.RepoID != repoID {
+		return nil, domain.ErrHashMismatch
+	}
+	out := make(map[domain.ContentHash]domain.RemoteSnapshotStateCursorEntry, len(file.Entries))
+	for id, entry := range file.Entries {
+		if domain.ValidateContentHash(id) != nil || domain.ValidateContentHash(entry.LocalState) != nil || domain.ValidateContentHash(entry.RemoteState) != nil || entry.LocalState == entry.RemoteState {
+			return nil, domain.ErrHashMismatch
+		}
+		out[id] = entry
+	}
+	return out, nil
+}
+
+// SaveRemoteSnapshotStateCursor atomically replaces the cursor. Equal local
+// and remote states need no hint and are omitted. Empty cursors remove the file.
+func (s *FileStore) SaveRemoteSnapshotStateCursor(_ context.Context, repoID string, entries map[domain.ContentHash]domain.RemoteSnapshotStateCursorEntry) error {
+	path, err := s.remoteSnapshotStateCursorPath(repoID)
+	if err != nil {
+		return err
+	}
+	clean := make(map[domain.ContentHash]domain.RemoteSnapshotStateCursorEntry, len(entries))
+	for id, entry := range entries {
+		if domain.ValidateContentHash(id) != nil || domain.ValidateContentHash(entry.LocalState) != nil || domain.ValidateContentHash(entry.RemoteState) != nil {
+			return domain.ErrHashMismatch
+		}
+		if entry.LocalState != entry.RemoteState {
+			clean[id] = entry
+		}
+	}
+	if len(clean) == 0 {
+		return removeCxtFile(path)
+	}
+	raw, err := json.Marshal(remoteSnapshotStateCursorFile{
+		Version: remoteSnapshotStateCursorVersion,
+		RepoID:  repoID,
+		Entries: clean,
+	})
+	if err != nil {
+		return err
+	}
+	return writeAtomic(path, raw)
+}
+
+var _ outbound.RemoteSnapshotStateCursorStore = (*FileStore)(nil)

--- a/cli/internal/adapters/storage/remote_state_cursor_test.go
+++ b/cli/internal/adapters/storage/remote_state_cursor_test.go
@@ -1,0 +1,72 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/wnsdy95/cxthub/cli/internal/domain"
+)
+
+func TestRemoteSnapshotStateCursorRoundTripAndValidation(t *testing.T) {
+	ctx := context.Background()
+	store := NewFileStore(t.TempDir())
+	repoID := string(domain.HashContent([]byte("cursor-repo")))
+	id := domain.HashContent([]byte("cursor-snapshot"))
+	local := domain.HashContent([]byte("cursor-local"))
+	remote := domain.HashContent([]byte("cursor-remote"))
+
+	if err := store.SaveRemoteSnapshotStateCursor(ctx, repoID, map[domain.ContentHash]domain.RemoteSnapshotStateCursorEntry{
+		id: {LocalState: local, RemoteState: remote},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	got, err := store.LoadRemoteSnapshotStateCursor(ctx, repoID)
+	if err != nil || len(got) != 1 || got[id].LocalState != local || got[id].RemoteState != remote {
+		t.Fatalf("cursor=%+v err=%v", got, err)
+	}
+
+	path, err := store.remoteSnapshotStateCursorPath(repoID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(`{"version":1,"repo_id":"wrong","entries":{}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.LoadRemoteSnapshotStateCursor(ctx, repoID); !errors.Is(err, domain.ErrHashMismatch) {
+		t.Fatalf("corrupt cursor error=%v", err)
+	}
+
+	if err := store.SaveRemoteSnapshotStateCursor(ctx, repoID, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Lstat(path); !os.IsNotExist(err) {
+		t.Fatalf("empty cursor file still exists: %v", err)
+	}
+}
+
+func TestRemoteSnapshotStateCursorRejectsSymlinkedDirectory(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".cxt"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(root, ".cxt", "remote-state-cursors")); err != nil {
+		t.Fatal(err)
+	}
+	store := NewFileStore(root)
+	repoID := string(domain.HashContent([]byte("symlink-cursor-repo")))
+	id := domain.HashContent([]byte("symlink-cursor-snapshot"))
+	err := store.SaveRemoteSnapshotStateCursor(context.Background(), repoID, map[domain.ContentHash]domain.RemoteSnapshotStateCursorEntry{
+		id: {LocalState: domain.HashContent([]byte("local")), RemoteState: domain.HashContent([]byte("remote"))},
+	})
+	if !errors.Is(err, domain.ErrHashMismatch) {
+		t.Fatalf("symlinked cursor directory error=%v", err)
+	}
+	entries, err := os.ReadDir(outside)
+	if err != nil || len(entries) != 0 {
+		t.Fatalf("cursor escaped .cxt: entries=%v err=%v", entries, err)
+	}
+}

--- a/cli/internal/app/sync_remote_state_cursor_test.go
+++ b/cli/internal/app/sync_remote_state_cursor_test.go
@@ -1,0 +1,183 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/wnsdy95/cxthub/cli/internal/adapters/storage"
+	"github.com/wnsdy95/cxthub/cli/internal/domain"
+	"github.com/wnsdy95/cxthub/cli/internal/ports/inbound"
+	"github.com/wnsdy95/cxthub/cli/internal/ports/outbound"
+)
+
+type remoteStateCursorRemote struct {
+	outbound.RemoteSync
+	snapshot domain.Snapshot
+	seen     []map[domain.ContentHash]domain.ContentHash
+}
+
+func (r *remoteStateCursorRemote) Pull(_ context.Context, _ string, states map[domain.ContentHash]domain.ContentHash, _ []domain.ContentHash) ([]domain.Snapshot, []domain.SessionDoc, []domain.Ref, error) {
+	copyStates := make(map[domain.ContentHash]domain.ContentHash, len(states))
+	for id, state := range states {
+		copyStates[id] = state
+	}
+	r.seen = append(r.seen, copyStates)
+	remoteState, err := domain.SnapshotStateHash(r.snapshot)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	if states[r.snapshot.ID] == remoteState {
+		return nil, nil, nil, nil
+	}
+	return []domain.Snapshot{r.snapshot}, nil, nil, nil
+}
+
+type remoteStateCursorFixture struct {
+	ctx    context.Context
+	repoID string
+	store  *storage.FileStore
+	remote *remoteStateCursorRemote
+	svc    *SyncRepoService
+	id     domain.ContentHash
+}
+
+func newRemoteStateCursorFixture(t *testing.T) remoteStateCursorFixture {
+	t.Helper()
+	ctx := context.Background()
+	repoID := string(domain.HashContent([]byte("remote-state-cursor-repo")))
+	doc := pullDoc(t, "local-ahead cursor snapshot")
+	store := storage.NewFileStore(t.TempDir())
+	if _, err := store.PutDoc(ctx, doc); err != nil {
+		t.Fatal(err)
+	}
+	remoteSnapshot := domain.Snapshot{ID: doc.Hash, DocHash: doc.Hash, RepoID: repoID, Branch: "main", Message: "recovery snapshot"}
+	localSnapshot := remoteSnapshot
+	localSnapshot.Grafted = true
+	localSnapshot.GraftParents = []domain.ContentHash{domain.HashContent([]byte("local recovery parent"))}
+	localSnapshot.GraftSeq = 1
+	if err := store.PutSnapshot(ctx, localSnapshot); err != nil {
+		t.Fatal(err)
+	}
+	remote := &remoteStateCursorRemote{snapshot: remoteSnapshot}
+	return remoteStateCursorFixture{
+		ctx: ctx, repoID: repoID, store: store, remote: remote,
+		svc: NewSyncRepoService(store, remote, nil), id: doc.Hash,
+	}
+}
+
+func (f remoteStateCursorFixture) pull(t *testing.T) inbound.SyncOutput {
+	t.Helper()
+	out, err := f.svc.Pull(f.ctx, inbound.SyncInput{RepoID: f.repoID, FetchOnly: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return out
+}
+
+func TestPullRemoteStateCursorSkipsRepeatedLocalAheadMetadata(t *testing.T) {
+	f := newRemoteStateCursorFixture(t)
+	if got := f.pull(t).Pulled; got != 1 {
+		t.Fatalf("first pull=%d snapshots, want 1", got)
+	}
+	if got := f.pull(t).Pulled; got != 0 {
+		t.Fatalf("second pull=%d snapshots, want 0", got)
+	}
+	local, err := f.store.GetSnapshot(f.ctx, f.id)
+	if err != nil || local.GraftSeq != 1 || len(local.GraftParents) != 1 {
+		t.Fatalf("local-ahead graft was not preserved: %+v err=%v", local, err)
+	}
+	entries, err := f.store.LoadRemoteSnapshotStateCursor(f.ctx, f.repoID)
+	if err != nil || len(entries) != 1 {
+		t.Fatalf("cursor=%+v err=%v", entries, err)
+	}
+}
+
+func TestPullRemoteStateCursorRefetchesRemoteAndLocalMutations(t *testing.T) {
+	t.Run("remote mutation", func(t *testing.T) {
+		f := newRemoteStateCursorFixture(t)
+		f.pull(t)
+		f.pull(t)
+
+		parentDoc := pullDoc(t, "new server graft parent")
+		if _, err := f.store.PutDoc(f.ctx, parentDoc); err != nil {
+			t.Fatal(err)
+		}
+		if err := f.store.PutSnapshot(f.ctx, domain.Snapshot{ID: parentDoc.Hash, DocHash: parentDoc.Hash, RepoID: f.repoID, Branch: "main"}); err != nil {
+			t.Fatal(err)
+		}
+		f.remote.snapshot.Grafted = true
+		f.remote.snapshot.GraftParents = []domain.ContentHash{parentDoc.Hash}
+		f.remote.snapshot.GraftSeq = 2
+		if got := f.pull(t).Pulled; got != 1 {
+			t.Fatalf("changed remote pull=%d snapshots, want 1", got)
+		}
+		local, err := f.store.GetSnapshot(f.ctx, f.id)
+		if err != nil || local.GraftSeq != 2 || len(local.GraftParents) != 1 || local.GraftParents[0] != parentDoc.Hash {
+			t.Fatalf("remote mutation not adopted: %+v err=%v", local, err)
+		}
+		if got := f.pull(t).Pulled; got != 0 {
+			t.Fatalf("settled remote pull=%d snapshots, want 0", got)
+		}
+	})
+
+	t.Run("local mutation", func(t *testing.T) {
+		f := newRemoteStateCursorFixture(t)
+		f.pull(t)
+		f.pull(t)
+
+		local, err := f.store.GetSnapshot(f.ctx, f.id)
+		if err != nil {
+			t.Fatal(err)
+		}
+		local.GraftSeq = 3
+		local.GraftParents = []domain.ContentHash{domain.HashContent([]byte("new local recovery parent"))}
+		if err := f.store.ReconcileGraftState(f.ctx, local); err != nil {
+			t.Fatal(err)
+		}
+		wantLocalState, err := domain.SnapshotStateHash(local)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := f.pull(t).Pulled; got != 1 {
+			t.Fatalf("changed local pull=%d snapshots, want 1", got)
+		}
+		if advertised := f.remote.seen[len(f.remote.seen)-1][f.id]; advertised != wantLocalState {
+			t.Fatalf("local mutation advertised cached remote state %s, want local %s", advertised, wantLocalState)
+		}
+		if got := f.pull(t).Pulled; got != 0 {
+			t.Fatalf("recached local-ahead pull=%d snapshots, want 0", got)
+		}
+	})
+}
+
+type failingRemoteStateCursorStore struct{ *storage.FileStore }
+
+func (s *failingRemoteStateCursorStore) LoadRemoteSnapshotStateCursor(context.Context, string) (map[domain.ContentHash]domain.RemoteSnapshotStateCursorEntry, error) {
+	return nil, errors.New("cursor unavailable")
+}
+
+func (s *failingRemoteStateCursorStore) SaveRemoteSnapshotStateCursor(context.Context, string, map[domain.ContentHash]domain.RemoteSnapshotStateCursorEntry) error {
+	return errors.New("cursor unavailable")
+}
+
+func TestPullRemoteStateCursorFailureIsFailOpen(t *testing.T) {
+	f := newRemoteStateCursorFixture(t)
+	store := &failingRemoteStateCursorStore{FileStore: f.store}
+	svc := NewSyncRepoService(store, f.remote, nil)
+	if _, err := svc.Pull(f.ctx, inbound.SyncInput{RepoID: f.repoID, FetchOnly: true}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPullRemoteStateCursorDoesNotAdvanceBeforeBatchValidation(t *testing.T) {
+	f := newRemoteStateCursorFixture(t)
+	f.remote.snapshot.RepoID = string(domain.HashContent([]byte("wrong cursor repo")))
+	if _, err := f.svc.Pull(f.ctx, inbound.SyncInput{RepoID: f.repoID, FetchOnly: true}); !errors.Is(err, domain.ErrHashMismatch) {
+		t.Fatalf("invalid pull error=%v", err)
+	}
+	entries, err := f.store.LoadRemoteSnapshotStateCursor(f.ctx, f.repoID)
+	if err != nil || len(entries) != 0 {
+		t.Fatalf("cursor advanced before validation: %+v err=%v", entries, err)
+	}
+}

--- a/cli/internal/app/sync_repo.go
+++ b/cli/internal/app/sync_repo.go
@@ -1070,6 +1070,93 @@ func (s *SyncRepoService) isAncestor(ctx context.Context, anc, desc domain.Conte
 	return false
 }
 
+// preparePullSnapshotStates overlays validated remote projection tokens on the
+// local manifest for snapshots whose local metadata intentionally remains
+// ahead. The cursor is only a negotiation hint: the current local state is the
+// guard, and any local mutation makes the cached remote token ineligible.
+func preparePullSnapshotStates(
+	ctx context.Context,
+	store outbound.SessionStore,
+	repoID string,
+	local map[domain.ContentHash]domain.ContentHash,
+) (
+	map[domain.ContentHash]domain.ContentHash,
+	outbound.RemoteSnapshotStateCursorStore,
+	map[domain.ContentHash]domain.RemoteSnapshotStateCursorEntry,
+) {
+	var advertised map[domain.ContentHash]domain.ContentHash
+	if local != nil {
+		advertised = make(map[domain.ContentHash]domain.ContentHash, len(local))
+		for id, state := range local {
+			advertised[id] = state
+		}
+	}
+
+	cursorStore, ok := store.(outbound.RemoteSnapshotStateCursorStore)
+	if !ok {
+		return advertised, nil, nil
+	}
+	active := map[domain.ContentHash]domain.RemoteSnapshotStateCursorEntry{}
+	if local == nil {
+		return advertised, cursorStore, active
+	}
+	loaded, err := cursorStore.LoadRemoteSnapshotStateCursor(ctx, repoID)
+	if err != nil {
+		// This sidecar is a disposable performance hint. Corruption, an old
+		// format, or an unavailable cache must degrade to the normal pull.
+		return advertised, cursorStore, active
+	}
+	for id, entry := range loaded {
+		current, exists := local[id]
+		if !exists || current != entry.LocalState {
+			continue
+		}
+		active[id] = entry
+		advertised[id] = entry.RemoteState
+	}
+	return advertised, cursorStore, active
+}
+
+// updateRemoteSnapshotStateCursor records only remote projections that were
+// returned, validated, and successfully reconciled locally. It runs after all
+// snapshot and memory writes. Cache failures never change pull correctness.
+func (s *SyncRepoService) updateRemoteSnapshotStateCursor(
+	ctx context.Context,
+	repoID string,
+	cursorStore outbound.RemoteSnapshotStateCursorStore,
+	entries map[domain.ContentHash]domain.RemoteSnapshotStateCursorEntry,
+	remoteSnapshots []domain.Snapshot,
+) {
+	if cursorStore == nil {
+		return
+	}
+	if entries == nil {
+		entries = map[domain.ContentHash]domain.RemoteSnapshotStateCursorEntry{}
+	}
+	for _, remote := range remoteSnapshots {
+		delete(entries, remote.ID)
+		remoteState, err := domain.SnapshotStateHash(remote)
+		if err != nil {
+			continue
+		}
+		local, err := s.store.GetSnapshot(ctx, remote.ID)
+		if err != nil {
+			continue
+		}
+		localState, err := domain.SnapshotStateHash(local)
+		if err != nil {
+			continue
+		}
+		if localState != remoteState {
+			entries[remote.ID] = domain.RemoteSnapshotStateCursorEntry{
+				LocalState:  localState,
+				RemoteState: remoteState,
+			}
+		}
+	}
+	_ = cursorStore.SaveRemoteSnapshotStateCursor(ctx, repoID, entries)
+}
+
 // Pull merges the snapshot/doc/ref from the central server into the local repository (fast-forward first).
 func (s *SyncRepoService) Pull(ctx context.Context, in inbound.SyncInput) (inbound.SyncOutput, error) {
 	repoID, err := s.repoID(ctx, in)
@@ -1093,7 +1180,8 @@ func (s *SyncRepoService) Pull(ctx context.Context, in inbound.SyncInput) (inbou
 			}
 		}
 	}
-	snaps, docs, refs, err := s.remote.Pull(ctx, repoID, snapshotStates, docHaves)
+	advertisedSnapshotStates, cursorStore, cursorEntries := preparePullSnapshotStates(ctx, s.store, repoID, snapshotStates)
+	snaps, docs, refs, err := s.remote.Pull(ctx, repoID, advertisedSnapshotStates, docHaves)
 	if err != nil {
 		return inbound.SyncOutput{}, err
 	}
@@ -1294,6 +1382,7 @@ func (s *SyncRepoService) Pull(ctx context.Context, in inbound.SyncInput) (inbou
 			}
 		}
 	}
+	s.updateRemoteSnapshotStateCursor(ctx, repoID, cursorStore, cursorEntries, snaps)
 	// FetchOnly (hook auto-pull): fetch objects only, local refs do not move — context does not force convergence unlike code. Instead, report remote branch ahead hint (pull is user choice).
 	if in.FetchOnly {
 		var ahead []string

--- a/cli/internal/domain/entities.go
+++ b/cli/internal/domain/entities.go
@@ -456,6 +456,15 @@ type Manifest struct {
 	UpdatedAt time.Time `json:"updated_at"`
 }
 
+// RemoteSnapshotStateCursorEntry is a local performance hint for a snapshot
+// whose mutable projection intentionally differs from the last validated
+// server projection. RemoteState may be advertised only while LocalState still
+// matches the current local snapshot token; any local mutation invalidates it.
+type RemoteSnapshotStateCursorEntry struct {
+	LocalState  ContentHash `json:"local_state"`
+	RemoteState ContentHash `json:"remote_state"`
+}
+
 // StashEntry is an item in the stash stack (git stash equivalent).
 // Temporarily stores the active session outside the branch history — snapshot objects are stored content-addressed but
 // do not point to any branch ref (excluding push targets), and stack order is managed by .cxt/stash.json.

--- a/cli/internal/ports/outbound/ports.go
+++ b/cli/internal/ports/outbound/ports.go
@@ -92,6 +92,14 @@ type SessionStore interface {
 	GetMemory(ctx context.Context, hash domain.ContentHash) (domain.MemoryDigest, error)
 }
 
+// RemoteSnapshotStateCursorStore persists optional pull negotiation hints.
+// It is deliberately separate from SessionStore: cursors never alter local
+// snapshot truth, refs, reachability, or push negotiation.
+type RemoteSnapshotStateCursorStore interface {
+	LoadRemoteSnapshotStateCursor(ctx context.Context, repoID string) (map[domain.ContentHash]domain.RemoteSnapshotStateCursorEntry, error)
+	SaveRemoteSnapshotStateCursor(ctx context.Context, repoID string, entries map[domain.ContentHash]domain.RemoteSnapshotStateCursorEntry) error
+}
+
 // ProviderCodec is a codec for provider raw JSONL ↔ CIR bidirectional transformation (domain model).
 //
 // Decode: claude/codex JSONL → CIR (provider-independent).

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -337,6 +337,11 @@ Downloads objects and refs from `origin`.
   remote memory pointer. The losing immutable local memory object and raw
   session remain stored; run `cxt memorize` again to project that session onto
   the selected remote lineage.
+- If validated server metadata intentionally remains behind a local snapshot,
+  cxt keeps a guarded local cursor so later pulls do not download that same
+  projection forever. The cursor is only a disposable negotiation hint: a
+  local or remote metadata change invalidates it, and it never participates in
+  refs, reachability, or push state.
 
 Review local work before using `--force`.
 


### PR DESCRIPTION
## Root cause

A snapshot can intentionally keep a newer local mutable projection, such as a recovery graft, while the server retains an older projection for the same content ID. Pull correctly preserves the higher local graft sequence, but the next process advertises that local token again, so the server retransmits the same snapshot forever.

## Fix

- persist only divergent `(guarded local token, validated remote token)` pairs in a repo-bound local sidecar
- advertise the remote token only while the current local token still matches its guard
- refresh the pair only after the returned batch validates and all local snapshot/memory writes succeed
- invalidate naturally on either local or remote metadata changes
- keep the cursor outside refs, reachability, snapshot truth, and push negotiation
- degrade to ordinary pull on missing, malformed, unsupported, or unwritable cursor state

## Verification

- local-ahead first pull returns 1 snapshot and the second returns 0
- remote mutation is fetched and adopted, then settles at 0
- local mutation invalidates the cursor, refetches once, then settles at 0
- invalid response cannot advance the cursor
- cursor read/write failure is fail-open
- symlink escape is rejected
- `go test ./...`, `go vet ./...`, and `go test -race ./...`
- `scripts/e2e.sh`, `scripts/e2e-sync.sh`, and `scripts/public-preflight.sh`

Closes #82