### PR TITLE
fix(memory): preserve post-compaction conversation

### DIFF
--- a/cli/internal/adapters/memory/distiller.go
+++ b/cli/internal/adapters/memory/distiller.go
@@ -12,7 +12,10 @@ import (
 
 // RuleDistiller is the deterministic, rule-based MemoryDistiller implementation (compatibility rules).
 //
-// Native-first with fallback: if native is non-nil, ingest its content; otherwise derive summaries and facts from CIR. The same (cir, native) pair always produces the same digest.
+// A provider compact summary or native memory is the long-term baseline. The
+// meaningful conversation accumulated after that baseline is retained as a
+// deterministic bounded delta. The same (cir, native) pair always produces
+// the same digest.
 type RuleDistiller struct{}
 
 // NewRuleDistiller creates a RuleDistiller.
@@ -20,17 +23,22 @@ func NewRuleDistiller() *RuleDistiller { return &RuleDistiller{} }
 
 // Distill generates a MemoryDigest from CIR(+native). Deterministic.
 //
-// Summary source priority:
-//  1. The agent's latest context-compression summary (Claude isCompactSummary / Codex compacted.message). These summaries are cumulative and provide the highest-quality source.
+// Summary baseline priority:
+//  1. The agent's latest context-compression summary (Claude isCompactSummary / Codex compacted.message).
 //  2. Native memory ingestion (memory file created by the provider CLI).
 //  3. Rules-based self-distillation (statistical summary — fallback).
+//
+// Baselines do not replace later conversation. A bounded extractive delta is
+// appended after the latest valid compaction summary, or after native memory
+// when no valid provider summary exists.
 func (d *RuleDistiller) Distill(_ context.Context, cir domain.CIRDocument, native *domain.NativeMemory) (domain.MemoryDigest, error) {
 	prov := cir.Envelope.SourceProvider
 	compactSummary := ""
+	compactSummaryAt := -1
 	var userMsgs, asstMsgs int
 	firstUser := ""
 	toolSet := map[string]struct{}{}
-	for _, ev := range cir.Events {
+	for i, ev := range cir.Events {
 		switch ev.Kind {
 		case domain.EventMessage:
 			if ev.CompactSummary && len(ev.Blocks) > 0 && ev.Blocks[0].Text != "" &&
@@ -40,6 +48,7 @@ func (d *RuleDistiller) Distill(_ context.Context, cir domain.CIRDocument, nativ
 				// boilerplate and mislabel it as agent-written (#38).
 				!containsSyntheticSeedText(ev.Blocks[0].Text) {
 				compactSummary = ev.Blocks[0].Text // last wins: newest cumulative summary
+				compactSummaryAt = i
 			}
 			if ev.Role == "user" {
 				userMsgs++
@@ -69,11 +78,12 @@ func (d *RuleDistiller) Distill(_ context.Context, cir domain.CIRDocument, nativ
 			facts = tools // unstructured summary (different format) — maintain existing fallback
 		}
 		// Source marker ("native memory: …") is not added to KeyFacts — native memory is loaded by agent at session start (review P2).
+		suffix := extractiveConversationDigest(cir.Events[compactSummaryAt+1:])
 		return domain.MemoryDigest{
 			// Provider-written compaction memory is already the authoritative
 			// distilled state. Keep it byte-for-byte in the immutable digest;
 			// seed and instruction-file renderers apply their own prompt budgets.
-			Summary:  compactSummary,
+			Summary:  domain.AppendExtractiveConversationDelta(compactSummary, suffix),
 			KeyFacts: facts,
 			// When structure extraction succeeds, this list becomes the merge authority (parent completion not inherited).
 			OpenTasks:          tasks,
@@ -82,9 +92,10 @@ func (d *RuleDistiller) Distill(_ context.Context, cir domain.CIRDocument, nativ
 		}, nil
 	}
 	if native != nil {
-		// Native-first ingestion (no compression summary).
+		// Native memory is a baseline, not a replacement for work performed in
+		// the current session after that file was loaded.
 		return domain.MemoryDigest{
-			Summary:  native.Text,
+			Summary:  domain.AppendExtractiveConversationDelta(native.Text, extractiveConversationDigest(cir.Events)),
 			KeyFacts: []string{"ingested from " + native.Source},
 			Provider: prov,
 		}, nil

--- a/cli/internal/adapters/memory/distiller_test.go
+++ b/cli/internal/adapters/memory/distiller_test.go
@@ -141,6 +141,54 @@ func TestDistillPreservesFullAgentCompactionSummary(t *testing.T) {
 	}
 }
 
+func TestDistillPreservesConversationAfterLatestCompactionSummary(t *testing.T) {
+	cir := domain.CIRDocument{Envelope: domain.Envelope{SourceProvider: domain.ProviderClaude}, Events: []domain.Event{
+		{Kind: domain.EventMessage, Role: "user", Blocks: []domain.ContentBlock{{Type: "text", Text: "ARCHIVAL TURN BEFORE COMPACTION"}}},
+		{Kind: domain.EventMessage, Role: "user", CompactSummary: true, Blocks: []domain.ContentBlock{{Type: "text", Text: "PROVIDER COMPACT BASELINE"}}},
+		{Kind: domain.EventMessage, Role: "user", Blocks: []domain.ContentBlock{{Type: "text", Text: "POST-COMPACTION DECISION"}}},
+		{Kind: domain.EventMessage, Role: "assistant", Blocks: []domain.ContentBlock{{Type: "text", Text: "POST-COMPACTION OUTCOME"}}},
+	}}
+
+	d, err := NewRuleDistiller().Distill(context.Background(), cir, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"PROVIDER COMPACT BASELINE", "POST-COMPACTION DECISION", "POST-COMPACTION OUTCOME"} {
+		if !strings.Contains(d.Summary, want) {
+			t.Fatalf("distilled memory lost %q:\n%s", want, d.Summary)
+		}
+	}
+	if strings.Contains(d.Summary, "ARCHIVAL TURN BEFORE COMPACTION") {
+		t.Fatalf("distilled memory resurrected context replaced by the provider:\n%s", d.Summary)
+	}
+}
+
+func TestDistillPreservesConversationAlongsideNativeMemory(t *testing.T) {
+	cir := domain.CIRDocument{Envelope: domain.Envelope{SourceProvider: domain.ProviderClaude}, Events: []domain.Event{
+		{Kind: domain.EventMessage, Role: "user", Blocks: []domain.ContentBlock{{Type: "text", Text: "CURRENT SESSION DECISION"}}},
+		{Kind: domain.EventMessage, Role: "assistant", Blocks: []domain.ContentBlock{{Type: "text", Text: "CURRENT SESSION RESULT"}}},
+	}}
+	native := &domain.NativeMemory{Source: "claude:MEMORY.md", Text: "NATIVE PROJECT BASELINE"}
+
+	d, err := NewRuleDistiller().Distill(context.Background(), cir, native)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"NATIVE PROJECT BASELINE", "CURRENT SESSION DECISION", "CURRENT SESSION RESULT"} {
+		if !strings.Contains(d.Summary, want) {
+			t.Fatalf("distilled native memory lost %q:\n%s", want, d.Summary)
+		}
+	}
+
+	empty, err := NewRuleDistiller().Distill(context.Background(), domain.CIRDocument{}, native)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if empty.Summary != native.Text {
+		t.Fatalf("native-only memory changed: got %q want %q", empty.Summary, native.Text)
+	}
+}
+
 // TestDistillNoProvenanceMarkerInFacts ensures that the source marker ("native memory: …") does not mix with KeyFacts — the source is not a fact (review P2). Native memory is loaded by the agent at session start, so it has no information value.
 func TestDistillNoProvenanceMarkerInFacts(t *testing.T) {
 	cir := domain.CIRDocument{}

--- a/cli/internal/app/branch_seed.go
+++ b/cli/internal/app/branch_seed.go
@@ -98,6 +98,7 @@ func (s *BranchSeedService) Seed(ctx context.Context, in inbound.SeedInput) (inb
 		if mainMem == nil && mainDocAvailable {
 			if d, derr := s.distiller.Distill(ctx, mainDoc.CIR.EffectiveContext(), nil); derr == nil {
 				d.SnapshotID = mainSnap.ID
+				d = domain.MergeDigests(domain.MemoryDigest{}, d)
 				if prior, ok := priorMemoryProjection(ctx, s.store, mainSnap); ok {
 					prior = boundCarriedDigest(prior)
 					d = domain.MergeDigests(prior, d)
@@ -109,11 +110,17 @@ func (s *BranchSeedService) Seed(ctx context.Context, in inbound.SeedInput) (inb
 
 	// Layer 2: departure branch on-the-fly distillation (+ ancestor inheritance) — always fresh without relying on stored digest.
 	branchContext := fromDoc.CIR.EffectiveContext()
-	branchMem, err := s.distiller.Distill(ctx, branchContext, nil)
+	freshBranchMem, err := s.distiller.Distill(ctx, branchContext, nil)
 	if err != nil {
 		return inbound.SeedOutput{}, err
 	}
-	branchMem.SnapshotID = fromSnap.ID
+	freshBranchMem.SnapshotID = fromSnap.ID
+	// The source conversation is replayed verbatim below. Keep its compact/native
+	// baseline in the prompt, but not the canonical current-conversation delta.
+	// The full fresh digest is still attached to the seed snapshot.
+	promptFreshBranchMem := domain.WithoutConversationDeltaFromSource(freshBranchMem, fromSnap.ID)
+	branchMem := freshBranchMem
+	promptBranchMem := promptFreshBranchMem
 	branchState, prior, hasBranchPrior, branchProjectionComplete, err := stablePriorMemoryProjection(ctx, s.store, fromSnap.ID)
 	if err != nil {
 		return inbound.SeedOutput{}, err
@@ -122,11 +129,18 @@ func (s *BranchSeedService) Seed(ctx context.Context, in inbound.SeedInput) (inb
 	if hasBranchPrior {
 		prior = boundCarriedDigest(prior)
 		branchMem = domain.MergeDigests(prior, branchMem)
+		promptBranchMem = domain.MergeDigests(prior, promptBranchMem)
 	}
 	// Preserve the departure snapshot as provenance even when it had no prior
 	// digest. The seed changes SnapshotID below, but inherited fragments must
 	// keep identifying their actual source for future stale-lineage repair.
 	branchMem = domain.MergeDigests(domain.MemoryDigest{}, branchMem)
+	promptBranchMem = domain.MergeDigests(domain.MemoryDigest{}, promptBranchMem)
+	mainPromptMem := mainMem
+	if mainPromptMem != nil && mainBranch == in.FromBranch {
+		promptCopy := domain.WithoutConversationDeltaFromSource(*mainPromptMem, fromSnap.ID)
+		mainPromptMem = &promptCopy
+	}
 
 	// Seed CIR synthesis: [Layer1⊕Layer2 summary message] + [Layer3 bounded
 	// full session]. Any semantic events cut from Layer3 become a bounded bridge
@@ -137,7 +151,7 @@ func (s *BranchSeedService) Seed(ctx context.Context, in inbound.SeedInput) (inb
 	seedSession := providerfs.NewSessionID()
 	events, seedBranchMemory, err := s.buildBranchSeedEvents(
 		ctx, provider, in.FromBranch, in.NewBranch, now, fromSnap.ID,
-		mainMem, branchMem, seedConversationContext(branchContext),
+		mainPromptMem, promptBranchMem, branchMem, seedConversationContext(branchContext),
 	)
 	if err != nil {
 		return inbound.SeedOutput{}, err
@@ -237,11 +251,12 @@ func (s *BranchSeedService) buildBranchSeedEvents(
 	from, to, now string,
 	sourceSnapshot domain.ContentHash,
 	mainMemory *domain.MemoryDigest,
-	branchMemory domain.MemoryDigest,
+	promptBranchMemory domain.MemoryDigest,
+	storedBranchMemory domain.MemoryDigest,
 	conversation domain.CIRDocument,
 ) ([]domain.Event, domain.MemoryDigest, error) {
 	totalBudget, digestBudget := seedBudgets(provider)
-	promptMemory := branchMemory
+	promptMemory := promptBranchMemory
 	maxConversationBudget := totalBudget
 	for attempt := 0; attempt <= len(conversation.Events)+1; attempt++ {
 		seedText := renderSeedText(from, to, mainMemory, promptMemory, digestBudget)
@@ -260,7 +275,8 @@ func (s *BranchSeedService) buildBranchSeedEvents(
 		}
 		trimmed, omitted := trimEventsForSeed(conversation, conversationBudget)
 
-		mergedMemory := branchMemory
+		mergedPromptMemory := promptBranchMemory
+		mergedStoredMemory := storedBranchMemory
 		if len(omitted) > 0 {
 			omittedCIR := conversation
 			omittedCIR.Events = append([]domain.Event(nil), omitted...)
@@ -269,13 +285,14 @@ func (s *BranchSeedService) buildBranchSeedEvents(
 				return nil, domain.MemoryDigest{}, err
 			}
 			bridge.SnapshotID = sourceSnapshot
-			mergedMemory = domain.MergeDigests(branchMemory, bridge)
+			mergedPromptMemory = domain.MergeDigests(promptBranchMemory, bridge)
+			mergedStoredMemory = domain.MergeDigests(storedBranchMemory, bridge)
 		}
 
 		// The bridge itself changes the summary size. Re-render before checking
 		// the actual wire-shaped event budget; if it grew, the next pass trims
 		// only more verbatim events and includes them in a new bridge.
-		seedText = renderSeedText(from, to, mainMemory, mergedMemory, digestBudget)
+		seedText = renderSeedText(from, to, mainMemory, mergedPromptMemory, digestBudget)
 		summaryEvent.Blocks[0].Text = seedText
 		events := []domain.Event{summaryEvent}
 		for i, event := range trimmed.Events {
@@ -283,9 +300,9 @@ func (s *BranchSeedService) buildBranchSeedEvents(
 			events = append(events, event)
 		}
 		if eventsJSONBytes(events) <= totalBudget {
-			return events, mergedMemory, nil
+			return events, mergedStoredMemory, nil
 		}
-		promptMemory = mergedMemory
+		promptMemory = mergedPromptMemory
 	}
 	return nil, domain.MemoryDigest{}, fmt.Errorf("branch seed context did not converge within %d bytes", totalBudget)
 }

--- a/cli/internal/app/branch_seed_inheritance_test.go
+++ b/cli/internal/app/branch_seed_inheritance_test.go
@@ -144,6 +144,67 @@ func TestBranchSeedSummarizesTrimmedPostCompactionConversation(t *testing.T) {
 	}
 }
 
+func TestBranchSeedDoesNotDuplicateCurrentConversationInSummary(t *testing.T) {
+	ctx := context.Background()
+	store := storage.NewFileStore(t.TempDir())
+	repo := domain.Repo{ID: "repo-seed-no-current-dup", DefaultBranch: "main", LocalPath: t.TempDir()}
+	events := []domain.Event{
+		{Kind: domain.EventMessage, Role: "user", Seq: 0, CompactSummary: true, Blocks: []domain.ContentBlock{{Type: "text", Text: "BRANCH PROVIDER BASELINE"}}},
+		seedMessage("user", "BRANCH CURRENT DECISION ONCE", 1),
+		seedMessage("assistant", "BRANCH CURRENT RESULT ONCE", 2),
+	}
+	fullMemory, err := memory.NewRuleDistiller().Distill(context.Background(), domain.CIRDocument{
+		Envelope: domain.Envelope{SourceProvider: domain.ProviderCodex}, Events: events,
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	head := putBranchSeedSnapshot(t, ctx, store, repo.ID, "main", events, nil, &fullMemory)
+	putBranchSeedRef(t, ctx, store, repo.ID, "main", head)
+	service := NewBranchSeedService(branchSeedGit{repo: repo}, store, memory.NewRuleDistiller(), nil, nil)
+
+	out, err := service.Seed(ctx, inbound.SeedInput{
+		Cwd: repo.LocalPath, FromBranch: "main", NewBranch: "feature/no-current-dup", Provider: domain.ProviderCodex,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	doc, err := store.GetDoc(ctx, out.SnapshotID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var prompt strings.Builder
+	for _, event := range doc.CIR.Events {
+		for _, block := range event.Blocks {
+			prompt.WriteString(block.Text)
+		}
+	}
+	for _, marker := range []string{"BRANCH CURRENT DECISION ONCE", "BRANCH CURRENT RESULT ONCE"} {
+		if count := strings.Count(prompt.String(), marker); count != 1 {
+			t.Fatalf("branch prompt contains %q %d times, want one verbatim copy:\n%s", marker, count, prompt.String())
+		}
+	}
+	if strings.Contains(prompt.String(), "[cxt conversation delta v1]") {
+		t.Fatalf("private memory marker leaked into branch prompt:\n%s", prompt.String())
+	}
+	seedSnap, err := store.GetSnapshot(ctx, out.SnapshotID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	seedMemory, err := store.GetMemory(ctx, seedSnap.MemoryHash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, marker := range []string{"BRANCH CURRENT DECISION ONCE", "BRANCH CURRENT RESULT ONCE"} {
+		if !strings.Contains(seedMemory.Summary, marker) {
+			t.Fatalf("attached seed memory lost %q:\n%s", marker, seedMemory.Summary)
+		}
+	}
+	if strings.Contains(seedMemory.Summary, "[cxt conversation delta v1]") {
+		t.Fatalf("private memory marker leaked into rendered seed memory:\n%s", seedMemory.Summary)
+	}
+}
+
 type failBridgeDistiller struct{ calls int }
 
 func (d *failBridgeDistiller) Distill(context.Context, domain.CIRDocument, *domain.NativeMemory) (domain.MemoryDigest, error) {

--- a/cli/internal/app/load_session.go
+++ b/cli/internal/app/load_session.go
@@ -588,6 +588,11 @@ func (s *LoadSessionService) prependTrimDigest(ctx context.Context, omitted, see
 func (s *LoadSessionService) prependTrimDigestWithStatus(ctx context.Context, omitted, seed domain.CIRDocument, snap domain.Snapshot, target domain.ProviderKind, cwd string, priorSeeds []domain.Event) (domain.CIRDocument, bool, bool) {
 	digest, derr := s.distiller.Distill(ctx, omitted, nil)
 	digest.SnapshotID = snap.ID
+	if digest.SnapshotID != "" {
+		// Normalize the private version marker into provenance fragments before
+		// rendering provider-visible prompt text.
+		digest = domain.MergeDigests(domain.MemoryDigest{}, digest)
+	}
 	if derr != nil {
 		digest = domain.MemoryDigest{} // Send the stored digest even if empty
 	}
@@ -605,6 +610,10 @@ func (s *LoadSessionService) prependTrimDigestWithStatus(ctx context.Context, om
 	}
 	storedUsable := false
 	if hasStored {
+		// This snapshot's recent conversation is present in the raw replay tail
+		// (or re-distilled from the exact omitted slice below). Retain provider or
+		// native baseline memory, but do not inject that same source delta twice.
+		stored = domain.WithoutConversationDeltaFromSource(stored, snap.ID)
 		// Stored memory is immutable archival state and can contain a full native
 		// memory or legacy cxt seed generations. Loading it into a provider prompt
 		// is an inherited projection, so apply the same recursion filter and carry
@@ -815,6 +824,7 @@ func (s *LoadSessionService) loadMemory(ctx context.Context, cir domain.CIRDocum
 		return inbound.LoadOutput{}, err
 	}
 	digest.SnapshotID = snap.ID
+	digest = domain.MergeDigests(domain.MemoryDigest{}, digest)
 	// Heritage continuation (same logic as memorize): merge project memory from
 	// every parent lineage, including overlay grafts.
 	if prior, ok := priorMemoryProjection(ctx, s.store, snap); ok {

--- a/cli/internal/app/memory_lineage_test.go
+++ b/cli/internal/app/memory_lineage_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/wnsdy95/cxthub/cli/internal/adapters/memory"
 	"github.com/wnsdy95/cxthub/cli/internal/adapters/storage"
 	"github.com/wnsdy95/cxthub/cli/internal/domain"
 	"github.com/wnsdy95/cxthub/cli/internal/ports/inbound"
@@ -499,6 +500,43 @@ func TestMemorizeDistillsEffectiveContextAfterCompaction(t *testing.T) {
 	}
 	if len(distiller.seen.Events) != 1 || distiller.seen.Events[0].Blocks[0].Text != "active replacement context" {
 		t.Fatalf("memorize distilled archival stream: %+v", distiller.seen.Events)
+	}
+}
+
+func TestMemorizePersistsPostCompactionConversation(t *testing.T) {
+	ctx := context.Background()
+	store := storage.NewFileStore(t.TempDir())
+	repo := domain.Repo{ID: "repo-memory-post-compact", DefaultBranch: "main", LocalPath: t.TempDir()}
+	docHash, err := store.PutDoc(ctx, domain.SessionDoc{CIR: domain.CIRDocument{
+		Envelope: domain.Envelope{CIRVersion: domain.CIRVersionV2, SourceProvider: domain.ProviderClaude},
+		Events: []domain.Event{
+			{Kind: domain.EventMessage, Seq: 0, Role: "user", CompactSummary: true, Blocks: []domain.ContentBlock{{Type: "text", Text: "MEMORIZE COMPACT BASELINE"}}},
+			{Kind: domain.EventMessage, Seq: 1, Role: "user", Blocks: []domain.ContentBlock{{Type: "text", Text: "MEMORIZE POST-COMPACT DECISION"}}},
+			{Kind: domain.EventMessage, Seq: 2, Role: "assistant", Blocks: []domain.ContentBlock{{Type: "text", Text: "MEMORIZE POST-COMPACT RESULT"}}},
+		},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.PutSnapshot(ctx, domain.Snapshot{ID: docHash, DocHash: docHash, RepoID: repo.ID, Branch: "main"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.PutRef(ctx, domain.Ref{Kind: domain.RefBranch, Name: "main", RepoID: repo.ID, Target: docHash}); err != nil {
+		t.Fatal(err)
+	}
+	service := NewMemorizeService(branchSeedGit{repo: repo}, nil, nil, nil, memory.NewRuleDistiller(), store)
+	out, err := service.Memorize(ctx, inbound.MemorizeInput{Cwd: repo.LocalPath, Provider: domain.ProviderClaude})
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest, err := store.GetMemory(ctx, out.MemoryHash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"MEMORIZE COMPACT BASELINE", "MEMORIZE POST-COMPACT DECISION", "MEMORIZE POST-COMPACT RESULT"} {
+		if !strings.Contains(digest.Summary, want) {
+			t.Fatalf("memorized digest lost %q:\n%s", want, digest.Summary)
+		}
 	}
 }
 

--- a/cli/internal/app/restore_test.go
+++ b/cli/internal/app/restore_test.go
@@ -349,8 +349,11 @@ func TestLoadMemoryMode(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.HasPrefix(string(data), userInstructions) || !strings.Contains(string(data), "cxt memory") || !strings.Contains(string(data), "NEWEST-NATIVE") {
+	if !strings.HasPrefix(string(data), userInstructions) || !strings.Contains(string(data), "cxt memory") || !strings.Contains(string(data), "NEWEST-NATIVE") || !strings.Contains(string(data), "do it") {
 		t.Fatalf("CLAUDE.md did not preserve user instructions and bounded latest memory")
+	}
+	if strings.Contains(string(data), "[cxt conversation delta v1]") {
+		t.Fatal("private memory marker leaked into provider instruction file")
 	}
 	if len(data) > len(userInstructions)+(64<<10)+2 {
 		t.Fatalf("CLAUDE.md bytes=%d exceeds user content + managed budget", len(data))

--- a/cli/internal/app/seed_digest_test.go
+++ b/cli/internal/app/seed_digest_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/wnsdy95/cxthub/cli/internal/adapters/memory"
 	"github.com/wnsdy95/cxthub/cli/internal/adapters/storage"
 	"github.com/wnsdy95/cxthub/cli/internal/domain"
 	"github.com/wnsdy95/cxthub/cli/internal/ports/inbound"
@@ -201,6 +202,85 @@ func TestPrependTrimDigestCompactSummary(t *testing.T) {
 	out = svc.prependTrimDigest(ctx, full, seed, domain.Snapshot{}, domain.ProviderClaude, t.TempDir())
 	if strings.Contains(out.Events[0].Blocks[0].Text, "MEMROOT") {
 		t.Fatalf("Native memory text re-injected into seed: %q", out.Events[0].Blocks[0].Text)
+	}
+}
+
+func TestPrependTrimDigestPreservesPostCompactionOmittedSpan(t *testing.T) {
+	ctx := context.Background()
+	st := storage.NewFileStore(t.TempDir())
+	svc := NewLoadSessionService(st, nil, nil, nil, memory.NewRuleDistiller(), nil)
+	omitted := domain.CIRDocument{Envelope: domain.Envelope{SourceProvider: domain.ProviderClaude}, Events: []domain.Event{
+		{Kind: domain.EventMessage, Role: "user", CompactSummary: true, Blocks: []domain.ContentBlock{{Type: "text", Text: "LOAD COMPACT BASELINE"}}},
+		{Kind: domain.EventMessage, Role: "user", Blocks: []domain.ContentBlock{{Type: "text", Text: "LOAD OMITTED POST-COMPACT DECISION"}}},
+		{Kind: domain.EventMessage, Role: "assistant", Blocks: []domain.ContentBlock{{Type: "text", Text: "LOAD OMITTED POST-COMPACT RESULT"}}},
+	}}
+	seed := domain.CIRDocument{Events: []domain.Event{
+		{Kind: domain.EventMessage, Role: "user", Blocks: []domain.ContentBlock{{Type: "text", Text: "LOAD RECENT RAW REQUEST"}}},
+	}}
+
+	out := svc.prependTrimDigest(ctx, omitted, seed, domain.Snapshot{ID: domain.HashContent([]byte("load-omitted-span"))}, domain.ProviderClaude, t.TempDir())
+	if len(out.Events) != 2 || len(out.Events[0].Blocks) == 0 {
+		t.Fatalf("trimmed seed = %+v", out.Events)
+	}
+	summary := out.Events[0].Blocks[0].Text
+	for _, want := range []string{"LOAD COMPACT BASELINE", "LOAD OMITTED POST-COMPACT DECISION", "LOAD OMITTED POST-COMPACT RESULT"} {
+		if !strings.Contains(summary, want) {
+			t.Fatalf("omitted-span digest lost %q:\n%s", want, summary)
+		}
+	}
+	if strings.Contains(summary, "LOAD RECENT RAW REQUEST") || out.Events[1].Blocks[0].Text != "LOAD RECENT RAW REQUEST" {
+		t.Fatalf("recent raw tail was duplicated or changed: %+v", out.Events)
+	}
+	if strings.Contains(summary, "[cxt conversation delta v1]") {
+		t.Fatalf("private memory marker leaked into load prompt:\n%s", summary)
+	}
+}
+
+func TestPrependTrimDigestDoesNotRepeatStoredCurrentConversation(t *testing.T) {
+	ctx := context.Background()
+	st := storage.NewFileStore(t.TempDir())
+	id := domain.HashContent([]byte("load-current-delta-source"))
+	full := domain.CIRDocument{Envelope: domain.Envelope{SourceProvider: domain.ProviderClaude}, Events: []domain.Event{
+		{Kind: domain.EventMessage, Role: "user", CompactSummary: true, Blocks: []domain.ContentBlock{{Type: "text", Text: "LOAD STORED BASELINE"}}},
+		{Kind: domain.EventMessage, Role: "user", Blocks: []domain.ContentBlock{{Type: "text", Text: "LOAD OLD OMITTED DECISION"}}},
+		{Kind: domain.EventMessage, Role: "user", Blocks: []domain.ContentBlock{{Type: "text", Text: "LOAD CURRENT RAW DECISION ONCE"}}},
+	}}
+	digest, err := memory.NewRuleDistiller().Distill(ctx, full, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest.SnapshotID = id
+	digest = domain.MergeDigests(domain.MemoryDigest{}, digest)
+	memoryHash, err := st.PutMemory(ctx, digest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	snap := domain.Snapshot{ID: id, DocHash: id, MemoryHash: memoryHash}
+	if err := st.PutSnapshot(ctx, snap); err != nil {
+		t.Fatal(err)
+	}
+	omitted := full
+	omitted.Events = append([]domain.Event(nil), full.Events[:2]...)
+	seed := domain.CIRDocument{Events: append([]domain.Event(nil), full.Events[2:]...)}
+	svc := NewLoadSessionService(st, nil, nil, nil, memory.NewRuleDistiller(), nil)
+
+	out := svc.prependTrimDigest(ctx, omitted, seed, snap, domain.ProviderClaude, t.TempDir())
+	var prompt strings.Builder
+	for _, event := range out.Events {
+		for _, block := range event.Blocks {
+			prompt.WriteString(block.Text)
+		}
+	}
+	for _, want := range []string{"LOAD STORED BASELINE", "LOAD OLD OMITTED DECISION", "LOAD CURRENT RAW DECISION ONCE"} {
+		if !strings.Contains(prompt.String(), want) {
+			t.Fatalf("load prompt lost %q:\n%s", want, prompt.String())
+		}
+	}
+	if count := strings.Count(prompt.String(), "LOAD CURRENT RAW DECISION ONCE"); count != 1 {
+		t.Fatalf("current raw conversation appears %d times, want one:\n%s", count, prompt.String())
+	}
+	if len(out.Events) < 2 || strings.Contains(out.Events[0].Blocks[0].Text, "LOAD CURRENT RAW DECISION ONCE") {
+		t.Fatalf("stored current delta leaked into summary layer: %+v", out.Events)
 	}
 }
 

--- a/cli/internal/domain/entities.go
+++ b/cli/internal/domain/entities.go
@@ -285,14 +285,18 @@ func renderMemoryFragments(out *MemoryDigest) {
 	var facts, tasks []string
 	for _, fragment := range out.Fragments {
 		if summary := strings.TrimSpace(fragment.Summary); summary != "" {
-			if users, assistants, ok := parseExtractiveFallbackSummary(summary); ok {
+			baseline, users, assistants, hasFallback := splitExtractiveFallbackSummary(summary)
+			if baseline != "" && !containsString(summaries, baseline) {
+				summaries = append(summaries, baseline)
+			}
+			if hasFallback {
 				// Keep the combined projection at the position of the newest
 				// fallback fragment. renderSeedDigest retains the newest tail, so
 				// placing it at the first fallback could evict newer unique items.
 				fallbackInsertAt = len(summaries)
 				fallbackUsers = dedupStrings(fallbackUsers, users)
 				fallbackAssistants = dedupStrings(fallbackAssistants, assistants)
-			} else if !containsString(summaries, summary) {
+			} else if baseline == "" && !containsString(summaries, summary) {
 				summaries = append(summaries, summary)
 			}
 		}
@@ -313,11 +317,59 @@ func renderMemoryFragments(out *MemoryDigest) {
 	out.OpenTasks = tasks
 }
 
+// WithoutConversationDeltaFromSource returns a prompt-only projection with
+// the canonical extractive conversation delta removed from one snapshot's
+// contribution. Branch/full replay callers use it when that exact source
+// conversation is also supplied verbatim. Other lineage fragments and the
+// provider/native baseline remain intact; the immutable stored digest is not
+// mutated.
+func WithoutConversationDeltaFromSource(d MemoryDigest, source ContentHash) MemoryDigest {
+	if source == "" {
+		return d
+	}
+	if len(d.Fragments) == 0 {
+		if d.SnapshotID == source {
+			if baseline, _, _, ok := splitExtractiveFallbackSummary(d.Summary); ok {
+				d.Summary = baseline
+			}
+		}
+		return d
+	}
+
+	fragments := append([]MemoryFragment(nil), d.Fragments...)
+	for i := range fragments {
+		if fragments[i].SourceSnapshot != source {
+			continue
+		}
+		if baseline, _, _, ok := splitExtractiveFallbackSummary(fragments[i].Summary); ok {
+			fragments[i].Summary = baseline
+		}
+	}
+	d.Fragments = fragments
+	renderMemoryFragments(&d)
+	return d
+}
+
 const (
 	extractiveFallbackHeader           = "Conversation digest (extractive fallback; provider compaction summary unavailable):"
 	extractiveFallbackUsersHeader      = "Recent user intent:"
 	extractiveFallbackAssistantsHeader = "Recent assistant outcomes:"
+	extractiveFallbackDeltaMarker      = "[cxt conversation delta v1]"
 )
+
+// AppendExtractiveConversationDelta combines a provider/native baseline with
+// the deterministic extractive fallback using a versioned private marker.
+// The marker prevents provider-authored prose that merely resembles the
+// fallback wire format from being removed as a cxt-owned delta later.
+func AppendExtractiveConversationDelta(baseline, delta string) string {
+	if delta == "" {
+		return baseline
+	}
+	if baseline == "" {
+		return delta
+	}
+	return baseline + "\n\n" + extractiveFallbackDeltaMarker + "\n" + delta
+}
 
 // RenderExtractiveFallbackSummary is the canonical text representation of the
 // deterministic conversation fallback. Keeping the format in the domain lets
@@ -396,6 +448,24 @@ func parseExtractiveFallbackSummary(summary string) (users, assistants []string,
 		return nil, nil, false
 	}
 	return users, assistants, true
+}
+
+// splitExtractiveFallbackSummary recognizes both a standalone deterministic
+// fallback and the canonical "provider/native baseline + fallback" shape.
+// Strict parsing keeps arbitrary provider-authored prose byte-for-byte.
+func splitExtractiveFallbackSummary(summary string) (baseline string, users, assistants []string, ok bool) {
+	summary = strings.TrimSpace(summary)
+	if users, assistants, ok = parseExtractiveFallbackSummary(summary); ok {
+		return "", users, assistants, true
+	}
+	marker := "\n\n" + extractiveFallbackDeltaMarker + "\n"
+	if at := strings.LastIndex(summary, marker); at >= 0 {
+		candidate := summary[at+len(marker):]
+		if users, assistants, ok = parseExtractiveFallbackSummary(candidate); ok {
+			return strings.TrimSpace(summary[:at]), users, assistants, true
+		}
+	}
+	return summary, nil, nil, false
 }
 
 func containsString(items []string, want string) bool {

--- a/cli/internal/domain/merge_digests_test.go
+++ b/cli/internal/domain/merge_digests_test.go
@@ -79,6 +79,74 @@ func TestMergeDigestsDeduplicatesExtractiveFallbackItems(t *testing.T) {
 	}
 }
 
+func TestMergeDigestsDeduplicatesBaselineAndKeepsConversationDeltas(t *testing.T) {
+	leftID := ContentHash("sha256:" + strings.Repeat("7", 64))
+	rightID := ContentHash("sha256:" + strings.Repeat("8", 64))
+	const baseline = "PROVIDER COMPACT BASELINE REMAINS BYTE STABLE"
+	left := MemoryDigest{
+		SnapshotID: leftID,
+		Summary: AppendExtractiveConversationDelta(baseline, RenderExtractiveFallbackSummary(
+			[]string{"Decision from the left lineage."},
+			[]string{"Result from the left lineage."},
+		)),
+	}
+	right := MemoryDigest{
+		SnapshotID: rightID,
+		Summary: AppendExtractiveConversationDelta(baseline, RenderExtractiveFallbackSummary(
+			[]string{"Decision from the right lineage."},
+			[]string{"Result from the right lineage."},
+		)),
+	}
+
+	got := MergeDigests(left, right)
+	if count := strings.Count(got.Summary, baseline); count != 1 {
+		t.Fatalf("merged baseline count=%d, want 1:\n%s", count, got.Summary)
+	}
+	if count := strings.Count(got.Summary, extractiveFallbackHeader); count != 1 {
+		t.Fatalf("merged extractive header count=%d, want 1:\n%s", count, got.Summary)
+	}
+	for _, want := range []string{
+		"Decision from the left lineage.", "Result from the left lineage.",
+		"Decision from the right lineage.", "Result from the right lineage.",
+	} {
+		if !strings.Contains(got.Summary, want) {
+			t.Fatalf("merged memory lost %q:\n%s", want, got.Summary)
+		}
+	}
+
+	prompt := WithoutConversationDeltaFromSource(got, rightID)
+	for _, kept := range []string{baseline, "Decision from the left lineage.", "Result from the left lineage."} {
+		if !strings.Contains(prompt.Summary, kept) {
+			t.Fatalf("source-filtered prompt lost %q:\n%s", kept, prompt.Summary)
+		}
+	}
+	for _, removed := range []string{"Decision from the right lineage.", "Result from the right lineage."} {
+		if strings.Contains(prompt.Summary, removed) {
+			t.Fatalf("source-filtered prompt retained %q:\n%s", removed, prompt.Summary)
+		}
+		if !strings.Contains(got.Summary, removed) {
+			t.Fatalf("source filtering mutated the immutable input projection: %q", removed)
+		}
+	}
+}
+
+func TestWithoutConversationDeltaLeavesUnstructuredProviderTextUntouched(t *testing.T) {
+	id := ContentHash("sha256:" + strings.Repeat("9", 64))
+	providerFallback := RenderExtractiveFallbackSummary(
+		[]string{"This sentence was authored by the provider."},
+		[]string{"It must remain part of the provider baseline."},
+	)
+	for _, summary := range []string{
+		"Provider prose mentioning " + extractiveFallbackHeader + " without the canonical sections",
+		"Provider-authored baseline\n\n" + providerFallback,
+	} {
+		digest := MemoryDigest{SnapshotID: id, Summary: summary}
+		if got := WithoutConversationDeltaFromSource(digest, id); got.Summary != summary {
+			t.Fatalf("unstructured provider text changed: got %q want %q", got.Summary, summary)
+		}
+	}
+}
+
 func TestMergeDigestsPreservesUniqueSiblingFallbackItems(t *testing.T) {
 	left := MemoryDigest{
 		SnapshotID: ContentHash("sha256:" + strings.Repeat("c", 64)),

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -248,7 +248,10 @@ That bridge is merged with the inherited compact/project memory, so work after
 an older provider compaction does not disappear between the summary and recent
 tail. The source snapshot remains immutable and reachable; the inherited
 memory plus bridge is attached to the seed for future memorize and branch
-operations without enlarging the provider prompt budget.
+operations without enlarging the provider prompt budget. When current
+conversation events are also replayed verbatim, their extractive memory delta
+is removed only from the prompt projection, so the new session receives each
+turn once while the full digest remains attached to the seed.
 
 ### `cxt switch`
 
@@ -306,7 +309,10 @@ With no ref, uses the current branch head. `memory` is an alias for
 `memorize`; there is no `cxt memory save` subcommand. Modern snapshots select
 their recorded source provider automatically. An explicit `--provider` must
 match it; cxt never imports unrelated native memory from another provider or
-terminal into that snapshot.
+terminal into that snapshot. A provider compact summary or native memory is
+kept as the long-term baseline, and meaningful user/assistant turns after that
+baseline are attached as a deterministic bounded conversation delta. Repeated
+baseline text is rendered once across merged lineage fragments.
 
 ## Synchronization
 


### PR DESCRIPTION
Closes #88.

## Root cause

`RuleDistiller` returned immediately at the latest provider compact summary or native memory, so every later user/assistant turn remained only in the immutable CIR and disappeared from active memory projections. Simply appending those turns would duplicate the current raw tail in branch and full-load prompts.

## Fix

- preserve compact/native text as the baseline and append a deterministic bounded post-baseline conversation delta
- normalize repeated baselines and fallback items across provenance fragments
- use a versioned private marker plus strict parsing to distinguish cxt-owned deltas from provider prose
- remove only the current source snapshot delta when its conversation is replayed verbatim
- retain ancestor, sibling-lineage, omitted-span, and attached seed memory
- keep provider prompt budgets and immutable CIR/replacement state unchanged

## Verification

- focused regressions repeated 20x
- CLI full test and vet
- CLI memory/domain/app race tests
- basic E2E
- sync E2E
- public preflight