### PR TITLE
fix(load): fail closed on omitted context loss

### DIFF
--- a/cli/internal/app/load_session.go
+++ b/cli/internal/app/load_session.go
@@ -131,13 +131,18 @@ func (s *LoadSessionService) Load(ctx context.Context, in inbound.LoadInput) (in
 	dropped := len(omitted)
 	if dropped > 0 {
 		// Omit memory digest of skipped segment at seed start with "CompactSummary" event — context compression equivalent (summary + recent raw). Viewer collapses, distiller 1st priority last-wins (memory ↔ context cycle accumulation block).
-		// Failure is fail-open (tail only).
+		// Distillation is mandatory: materializing a resumable tail without a
+		// representation of the exact omitted span would silently lose context.
 		omittedCIR := cir
 		omittedCIR.Events = omitted
+		var digestErr error
 		if keptReplacement {
-			seedCIR = s.insertTrimDigestAfterPrefix(ctx, omittedCIR, seedCIR, replacementCount, snap, target, in.Cwd)
+			seedCIR, digestErr = s.insertTrimDigestAfterPrefix(ctx, omittedCIR, seedCIR, replacementCount, snap, target, in.Cwd)
 		} else {
-			seedCIR = s.prependTrimDigest(ctx, omittedCIR, seedCIR, snap, target, in.Cwd)
+			seedCIR, digestErr = s.prependTrimDigest(ctx, omittedCIR, seedCIR, snap, target, in.Cwd)
+		}
+		if digestErr != nil {
+			return inbound.LoadOutput{}, fmt.Errorf("distill omitted context: %w", digestErr)
 		}
 	}
 	// A restored session belongs to the working tree it is being restored into,
@@ -568,16 +573,17 @@ const seedSummaryPrefix = "[cxt] This session was resumed from a branch context 
 //
 // Summary source priority: The digest on this snapshot, or the deterministic
 // projection of nearest digests across every parent lineage, is first priority.
-// In-place head distillation supplements that project memory. If both fail,
-// fail open with only the recent tail.
+// In-place omitted-span distillation supplements that project memory. It is
+// mandatory whenever events were trimmed; stored memory cannot prove that it
+// contains the exact current omitted span.
 //
 // Deduplication:
 //   - Previous generation seed summary (prefix CompactSummary) in the tail is removed — the new summary takes precedence.
 //   - If the digest summary matches the original native memory (e.g., MEMORY.md) of the target provider, it is omitted — the agent loads context itself at session start, so context re-injection is redundant.
 //   - KeyFacts noise such as whitespace-free tool tokens and legacy ingestion markers ("native memory:"/"absorbed from") is excluded from seed content.
-func (s *LoadSessionService) prependTrimDigest(ctx context.Context, omitted, seed domain.CIRDocument, snap domain.Snapshot, target domain.ProviderKind, cwd string) domain.CIRDocument {
-	out, _, _ := s.prependTrimDigestWithStatus(ctx, omitted, seed, snap, target, cwd, nil)
-	return out
+func (s *LoadSessionService) prependTrimDigest(ctx context.Context, omitted, seed domain.CIRDocument, snap domain.Snapshot, target domain.ProviderKind, cwd string) (domain.CIRDocument, error) {
+	out, _, _, err := s.prependTrimDigestWithStatus(ctx, omitted, seed, snap, target, cwd, nil)
+	return out, err
 }
 
 // prependTrimDigestWithStatus reports both whether a new bounded digest was
@@ -585,16 +591,16 @@ func (s *LoadSessionService) prependTrimDigest(ctx context.Context, omitted, see
 // retain an old seed unless its meaning came from stored memory or was folded
 // into a normalized projection; otherwise that seed can be the sole surviving
 // representation of earlier context.
-func (s *LoadSessionService) prependTrimDigestWithStatus(ctx context.Context, omitted, seed domain.CIRDocument, snap domain.Snapshot, target domain.ProviderKind, cwd string, priorSeeds []domain.Event) (domain.CIRDocument, bool, bool) {
-	digest, derr := s.distiller.Distill(ctx, omitted, nil)
+func (s *LoadSessionService) prependTrimDigestWithStatus(ctx context.Context, omitted, seed domain.CIRDocument, snap domain.Snapshot, target domain.ProviderKind, cwd string, priorSeeds []domain.Event) (domain.CIRDocument, bool, bool, error) {
+	digest, err := s.distiller.Distill(ctx, omitted, nil)
+	if err != nil {
+		return seed, false, false, err
+	}
 	digest.SnapshotID = snap.ID
 	if digest.SnapshotID != "" {
 		// Normalize the private version marker into provenance fragments before
 		// rendering provider-visible prompt text.
 		digest = domain.MergeDigests(domain.MemoryDigest{}, digest)
-	}
-	if derr != nil {
-		digest = domain.MemoryDigest{} // Send the stored digest even if empty
 	}
 	// Prioritize the stored memorize digest (self-snapshot → parent projection).
 	stored, hasStored := domain.MemoryDigest{}, false
@@ -624,9 +630,6 @@ func (s *LoadSessionService) prependTrimDigestWithStatus(ctx context.Context, om
 		if storedUsable {
 			digest = domain.MergeDigests(stored, digest)
 		}
-	}
-	if derr != nil && !storedUsable {
-		return seed, false, false
 	}
 	seedProjected := false
 	if !storedUsable {
@@ -661,14 +664,14 @@ func (s *LoadSessionService) prependTrimDigestWithStatus(ctx context.Context, om
 	}
 	out := seed
 	out.Events = append([]domain.Event{ev}, tail...)
-	return out, true, len(priorSeeds) == 0 || storedUsable || seedProjected
+	return out, true, len(priorSeeds) == 0 || storedUsable || seedProjected, nil
 }
 
 func memoryDigestHasProjection(d domain.MemoryDigest) bool {
 	return strings.TrimSpace(d.Summary) != "" || len(d.KeyFacts) > 0 || len(d.OpenTasks) > 0 || len(d.Fragments) > 0
 }
 
-func (s *LoadSessionService) insertTrimDigestAfterPrefix(ctx context.Context, omitted, seed domain.CIRDocument, prefixCount int, snap domain.Snapshot, target domain.ProviderKind, cwd string) domain.CIRDocument {
+func (s *LoadSessionService) insertTrimDigestAfterPrefix(ctx context.Context, omitted, seed domain.CIRDocument, prefixCount int, snap domain.Snapshot, target domain.ProviderKind, cwd string) (domain.CIRDocument, error) {
 	if prefixCount < 0 || prefixCount > len(seed.Events) {
 		return s.prependTrimDigest(ctx, omitted, seed, snap, target, cwd)
 	}
@@ -682,7 +685,11 @@ func (s *LoadSessionService) insertTrimDigestAfterPrefix(ctx context.Context, om
 	tail := seed
 	tail.Events = seed.Events[prefixCount:]
 	var inserted, replacesPriorSeeds bool
-	tail, inserted, replacesPriorSeeds = s.prependTrimDigestWithStatus(ctx, omitted, tail, snap, target, cwd, priorSeeds)
+	var err error
+	tail, inserted, replacesPriorSeeds, err = s.prependTrimDigestWithStatus(ctx, omitted, tail, snap, target, cwd, priorSeeds)
+	if err != nil {
+		return seed, err
+	}
 	if inserted && replacesPriorSeeds {
 		// A prior cxt seed is semantic projection, not provider-owned replay
 		// state. Keeping it beside the replacement digest recursively embeds
@@ -706,7 +713,7 @@ func (s *LoadSessionService) insertTrimDigestAfterPrefix(ctx context.Context, om
 	for i := range out.Events {
 		out.Events[i].Seq = i
 	}
-	return out
+	return out, nil
 }
 
 // syntheticSeedMemoryProjection makes a bounded carried digest from legacy

--- a/cli/internal/app/restore_test.go
+++ b/cli/internal/app/restore_test.go
@@ -131,6 +131,117 @@ func TestLoadCrossProvider(t *testing.T) {
 	}
 }
 
+func TestLoadTrimDistillationFailureCreatesNoSession(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	ctx := context.Background()
+	store := storage.NewFileStore(t.TempDir())
+	var events []domain.Event
+	for i := 0; i < 20; i++ {
+		events = append(events,
+			domain.Event{Kind: domain.EventMessage, Seq: len(events), Role: "user", Blocks: []domain.ContentBlock{{Type: "text", Text: "OMITTED LOAD REQUEST " + strings.Repeat("u", 16<<10)}}},
+			domain.Event{Kind: domain.EventMessage, Seq: len(events) + 1, Role: "assistant", Blocks: []domain.ContentBlock{{Type: "text", Text: "OMITTED LOAD RESULT " + strings.Repeat("a", 16<<10)}}},
+		)
+	}
+	cir := domain.CIRDocument{
+		Envelope: domain.Envelope{CIRVersion: domain.CIRVersionV1, SourceProvider: domain.ProviderClaude, Cwd: "/source", GitBranch: "main", SessionOriginID: "load-distill-failure"},
+		Events:   events,
+	}
+	hash, err := store.PutDoc(ctx, domain.SessionDoc{CIR: cir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.PutSnapshot(ctx, domain.Snapshot{ID: hash, DocHash: hash, Branch: "main", Provider: domain.ProviderClaude, Fidelity: domain.FidelityFull}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.PutRef(ctx, domain.Ref{Kind: domain.RefBranch, Name: "main", Target: hash}); err != nil {
+		t.Fatal(err)
+	}
+	svc := NewLoadSessionService(
+		store,
+		map[domain.ProviderKind]outbound.ProviderCodec{domain.ProviderClaude: codec.NewClaudeCodec()},
+		map[domain.ProviderKind]outbound.SessionMaterializer{domain.ProviderClaude: session.NewClaudeMaterializer()},
+		nil, failingDistiller{}, nil,
+	)
+	cwd := t.TempDir()
+
+	out, err := svc.Load(ctx, inbound.LoadInput{Ref: "main", TargetProvider: domain.ProviderClaude, Mode: domain.FidelityFull, Cwd: cwd})
+	if err == nil || !strings.Contains(err.Error(), "distill omitted context") {
+		t.Fatalf("Load output=%+v error=%v, want fail-closed distillation error", out, err)
+	}
+	var materialized []string
+	if walkErr := filepath.Walk(filepath.Join(home, ".claude"), func(path string, info os.FileInfo, walkErr error) error {
+		if walkErr == nil && info != nil && !info.IsDir() && strings.HasSuffix(path, ".jsonl") {
+			materialized = append(materialized, path)
+		}
+		return nil
+	}); walkErr != nil && !os.IsNotExist(walkErr) {
+		t.Fatal(walkErr)
+	}
+	if len(materialized) != 0 {
+		t.Fatalf("failed distillation materialized provider sessions: %v", materialized)
+	}
+}
+
+func TestLoadPinnedReplacementDistillationFailureCreatesNoSession(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	ctx := context.Background()
+	store := storage.NewFileStore(t.TempDir())
+	replacement := []domain.Event{
+		{Kind: domain.EventMessage, Seq: 0, Role: "developer", Blocks: []domain.ContentBlock{{Type: "text", Text: "PINNED RUNTIME CONTRACT"}}},
+		{Kind: domain.EventCompaction, Seq: 1, Locked: &domain.LockedBlob{Provider: domain.ProviderCodex, Scheme: "encrypted_content", Blob: "PINNED-STATE"}},
+	}
+	events := []domain.Event{
+		{Kind: domain.EventMessage, Seq: 0, Role: "user", Blocks: []domain.ContentBlock{{Type: "text", Text: "archival context"}}},
+		{Kind: domain.EventCompaction, Seq: 1, Replacement: replacement, ReplacementComplete: true},
+	}
+	for i := 0; i < 20; i++ {
+		events = append(events,
+			domain.Event{Kind: domain.EventMessage, Seq: len(events), Role: "user", Blocks: []domain.ContentBlock{{Type: "text", Text: "CODEX OMITTED REQUEST " + strings.Repeat("u", 16<<10)}}},
+			domain.Event{Kind: domain.EventMessage, Seq: len(events) + 1, Role: "assistant", Blocks: []domain.ContentBlock{{Type: "text", Text: "CODEX OMITTED RESULT " + strings.Repeat("a", 16<<10)}}},
+		)
+	}
+	cir := domain.CIRDocument{
+		Envelope: domain.Envelope{CIRVersion: domain.CIRVersionV2, SourceProvider: domain.ProviderCodex, Cwd: "/source", GitBranch: "main", SessionOriginID: "pinned-distill-failure", CompactionCount: 1},
+		Events:   events,
+	}
+	hash, err := store.PutDoc(ctx, domain.SessionDoc{CIR: cir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.PutSnapshot(ctx, domain.Snapshot{ID: hash, DocHash: hash, Branch: "main", Provider: domain.ProviderCodex, Fidelity: domain.FidelityFull}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.PutRef(ctx, domain.Ref{Kind: domain.RefBranch, Name: "main", Target: hash}); err != nil {
+		t.Fatal(err)
+	}
+	svc := NewLoadSessionService(
+		store,
+		map[domain.ProviderKind]outbound.ProviderCodec{domain.ProviderCodex: codec.NewCodexCodec()},
+		map[domain.ProviderKind]outbound.SessionMaterializer{domain.ProviderCodex: session.NewCodexMaterializer()},
+		nil, failingDistiller{}, nil,
+	)
+	cwd := t.TempDir()
+
+	out, err := svc.Load(ctx, inbound.LoadInput{Ref: "main", TargetProvider: domain.ProviderCodex, Mode: domain.FidelityFull, Cwd: cwd})
+	if err == nil || !strings.Contains(err.Error(), "distill omitted context") {
+		t.Fatalf("Load output=%+v error=%v, want fail-closed pinned distillation error", out, err)
+	}
+	var materialized []string
+	if walkErr := filepath.Walk(filepath.Join(home, ".codex"), func(path string, info os.FileInfo, walkErr error) error {
+		if walkErr == nil && info != nil && !info.IsDir() && strings.HasSuffix(path, ".jsonl") {
+			materialized = append(materialized, path)
+		}
+		return nil
+	}); walkErr != nil && !os.IsNotExist(walkErr) {
+		t.Fatal(walkErr)
+	}
+	if len(materialized) != 0 {
+		t.Fatalf("failed pinned distillation materialized provider sessions: %v", materialized)
+	}
+}
+
 func TestLoadFullReplaysCodexReplacementInsteadOfPreCompactionArchive(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	ctx := context.Background()

--- a/cli/internal/app/seed_digest_test.go
+++ b/cli/internal/app/seed_digest_test.go
@@ -173,7 +173,10 @@ func TestPrependTrimDigestCompactSummary(t *testing.T) {
 		Summary:  "did X, decided Y",
 		KeyFacts: []string{"apply_patch", "unknown:Agent", "native memory: claude:MEMORY.md", "absorbed from claude:MEMORY.md", "budget is 400KB per seed"},
 	}, "")
-	out := svc.prependTrimDigest(ctx, full, seed, domain.Snapshot{}, domain.ProviderClaude, t.TempDir())
+	out, err := svc.prependTrimDigest(ctx, full, seed, domain.Snapshot{}, domain.ProviderClaude, t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if len(out.Events) != 2 {
 		t.Fatalf("Event count: got %d want 2 (new summary 1 + recent 1 — old [cxt] removed)", len(out.Events))
@@ -199,7 +202,10 @@ func TestPrependTrimDigestCompactSummary(t *testing.T) {
 
 	// (4) Omit summary of native memory text as-is.
 	svc = mk(domain.MemoryDigest{Summary: "MEMROOT\nfacts"}, "MEMROOT\nfacts")
-	out = svc.prependTrimDigest(ctx, full, seed, domain.Snapshot{}, domain.ProviderClaude, t.TempDir())
+	out, err = svc.prependTrimDigest(ctx, full, seed, domain.Snapshot{}, domain.ProviderClaude, t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
 	if strings.Contains(out.Events[0].Blocks[0].Text, "MEMROOT") {
 		t.Fatalf("Native memory text re-injected into seed: %q", out.Events[0].Blocks[0].Text)
 	}
@@ -218,7 +224,10 @@ func TestPrependTrimDigestPreservesPostCompactionOmittedSpan(t *testing.T) {
 		{Kind: domain.EventMessage, Role: "user", Blocks: []domain.ContentBlock{{Type: "text", Text: "LOAD RECENT RAW REQUEST"}}},
 	}}
 
-	out := svc.prependTrimDigest(ctx, omitted, seed, domain.Snapshot{ID: domain.HashContent([]byte("load-omitted-span"))}, domain.ProviderClaude, t.TempDir())
+	out, err := svc.prependTrimDigest(ctx, omitted, seed, domain.Snapshot{ID: domain.HashContent([]byte("load-omitted-span"))}, domain.ProviderClaude, t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
 	if len(out.Events) != 2 || len(out.Events[0].Blocks) == 0 {
 		t.Fatalf("trimmed seed = %+v", out.Events)
 	}
@@ -264,7 +273,10 @@ func TestPrependTrimDigestDoesNotRepeatStoredCurrentConversation(t *testing.T) {
 	seed := domain.CIRDocument{Events: append([]domain.Event(nil), full.Events[2:]...)}
 	svc := NewLoadSessionService(st, nil, nil, nil, memory.NewRuleDistiller(), nil)
 
-	out := svc.prependTrimDigest(ctx, omitted, seed, snap, domain.ProviderClaude, t.TempDir())
+	out, err := svc.prependTrimDigest(ctx, omitted, seed, snap, domain.ProviderClaude, t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
 	var prompt strings.Builder
 	for _, event := range out.Events {
 		for _, block := range event.Blocks {
@@ -317,7 +329,10 @@ func TestPrependTrimDigestProjectsStoredMemoryWithoutSeedRecursion(t *testing.T)
 		{Kind: domain.EventMessage, Role: "user", Seq: 1, Blocks: []domain.ContentBlock{{Type: "text", Text: "latest request"}}},
 	}}
 
-	out := svc.prependTrimDigest(ctx, omitted, seed, snap, domain.ProviderCodex, t.TempDir())
+	out, err := svc.prependTrimDigest(ctx, omitted, seed, snap, domain.ProviderCodex, t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
 	if len(out.Events) != 2 || len(out.Events[0].Blocks) == 0 {
 		t.Fatalf("projected seed = %+v", out.Events)
 	}
@@ -337,7 +352,7 @@ func TestPrependTrimDigestProjectsStoredMemoryWithoutSeedRecursion(t *testing.T)
 	}
 }
 
-func TestInsertTrimDigestKeepsExistingSeedWhenReplacementFails(t *testing.T) {
+func TestInsertTrimDigestFailsClosedWhenReplacementFails(t *testing.T) {
 	ctx := context.Background()
 	st := storage.NewFileStore(t.TempDir())
 	svc := NewLoadSessionService(st, nil, nil, nil, failingDistiller{}, nil)
@@ -351,9 +366,12 @@ func TestInsertTrimDigestKeepsExistingSeedWhenReplacementFails(t *testing.T) {
 		{Kind: domain.EventMessage, Role: "user", Blocks: []domain.ContentBlock{{Type: "text", Text: "older request"}}},
 	}}
 
-	out := svc.insertTrimDigestAfterPrefix(ctx, omitted, seed, 2, domain.Snapshot{}, domain.ProviderCodex, t.TempDir())
+	out, err := svc.insertTrimDigestAfterPrefix(ctx, omitted, seed, 2, domain.Snapshot{}, domain.ProviderCodex, t.TempDir())
+	if err == nil || !strings.Contains(err.Error(), "distillation unavailable") {
+		t.Fatalf("insert error=%v, want distillation failure", err)
+	}
 	if len(out.Events) != len(seed.Events) || out.Events[0].Blocks[0].Text != oldSeed {
-		t.Fatalf("failed replacement discarded the existing seed: %+v", out.Events)
+		t.Fatalf("failed projection mutated the existing seed: %+v", out.Events)
 	}
 	if out.Events[1].Locked == nil || out.Events[1].Locked.Blob != "PINNED" {
 		t.Fatalf("failed replacement changed provider state: %+v", out.Events[1])
@@ -380,7 +398,10 @@ func TestInsertTrimDigestProjectsExistingSeedWithoutStoredMemory(t *testing.T) {
 		{Kind: domain.EventMessage, Role: "user", Blocks: []domain.ContentBlock{{Type: "text", Text: "older request"}}},
 	}}
 
-	out := svc.insertTrimDigestAfterPrefix(ctx, omitted, seed, 2, domain.Snapshot{ID: snapshotID}, domain.ProviderCodex, t.TempDir())
+	out, err := svc.insertTrimDigestAfterPrefix(ctx, omitted, seed, 2, domain.Snapshot{ID: snapshotID}, domain.ProviderCodex, t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
 	seedCount := 0
 	seedText := ""
 	for _, ev := range out.Events {
@@ -433,7 +454,10 @@ func TestInsertTrimDigestFallsBackWhenStoredMemorySanitizesEmpty(t *testing.T) {
 	}}
 	snap := domain.Snapshot{ID: snapshotID, DocHash: snapshotID, MemoryHash: memoryHash}
 
-	out := svc.insertTrimDigestAfterPrefix(ctx, omitted, seed, 2, snap, domain.ProviderCodex, t.TempDir())
+	out, err := svc.insertTrimDigestAfterPrefix(ctx, omitted, seed, 2, snap, domain.ProviderCodex, t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
 	seedCount := 0
 	for _, ev := range out.Events {
 		if !isSeedSummaryEvent(ev) {

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -282,7 +282,10 @@ cxt load [<ref>]
 
 Restores a snapshot without creating a branch. Omitting `<ref>` loads the
 current context head. `--provider` enables supported cross-provider
-materialization.
+materialization. If an oversized conversation must be trimmed, cxt first
+distills the exact omitted span and fails without creating a provider session
+file if that projection is unavailable; it never resumes from an unexplained
+recent tail.
 
 The mode priority is:
 


### PR DESCRIPTION
Closes #90.

## Root cause

Oversized full/reconstructed loads trim an exact omitted event span before provider materialization. A distiller error was swallowed, allowing stored memory or only the recent raw tail to produce a resumable file even though the current omitted conversation had no representation.

## Fix

- make omitted-span distillation mandatory before any provider encode/materialize step
- propagate errors through both ordinary prepend and pinned Codex replacement paths
- prevent stored/ancestor memory from masking a failed current-span projection
- keep the original seed/pinned replacement unchanged on helper failure
- document the fail-closed load contract

## Verification

- Claude and pinned Codex service regressions assert no session file is created
- focused failure tests repeated 20x
- CLI full test and vet
- app race tests
- basic E2E
- sync E2E
- public preflight