### PR TITLE
fix(seed): preserve trimmed post-compaction context

### DIFF
--- a/cli/internal/app/branch_seed.go
+++ b/cli/internal/app/branch_seed.go
@@ -129,26 +129,18 @@ func (s *BranchSeedService) Seed(ctx context.Context, in inbound.SeedInput) (inb
 	branchMem = domain.MergeDigests(domain.MemoryDigest{}, branchMem)
 
 	// Seed CIR synthesis: [Layer1⊕Layer2 summary message] + [Layer3 bounded
-	// full session]. The summary has a fixed maximum, and the exact encoded
-	// summary size is subtracted from the shared seed budget before selecting
-	// the recent user-boundary-aligned conversation tail.
+	// full session]. Any semantic events cut from Layer3 become a bounded bridge
+	// digest before the final prompt is accepted. Without that bridge, a source
+	// with an older provider compaction summary silently loses post-compaction
+	// work between the summary and the retained tail (#84).
 	now := time.Now().UTC().Format(time.RFC3339)
 	seedSession := providerfs.NewSessionID()
-	totalBudget, digestBudget := seedBudgets(provider)
-	seedText := renderSeedText(in.FromBranch, in.NewBranch, mainMem, branchMem, digestBudget)
-	summaryEvent := domain.Event{
-		Kind: domain.EventMessage, Role: "user", Ts: now, Seq: 0,
-		Blocks: []domain.ContentBlock{{Type: "text", Text: seedText}},
-	}
-	conversationBudget := totalBudget - eventsJSONBytes([]domain.Event{summaryEvent})
-	if conversationBudget < 0 {
-		conversationBudget = 0
-	}
-	trimmedConversation, _ := trimEventsForSeed(seedConversationContext(branchContext), conversationBudget)
-	events := []domain.Event{summaryEvent}
-	for i, ev := range trimmedConversation.Events {
-		ev.Seq = i + 1
-		events = append(events, ev)
+	events, seedBranchMemory, err := s.buildBranchSeedEvents(
+		ctx, provider, in.FromBranch, in.NewBranch, now, fromSnap.ID,
+		mainMem, branchMem, seedConversationContext(branchContext),
+	)
+	if err != nil {
+		return inbound.SeedOutput{}, err
 	}
 	cir := domain.CIRDocument{Events: events}
 	cir.Envelope = fromDoc.CIR.Envelope // Inherit model, cwd, etc.
@@ -187,9 +179,9 @@ func (s *BranchSeedService) Seed(ctx context.Context, in inbound.SeedInput) (inb
 	// it rather than re-distilling the truncated summary event. The carried
 	// copy is bounded (#33 — newest tail); older generations stay reachable
 	// through the parent chain's memory objects.
-	seedMemory := branchMem
+	seedMemory := seedBranchMemory
 	if mainMem != nil {
-		seedMemory = domain.MergeDigests(boundCarriedDigest(*mainMem), branchMem)
+		seedMemory = domain.MergeDigests(boundCarriedDigest(*mainMem), seedBranchMemory)
 	}
 	seedMemory.SnapshotID = docHash
 	// A seed is a new snapshot, so its first attachment is a causal root even
@@ -232,6 +224,70 @@ func (s *BranchSeedService) Seed(ctx context.Context, in inbound.SeedInput) (inb
 		}
 	}
 	return out, nil
+}
+
+// buildBranchSeedEvents partitions the source conversation into a bridge
+// distilled from the exact omitted slice and a verbatim recent tail. Rendering the bridge can enlarge
+// the summary event, so the loop only moves the cut forward until the final
+// encoded event list fits; it never re-expands a tail and therefore converges
+// after at most one pass per source event.
+func (s *BranchSeedService) buildBranchSeedEvents(
+	ctx context.Context,
+	provider domain.ProviderKind,
+	from, to, now string,
+	sourceSnapshot domain.ContentHash,
+	mainMemory *domain.MemoryDigest,
+	branchMemory domain.MemoryDigest,
+	conversation domain.CIRDocument,
+) ([]domain.Event, domain.MemoryDigest, error) {
+	totalBudget, digestBudget := seedBudgets(provider)
+	promptMemory := branchMemory
+	maxConversationBudget := totalBudget
+	for attempt := 0; attempt <= len(conversation.Events)+1; attempt++ {
+		seedText := renderSeedText(from, to, mainMemory, promptMemory, digestBudget)
+		summaryEvent := domain.Event{
+			Kind: domain.EventMessage, Role: "user", Ts: now, Seq: 0,
+			Blocks: []domain.ContentBlock{{Type: "text", Text: seedText}},
+		}
+		conversationBudget := totalBudget - eventsJSONBytes([]domain.Event{summaryEvent})
+		if conversationBudget < 0 {
+			conversationBudget = 0
+		}
+		if conversationBudget > maxConversationBudget {
+			conversationBudget = maxConversationBudget
+		} else {
+			maxConversationBudget = conversationBudget
+		}
+		trimmed, omitted := trimEventsForSeed(conversation, conversationBudget)
+
+		mergedMemory := branchMemory
+		if len(omitted) > 0 {
+			omittedCIR := conversation
+			omittedCIR.Events = append([]domain.Event(nil), omitted...)
+			bridge, err := s.distiller.Distill(ctx, omittedCIR, nil)
+			if err != nil {
+				return nil, domain.MemoryDigest{}, err
+			}
+			bridge.SnapshotID = sourceSnapshot
+			mergedMemory = domain.MergeDigests(branchMemory, bridge)
+		}
+
+		// The bridge itself changes the summary size. Re-render before checking
+		// the actual wire-shaped event budget; if it grew, the next pass trims
+		// only more verbatim events and includes them in a new bridge.
+		seedText = renderSeedText(from, to, mainMemory, mergedMemory, digestBudget)
+		summaryEvent.Blocks[0].Text = seedText
+		events := []domain.Event{summaryEvent}
+		for i, event := range trimmed.Events {
+			event.Seq = i + 1
+			events = append(events, event)
+		}
+		if eventsJSONBytes(events) <= totalBudget {
+			return events, mergedMemory, nil
+		}
+		promptMemory = mergedMemory
+	}
+	return nil, domain.MemoryDigest{}, fmt.Errorf("branch seed context did not converge within %d bytes", totalBudget)
 }
 
 // seedConversationContext keeps only the human/agent conversation needed by a

--- a/cli/internal/app/branch_seed_inheritance_test.go
+++ b/cli/internal/app/branch_seed_inheritance_test.go
@@ -2,9 +2,11 @@ package app
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
+	"github.com/wnsdy95/cxthub/cli/internal/adapters/memory"
 	"github.com/wnsdy95/cxthub/cli/internal/adapters/storage"
 	"github.com/wnsdy95/cxthub/cli/internal/domain"
 	"github.com/wnsdy95/cxthub/cli/internal/ports/inbound"
@@ -22,7 +24,7 @@ func putBranchSeedSnapshot(
 	t.Helper()
 	docHash, err := store.PutDoc(ctx, domain.SessionDoc{CIR: domain.CIRDocument{
 		Envelope: domain.Envelope{
-			CIRVersion:     "1",
+			CIRVersion:     domain.CIRVersionForEvents(events),
 			SourceProvider: domain.ProviderCodex,
 			GitBranch:      branch,
 			Fidelity:       domain.FidelityFull,
@@ -54,6 +56,130 @@ func putBranchSeedSnapshot(
 		t.Fatalf("put snapshot: %v", err)
 	}
 	return docHash
+}
+
+func TestBranchSeedSummarizesTrimmedPostCompactionConversation(t *testing.T) {
+	ctx := context.Background()
+	store := storage.NewFileStore(t.TempDir())
+	repo := domain.Repo{ID: "repo-post-compaction-bridge", DefaultBranch: "main", LocalPath: t.TempDir()}
+	const (
+		compactBase = "PROVIDER COMPACT BASELINE MUST SURVIVE"
+		middle      = "MIDDLE POST-COMPACTION DECISION MUST SURVIVE"
+		latest      = "LATEST POST-COMPACTION REQUEST MUST SURVIVE"
+	)
+	events := []domain.Event{{
+		Kind: domain.EventMessage, Role: "user", Seq: 0, CompactSummary: true,
+		Blocks: []domain.ContentBlock{{Type: "text", Text: compactBase}},
+	}}
+	for i := 0; i < 20; i++ {
+		user := fmt.Sprintf("post-compaction request %02d %s", i, strings.Repeat("u", 16<<10))
+		if i == 10 {
+			user = middle + " " + strings.Repeat("m", 16<<10)
+		}
+		if i == 19 {
+			user = latest + " " + strings.Repeat("l", 16<<10)
+		}
+		events = append(events,
+			seedMessage("user", user, len(events)),
+			seedMessage("assistant", fmt.Sprintf("post-compaction answer %02d %s", i, strings.Repeat("a", 16<<10)), len(events)+1),
+		)
+	}
+
+	head := putBranchSeedSnapshot(t, ctx, store, repo.ID, "main", events, nil, nil)
+	putBranchSeedRef(t, ctx, store, repo.ID, "main", head)
+	service := NewBranchSeedService(
+		branchSeedGit{repo: repo}, store, memory.NewRuleDistiller(), nil, nil,
+	)
+	out, err := service.Seed(ctx, inbound.SeedInput{
+		Cwd: repo.LocalPath, FromBranch: "main", NewBranch: "feature/post-compaction-bridge", Provider: domain.ProviderCodex,
+	})
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	seed, err := store.GetDoc(ctx, out.SnapshotID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	totalBudget, _ := seedBudgets(domain.ProviderCodex)
+	if got := eventsJSONBytes(seed.CIR.Events); got > totalBudget {
+		t.Fatalf("seed events = %d bytes, want <= %d", got, totalBudget)
+	}
+	var prompt strings.Builder
+	middleIsVerbatim := false
+	for i, event := range seed.CIR.Events {
+		for _, block := range event.Blocks {
+			prompt.WriteString(block.Text)
+			if i > 0 && strings.Contains(block.Text, middle) {
+				middleIsVerbatim = true
+			}
+		}
+	}
+	if middleIsVerbatim {
+		t.Fatal("fixture did not trim the middle post-compaction decision")
+	}
+	if !strings.Contains(seed.CIR.Events[0].Blocks[0].Text, middle) {
+		t.Fatal("trimmed post-compaction decision was not bridged into the summary layer")
+	}
+	if strings.Contains(seed.CIR.Events[0].Blocks[0].Text, latest) {
+		t.Fatal("verbatim latest request was redundantly copied into the bridge summary")
+	}
+	for _, want := range []string{compactBase, middle, latest} {
+		if !strings.Contains(prompt.String(), want) {
+			t.Fatalf("branch seed prompt lost %q", want)
+		}
+	}
+	if count := strings.Count(prompt.String(), latest); count != 1 {
+		t.Fatalf("latest request appears %d times, want one verbatim copy", count)
+	}
+	seedSnapshot, err := store.GetSnapshot(ctx, out.SnapshotID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	seedMemory, err := store.GetMemory(ctx, seedSnapshot.MemoryHash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(seedMemory.Summary, middle) {
+		t.Fatal("branch seed memory lost the trimmed post-compaction decision")
+	}
+}
+
+type failBridgeDistiller struct{ calls int }
+
+func (d *failBridgeDistiller) Distill(context.Context, domain.CIRDocument, *domain.NativeMemory) (domain.MemoryDigest, error) {
+	d.calls++
+	if d.calls > 1 {
+		return domain.MemoryDigest{}, fmt.Errorf("bridge distillation failed")
+	}
+	return domain.MemoryDigest{Summary: "fresh branch memory", Provider: domain.ProviderCodex}, nil
+}
+
+func TestBranchSeedBridgeFailureDoesNotCreateLossyBranch(t *testing.T) {
+	ctx := context.Background()
+	store := storage.NewFileStore(t.TempDir())
+	repo := domain.Repo{ID: "repo-bridge-fail-closed", DefaultBranch: "main", LocalPath: t.TempDir()}
+	var events []domain.Event
+	for i := 0; i < 20; i++ {
+		events = append(events,
+			seedMessage("user", strings.Repeat("large request ", 1400), len(events)),
+			seedMessage("assistant", strings.Repeat("large answer ", 1400), len(events)+1),
+		)
+	}
+	head := putBranchSeedSnapshot(t, ctx, store, repo.ID, "main", events, nil, &domain.MemoryDigest{
+		Summary: "stored project memory", Provider: domain.ProviderCodex,
+	})
+	putBranchSeedRef(t, ctx, store, repo.ID, "main", head)
+	distiller := &failBridgeDistiller{}
+	service := NewBranchSeedService(branchSeedGit{repo: repo}, store, distiller, nil, nil)
+	_, err := service.Seed(ctx, inbound.SeedInput{
+		Cwd: repo.LocalPath, FromBranch: "main", NewBranch: "feature/bridge-failure", Provider: domain.ProviderCodex,
+	})
+	if err == nil || !strings.Contains(err.Error(), "bridge distillation failed") {
+		t.Fatalf("seed error=%v", err)
+	}
+	if _, err := store.GetRef(ctx, repo.ID, domain.RefBranch, "feature/bridge-failure"); err == nil {
+		t.Fatal("lossy branch ref was created after bridge distillation failed")
+	}
 }
 
 func putBranchSeedRef(

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -243,9 +243,12 @@ ref. Git checkout hooks normally invoke the corresponding behavior
 automatically. A new branch seed carries the main head's compact memory plus
 the departure branch head's session conversation. Conversations that fit are
 preserved in full; larger sessions keep a bounded recent tail starting at a
-user-turn boundary. The prompt copy is bounded independently; the complete
-untruncated merged memory remains attached to the seed snapshot for future
-memorize and branch operations.
+user-turn boundary and distill the exact omitted slice into a bounded bridge.
+That bridge is merged with the inherited compact/project memory, so work after
+an older provider compaction does not disappear between the summary and recent
+tail. The source snapshot remains immutable and reachable; the inherited
+memory plus bridge is attached to the seed for future memorize and branch
+operations without enlarging the provider prompt budget.
 
 ### `cxt switch`
 


### PR DESCRIPTION
## Root cause

Branch seed creation distilled the full source before trimming its provider-visible conversation, then discarded `trimEventsForSeed` omitted events. When an agent-written compact summary existed, the distiller correctly selected that older summary and ignored ordinary messages written after the compaction. Once those later messages exceeded the seed budget, the new branch contained the compact baseline and newest tail but silently lost the trimmed segment between them.

## Fix

- distill a bounded bridge from the exact semantic slice omitted from the verbatim tail
- merge the bridge with existing project/lineage memory using snapshot fragment provenance
- attach the bridge to seed memory so later memorize/branch operations retain it
- re-render the summary and monotonically reduce the tail until the actual encoded event list fits the existing provider budget
- keep the newest request only as verbatim context rather than duplicating it in the bridge
- fail before creating the seed doc/ref if bridge distillation fails
- keep source snapshots immutable and reachable

The Codex/Claude prompt budgets are unchanged; increasing them would only postpone the loss and increase compaction pressure.

## Regression proof

The new test first reproduced the failure: an oversized post-compaction session kept the provider compact baseline and latest request but lost a marked middle decision. It now proves all three survive, the middle decision is summary-only, the latest request appears once, the seed stays within budget, and attached seed memory carries the bridge.

## Verification

- `go test ./...`
- `go vet ./...`
- `go test -race ./...`
- `scripts/e2e.sh`
- `scripts/e2e-sync.sh`
- `scripts/public-preflight.sh`

Closes #84