### PR TITLE
fix(memory): make native prompt projection provider-aware

### DIFF
--- a/cli/cmd/cxt/main.go
+++ b/cli/cmd/cxt/main.go
@@ -234,7 +234,7 @@ func buildContainer(cfg config) container {
 	listSvc := app.NewListSessionsService(store)
 	memorizeSvc := app.NewMemorizeService(gitCtx, captures, codecs, memSources, distiller, store)
 	syncSvc := app.NewSyncRepoService(store, remote, gitCtx)
-	seedSvc := app.NewBranchSeedService(gitCtx, store, distiller, codecs, materializers)
+	seedSvc := app.NewBranchSeedService(gitCtx, store, distiller, codecs, materializers, memSources)
 	tagSvc := app.NewTagService(gitCtx, store)
 	stashSvc := app.NewStashService(gitCtx, captures, codecs, store, loadSvc)
 

--- a/cli/internal/adapters/memory/claude_memory.go
+++ b/cli/internal/adapters/memory/claude_memory.go
@@ -3,6 +3,8 @@ package memory
 import (
 	"context"
 	"path/filepath"
+	"strings"
+	"unicode/utf8"
 
 	"github.com/wnsdy95/cxthub/cli/internal/adapters/providerfs"
 	"github.com/wnsdy95/cxthub/cli/internal/domain"
@@ -34,7 +36,53 @@ func (s *ClaudeMemorySource) ReadNative(_ context.Context, cwd, _ string) (domai
 	if err != nil {
 		return domain.NativeMemory{}, false, nil
 	}
-	return domain.NativeMemory{Provider: domain.ProviderClaude, Source: "claude:MEMORY.md", Text: string(data)}, true, nil
+	text := string(data)
+	return domain.NativeMemory{
+		Provider: domain.ProviderClaude,
+		Source:   "claude:MEMORY.md",
+		Scope:    domain.NativeMemoryScopeWorkingTree,
+		// Claude currently loads the first 200 lines or 25KB of auto memory
+		// (https://code.claude.com/docs/en/memory).
+		// Use lower bounds and complete lines only so a provider-visible suffix
+		// is never removed on an ambiguous boundary.
+		AutoLoadedPrefix: claudeAutoLoadedPrefix(text),
+		Text:             text,
+	}, true, nil
+}
+
+const (
+	claudeAutoMemorySafeLines = 199
+	claudeAutoMemorySafeBytes = 24 << 10
+)
+
+func claudeAutoLoadedPrefix(text string) string {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return ""
+	}
+	if len(text) <= claudeAutoMemorySafeBytes && strings.Count(text, "\n")+1 <= claudeAutoMemorySafeLines {
+		return text
+	}
+	end := len(text)
+	if end > claudeAutoMemorySafeBytes {
+		end = claudeAutoMemorySafeBytes
+	}
+	for end > 0 && !utf8.ValidString(text[:end]) {
+		end--
+	}
+	lines := 0
+	lastCompleteLine := 0
+	for i := 0; i < end; i++ {
+		if text[i] != '\n' {
+			continue
+		}
+		lines++
+		lastCompleteLine = i + 1
+		if lines >= claudeAutoMemorySafeLines {
+			break
+		}
+	}
+	return strings.TrimSpace(text[:lastCompleteLine])
 }
 
 // ClaudeMemorySink implements MemorySink by writing a MemoryDigest to the Claude project instructions file (CLAUDE.md) (compatibility rules).

--- a/cli/internal/adapters/memory/claude_memory_test.go
+++ b/cli/internal/adapters/memory/claude_memory_test.go
@@ -1,0 +1,34 @@
+package memory
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestClaudeAutoLoadedPrefixUsesConservativeCompleteLines(t *testing.T) {
+	t.Run("small memory is fully loaded", func(t *testing.T) {
+		const text = "first memory\nsecond memory"
+		if got := claudeAutoLoadedPrefix(text); got != text {
+			t.Fatalf("prefix=%q want full memory", got)
+		}
+	})
+
+	t.Run("line-limited memory retains the unproven tail", func(t *testing.T) {
+		lines := make([]string, 250)
+		for i := range lines {
+			lines[i] = fmt.Sprintf("memory-line-%03d", i)
+		}
+		got := claudeAutoLoadedPrefix(strings.Join(lines, "\n"))
+		if !strings.Contains(got, "memory-line-198") || strings.Contains(got, "memory-line-199") {
+			t.Fatalf("line-safe prefix ended at the wrong boundary: lines=%d tail=%q", strings.Count(got, "\n")+1, got[len(got)-32:])
+		}
+	})
+
+	t.Run("byte-limited memory never cuts a long line", func(t *testing.T) {
+		text := "safe complete line\n" + strings.Repeat("x", 30<<10) + "\nUNLOADED TAIL"
+		if got := claudeAutoLoadedPrefix(text); got != "safe complete line" {
+			t.Fatalf("prefix cut an incomplete line: bytes=%d tail=%q", len(got), got[max(0, len(got)-32):])
+		}
+	})
+}

--- a/cli/internal/adapters/memory/codex_memory.go
+++ b/cli/internal/adapters/memory/codex_memory.go
@@ -97,6 +97,7 @@ func (s *CodexMemorySource) ReadNative(ctx context.Context, cwd, sessionID strin
 		return domain.NativeMemory{
 			Provider: domain.ProviderCodex,
 			Source:   "codex:memories_1.sqlite",
+			Scope:    domain.NativeMemoryScopeSession,
 			Text:     text,
 		}, true, nil
 	}

--- a/cli/internal/adapters/memory/codex_memory_test.go
+++ b/cli/internal/adapters/memory/codex_memory_test.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"testing"
 	"unicode/utf8"
+
+	"github.com/wnsdy95/cxthub/cli/internal/domain"
 )
 
 // TestCodexReadNative verifies the reading of memories_1.sqlite and rollout files from a fake HOME directory, matching cwd to thread_id, reading from SQLite, and assembling NativeMemory.
@@ -72,6 +74,9 @@ func TestCodexReadNative(t *testing.T) {
 	}
 	if native.Source != "codex:memories_1.sqlite" || native.Provider != "codex" {
 		t.Errorf("source/provider mismatch: %+v", native)
+	}
+	if native.Scope != domain.NativeMemoryScopeSession {
+		t.Errorf("scope=%q, want session", native.Scope)
 	}
 
 	// An empty raw_memory is a fallback for rollout_summary.

--- a/cli/internal/adapters/memory/distiller.go
+++ b/cli/internal/adapters/memory/distiller.go
@@ -77,7 +77,9 @@ func (d *RuleDistiller) Distill(_ context.Context, cir domain.CIRDocument, nativ
 		if len(facts) == 0 {
 			facts = tools // unstructured summary (different format) — maintain existing fallback
 		}
-		// Source marker ("native memory: …") is not added to KeyFacts — native memory is loaded by agent at session start (review P2).
+		// Native-memory source metadata is provenance, not project knowledge, so it
+		// is never added to KeyFacts. Prompt projection separately decides whether
+		// the target provider auto-loads that source in a new session.
 		suffix := extractiveConversationDigest(cir.Events[compactSummaryAt+1:])
 		return domain.MemoryDigest{
 			// Provider-written compaction memory is already the authoritative
@@ -93,10 +95,10 @@ func (d *RuleDistiller) Distill(_ context.Context, cir domain.CIRDocument, nativ
 	}
 	if native != nil {
 		// Native memory is a baseline, not a replacement for work performed in
-		// the current session after that file was loaded.
+		// the current session after that memory was produced. Scope is consumed by
+		// the app layer; the immutable digest keeps the baseline for portability.
 		return domain.MemoryDigest{
 			Summary:  domain.AppendExtractiveConversationDelta(native.Text, extractiveConversationDigest(cir.Events)),
-			KeyFacts: []string{"ingested from " + native.Source},
 			Provider: prov,
 		}, nil
 	}

--- a/cli/internal/adapters/memory/distiller_test.go
+++ b/cli/internal/adapters/memory/distiller_test.go
@@ -189,7 +189,9 @@ func TestDistillPreservesConversationAlongsideNativeMemory(t *testing.T) {
 	}
 }
 
-// TestDistillNoProvenanceMarkerInFacts ensures that the source marker ("native memory: …") does not mix with KeyFacts — the source is not a fact (review P2). Native memory is loaded by the agent at session start, so it has no information value.
+// TestDistillNoProvenanceMarkerInFacts ensures that native-memory source
+// metadata does not mix with KeyFacts. Provenance controls prompt projection;
+// it is not project knowledge.
 func TestDistillNoProvenanceMarkerInFacts(t *testing.T) {
 	cir := domain.CIRDocument{}
 	cir.Envelope.SourceProvider = domain.ProviderClaude
@@ -202,10 +204,19 @@ func TestDistillNoProvenanceMarkerInFacts(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, f := range d.KeyFacts {
-		if strings.HasPrefix(f, "native memory:") {
-			t.Fatalf("source marker mixed with KeyFacts: %q", f)
+	for _, fact := range d.KeyFacts {
+		if strings.HasPrefix(fact, "native memory:") || strings.HasPrefix(fact, "absorbed from") ||
+			strings.HasPrefix(fact, "ingested from") {
+			t.Fatalf("native-memory provenance mixed with structured KeyFacts: %q", fact)
 		}
+	}
+
+	nativeOnly, err := NewRuleDistiller().Distill(context.Background(), domain.CIRDocument{}, native)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(nativeOnly.KeyFacts) != 0 {
+		t.Fatalf("native-memory provenance mixed with KeyFacts: %v", nativeOnly.KeyFacts)
 	}
 }
 

--- a/cli/internal/adapters/memory/managed_sink_test.go
+++ b/cli/internal/adapters/memory/managed_sink_test.go
@@ -89,6 +89,23 @@ func TestMemorySinkAppendsOneManagedBlock(t *testing.T) {
 	}
 }
 
+func TestRenderMemoryMarkdownOmitsLegacyNativeProvenanceFacts(t *testing.T) {
+	got := renderMemoryMarkdown(domain.MemoryDigest{KeyFacts: []string{
+		"native memory: claude:MEMORY.md",
+		"absorbed from claude:MEMORY.md",
+		"ingested from codex:memories_1.sqlite",
+		"Overlay graft parents remain immutable.",
+	}})
+	for _, forbidden := range []string{"native memory:", "absorbed from", "ingested from"} {
+		if strings.Contains(got, forbidden) {
+			t.Fatalf("provider memory contains legacy provenance %q:\n%s", forbidden, got)
+		}
+	}
+	if !strings.Contains(got, "Overlay graft parents remain immutable.") {
+		t.Fatalf("provider memory lost project fact:\n%s", got)
+	}
+}
+
 func TestMemorySinkRejectsMalformedMarkersWithoutWrite(t *testing.T) {
 	for _, body := range []string{
 		"user\n" + testManagedMemoryBegin + "\nunterminated\n",

--- a/cli/internal/adapters/memory/render.go
+++ b/cli/internal/adapters/memory/render.go
@@ -32,7 +32,13 @@ func renderMemoryMarkdown(d domain.MemoryDigest) string {
 
 	// Structured state receives fixed reservations before narrative. Lists are
 	// selected newest-first but rendered in their original order.
-	facts := renderMemoryListTail("Key facts", d.KeyFacts, available/6)
+	providerFacts := make([]string, 0, len(d.KeyFacts))
+	for _, fact := range d.KeyFacts {
+		if !domain.IsNativeMemoryProvenanceFact(fact) {
+			providerFacts = append(providerFacts, fact)
+		}
+	}
+	facts := renderMemoryListTail("Key facts", providerFacts, available/6)
 	tasks := renderMemoryListTail("Open tasks", d.OpenTasks, available/4)
 	remaining := available - len(facts) - len(tasks)
 	summary := ""

--- a/cli/internal/app/branch_seed.go
+++ b/cli/internal/app/branch_seed.go
@@ -27,6 +27,7 @@ type BranchSeedService struct {
 	distiller     outbound.MemoryDistiller
 	codecs        map[domain.ProviderKind]outbound.ProviderCodec
 	materializers map[domain.ProviderKind]outbound.SessionMaterializer
+	memSources    map[domain.ProviderKind]outbound.MemorySource
 }
 
 // NewBranchSeedService creates BranchSeedService and injects dependencies.
@@ -36,8 +37,12 @@ func NewBranchSeedService(
 	distiller outbound.MemoryDistiller,
 	codecs map[domain.ProviderKind]outbound.ProviderCodec,
 	materializers map[domain.ProviderKind]outbound.SessionMaterializer,
+	memSources map[domain.ProviderKind]outbound.MemorySource,
 ) *BranchSeedService {
-	return &BranchSeedService{gitCtx: gitCtx, store: store, distiller: distiller, codecs: codecs, materializers: materializers}
+	return &BranchSeedService{
+		gitCtx: gitCtx, store: store, distiller: distiller,
+		codecs: codecs, materializers: materializers, memSources: memSources,
+	}
 }
 
 var _ inbound.SeedBranch = (*BranchSeedService)(nil)
@@ -64,6 +69,11 @@ func (s *BranchSeedService) Seed(ctx context.Context, in inbound.SeedInput) (inb
 	if err != nil {
 		return inbound.SeedOutput{}, err
 	}
+	targetCwd := in.Cwd
+	if targetCwd == "" {
+		targetCwd = repo.LocalPath
+	}
+	targetCwd = materializationCwd(targetCwd)
 
 	// Layer 1: main head memory (explicit project understanding), including
 	// when the departure branch itself is main. The post-checkout hook
@@ -141,6 +151,18 @@ func (s *BranchSeedService) Seed(ctx context.Context, in inbound.SeedInput) (inb
 		promptCopy := domain.WithoutConversationDeltaFromSource(*mainPromptMem, fromSnap.ID)
 		mainPromptMem = &promptCopy
 	}
+	// A branch seed is a new provider session. Remove only a baseline that the
+	// target provider guarantees it will independently load for this working
+	// tree. The attached seedMemory below keeps the complete portable digest.
+	if native, ok := readTargetNativeMemory(
+		ctx, s.memSources, provider, targetCwd, fromDoc.CIR.Envelope.SessionOriginID,
+	); ok {
+		if mainPromptMem != nil {
+			projected := projectAutoLoadedNative(*mainPromptMem, native)
+			mainPromptMem = &projected
+		}
+		promptBranchMem = projectAutoLoadedNative(promptBranchMem, native)
+	}
 
 	// Seed CIR synthesis: [Layer1⊕Layer2 summary message] + [Layer3 bounded
 	// full session]. Any semantic events cut from Layer3 become a bounded bridge
@@ -159,11 +181,7 @@ func (s *BranchSeedService) Seed(ctx context.Context, in inbound.SeedInput) (inb
 	cir := domain.CIRDocument{Events: events}
 	cir.Envelope = fromDoc.CIR.Envelope // Inherit model, cwd, etc.
 	cir.Envelope.CIRVersion = domain.CIRVersionForEvents(events)
-	targetCwd := in.Cwd
-	if targetCwd == "" {
-		targetCwd = repo.LocalPath
-	}
-	if targetCwd = materializationCwd(targetCwd); targetCwd != "" {
+	if targetCwd != "" {
 		cir.Envelope.Cwd = targetCwd
 	}
 	cir.Envelope.GitBranch = in.NewBranch

--- a/cli/internal/app/branch_seed_cwd_test.go
+++ b/cli/internal/app/branch_seed_cwd_test.go
@@ -75,6 +75,7 @@ func TestBranchSeedUsesTargetWorkingDirectory(t *testing.T) {
 		memory.NewRuleDistiller(),
 		nil,
 		nil,
+		nil,
 	)
 	out, err := service.Seed(ctx, inbound.SeedInput{
 		Cwd:        targetCwd,

--- a/cli/internal/app/branch_seed_inheritance_test.go
+++ b/cli/internal/app/branch_seed_inheritance_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/wnsdy95/cxthub/cli/internal/adapters/storage"
 	"github.com/wnsdy95/cxthub/cli/internal/domain"
 	"github.com/wnsdy95/cxthub/cli/internal/ports/inbound"
+	"github.com/wnsdy95/cxthub/cli/internal/ports/outbound"
 )
 
 func putBranchSeedSnapshot(
@@ -88,7 +89,7 @@ func TestBranchSeedSummarizesTrimmedPostCompactionConversation(t *testing.T) {
 	head := putBranchSeedSnapshot(t, ctx, store, repo.ID, "main", events, nil, nil)
 	putBranchSeedRef(t, ctx, store, repo.ID, "main", head)
 	service := NewBranchSeedService(
-		branchSeedGit{repo: repo}, store, memory.NewRuleDistiller(), nil, nil,
+		branchSeedGit{repo: repo}, store, memory.NewRuleDistiller(), nil, nil, nil,
 	)
 	out, err := service.Seed(ctx, inbound.SeedInput{
 		Cwd: repo.LocalPath, FromBranch: "main", NewBranch: "feature/post-compaction-bridge", Provider: domain.ProviderCodex,
@@ -161,7 +162,7 @@ func TestBranchSeedDoesNotDuplicateCurrentConversationInSummary(t *testing.T) {
 	}
 	head := putBranchSeedSnapshot(t, ctx, store, repo.ID, "main", events, nil, &fullMemory)
 	putBranchSeedRef(t, ctx, store, repo.ID, "main", head)
-	service := NewBranchSeedService(branchSeedGit{repo: repo}, store, memory.NewRuleDistiller(), nil, nil)
+	service := NewBranchSeedService(branchSeedGit{repo: repo}, store, memory.NewRuleDistiller(), nil, nil, nil)
 
 	out, err := service.Seed(ctx, inbound.SeedInput{
 		Cwd: repo.LocalPath, FromBranch: "main", NewBranch: "feature/no-current-dup", Provider: domain.ProviderCodex,
@@ -231,7 +232,7 @@ func TestBranchSeedBridgeFailureDoesNotCreateLossyBranch(t *testing.T) {
 	})
 	putBranchSeedRef(t, ctx, store, repo.ID, "main", head)
 	distiller := &failBridgeDistiller{}
-	service := NewBranchSeedService(branchSeedGit{repo: repo}, store, distiller, nil, nil)
+	service := NewBranchSeedService(branchSeedGit{repo: repo}, store, distiller, nil, nil, nil)
 	_, err := service.Seed(ctx, inbound.SeedInput{
 		Cwd: repo.LocalPath, FromBranch: "main", NewBranch: "feature/bridge-failure", Provider: domain.ProviderCodex,
 	})
@@ -286,6 +287,7 @@ func TestBranchSeedFromMainIncludesStoredMemoryAndFullSession(t *testing.T) {
 		stubDistiller{d: domain.MemoryDigest{Summary: "fresh main lineage summary"}},
 		nil,
 		nil,
+		nil,
 	)
 	out, err := service.Seed(ctx, inbound.SeedInput{
 		Cwd: repo.LocalPath, FromBranch: "main", NewBranch: "feature/main-inheritance", Provider: domain.ProviderCodex,
@@ -331,6 +333,61 @@ func TestBranchSeedFromMainIncludesStoredMemoryAndFullSession(t *testing.T) {
 	}
 }
 
+func TestBranchSeedProjectsClaudeCwdNativeOnlyFromPrompt(t *testing.T) {
+	ctx := context.Background()
+	store := storage.NewFileStore(t.TempDir())
+	repo := domain.Repo{ID: "repo-claude-native-seed", DefaultBranch: "main", LocalPath: t.TempDir()}
+	const nativeBaseline = "CLAUDE AUTO-LOADED PROJECT MEMORY"
+	head := putBranchSeedSnapshot(t, ctx, store, repo.ID, "main", []domain.Event{
+		seedMessage("user", "RAW DEPARTURE REQUEST", 0),
+		seedMessage("assistant", "RAW DEPARTURE RESULT", 1),
+	}, nil, &domain.MemoryDigest{Summary: nativeBaseline})
+	putBranchSeedRef(t, ctx, store, repo.ID, "main", head)
+
+	service := NewBranchSeedService(
+		branchSeedGit{repo: repo}, store,
+		stubDistiller{d: domain.MemoryDigest{Summary: "FRESH LINEAGE SUMMARY"}}, nil, nil,
+		map[domain.ProviderKind]outbound.MemorySource{
+			domain.ProviderClaude: stubMemSource{text: nativeBaseline},
+		},
+	)
+	out, err := service.Seed(ctx, inbound.SeedInput{
+		Cwd: repo.LocalPath, FromBranch: "main", NewBranch: "feature/claude-native", Provider: domain.ProviderClaude,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	seedDoc, err := store.GetDoc(ctx, out.SnapshotID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var prompt strings.Builder
+	for _, event := range seedDoc.CIR.Events {
+		for _, block := range event.Blocks {
+			prompt.WriteString(block.Text)
+		}
+	}
+	if strings.Contains(prompt.String(), nativeBaseline) {
+		t.Fatalf("branch prompt duplicated Claude cwd memory:\n%s", prompt.String())
+	}
+	for _, want := range []string{"FRESH LINEAGE SUMMARY", "RAW DEPARTURE REQUEST", "RAW DEPARTURE RESULT"} {
+		if !strings.Contains(prompt.String(), want) {
+			t.Fatalf("branch prompt lost %q:\n%s", want, prompt.String())
+		}
+	}
+	seedSnap, err := store.GetSnapshot(ctx, out.SnapshotID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	attached, err := store.GetMemory(ctx, seedSnap.MemoryHash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(attached.Summary, nativeBaseline) {
+		t.Fatalf("prompt-only projection mutated portable seed memory:\n%s", attached.Summary)
+	}
+}
+
 func TestBranchSeedFromMainDistillsMemoryWhenHeadHasNoStoredDigest(t *testing.T) {
 	ctx := context.Background()
 	store := storage.NewFileStore(t.TempDir())
@@ -344,6 +401,7 @@ func TestBranchSeedFromMainDistillsMemoryWhenHeadHasNoStoredDigest(t *testing.T)
 		branchSeedGit{repo: repo},
 		store,
 		stubDistiller{d: domain.MemoryDigest{Summary: "DISTILLED MAIN COMPACT MEMORY"}},
+		nil,
 		nil,
 		nil,
 	)
@@ -388,6 +446,7 @@ func TestBranchSeedFromOtherLineageIncludesMainMemoryAndLineageSession(t *testin
 		branchSeedGit{repo: repo},
 		store,
 		stubDistiller{d: domain.MemoryDigest{Summary: "feature lineage digest"}},
+		nil,
 		nil,
 		nil,
 	)
@@ -531,6 +590,7 @@ func TestBranchSeedUsesStoredMainMemoryWhenMainDocIsNotLocal(t *testing.T) {
 		stubDistiller{d: domain.MemoryDigest{Summary: "feature digest"}},
 		nil,
 		nil,
+		nil,
 	)
 	out, err := service.Seed(ctx, inbound.SeedInput{
 		Cwd: repo.LocalPath, FromBranch: "feature/source", NewBranch: "feature/partial-main", Provider: domain.ProviderCodex,
@@ -574,6 +634,7 @@ func TestBranchSeedMainMemoryAndConversationStayWithinBudget(t *testing.T) {
 		branchSeedGit{repo: repo},
 		store,
 		stubDistiller{d: domain.MemoryDigest{Summary: "bounded lineage summary"}},
+		nil,
 		nil,
 		nil,
 	)
@@ -692,6 +753,7 @@ func TestBranchSeedCarriedMemoryIsBounded(t *testing.T) {
 		stubDistiller{d: domain.MemoryDigest{Summary: "fresh lineage summary"}},
 		nil,
 		nil,
+		nil,
 	)
 	out, err := service.Seed(ctx, inbound.SeedInput{
 		Cwd: repo.LocalPath, FromBranch: "main", NewBranch: "feature/cap", Provider: domain.ProviderCodex,
@@ -741,7 +803,7 @@ func TestRepeatedBranchSeedsDoNotCarryPriorSyntheticPrompts(t *testing.T) {
 
 	service := NewBranchSeedService(
 		branchSeedGit{repo: repo}, store,
-		stubDistiller{d: domain.MemoryDigest{Summary: "fresh lineage memory"}}, nil, nil,
+		stubDistiller{d: domain.MemoryDigest{Summary: "fresh lineage memory"}}, nil, nil, nil,
 	)
 	first, err := service.Seed(ctx, inbound.SeedInput{
 		Cwd: repo.LocalPath, FromBranch: "main", NewBranch: "feature/one", Provider: domain.ProviderCodex,

--- a/cli/internal/app/load_session.go
+++ b/cli/internal/app/load_session.go
@@ -579,7 +579,9 @@ const seedSummaryPrefix = "[cxt] This session was resumed from a branch context 
 //
 // Deduplication:
 //   - Previous generation seed summary (prefix CompactSummary) in the tail is removed — the new summary takes precedence.
-//   - If the digest summary matches the original native memory (e.g., MEMORY.md) of the target provider, it is omitted — the agent loads context itself at session start, so context re-injection is redundant.
+//   - An exact working-tree-scoped native baseline (e.g. Claude MEMORY.md) is
+//     omitted from the prompt copy because the target provider loads it again.
+//     Session-scoped memory remains portable across the new provider session ID.
 //   - KeyFacts noise such as whitespace-free tool tokens and legacy ingestion markers ("native memory:"/"absorbed from") is excluded from seed content.
 func (s *LoadSessionService) prependTrimDigest(ctx context.Context, omitted, seed domain.CIRDocument, snap domain.Snapshot, target domain.ProviderKind, cwd string) (domain.CIRDocument, error) {
 	out, _, _, err := s.prependTrimDigestWithStatus(ctx, omitted, seed, snap, target, cwd, nil)
@@ -638,13 +640,10 @@ func (s *LoadSessionService) prependTrimDigestWithStatus(ctx context.Context, om
 			seedProjected = true
 		}
 	}
-	// Skip native-memory duplicates when the summary repeats the ingested native memory verbatim.
-	if src, ok := s.memSources[target]; ok && digest.Summary != "" &&
-		(omitted.Envelope.SourceProvider == "" || target == omitted.Envelope.SourceProvider) {
-		if nm, found, _ := src.ReadNative(ctx, cwd, omitted.Envelope.SessionOriginID); found &&
-			strings.TrimSpace(digest.Summary) == strings.TrimSpace(nm.Text) {
-			digest.Summary = ""
-		}
+	// Stored memory remains untouched. Only the provider-visible copy may drop
+	// a baseline that the target guarantees it will load for this working tree.
+	if native, ok := readTargetNativeMemory(ctx, s.memSources, target, cwd, omitted.Envelope.SessionOriginID); ok {
+		digest = projectAutoLoadedNative(digest, native)
 	}
 	_, digestBudget := seedBudgets(target)
 	text := renderSeedDigest(digest, len(omitted.Events), digestBudget)
@@ -808,8 +807,7 @@ func seedWorthyFacts(facts []string) []string {
 	var out []string
 	for _, f := range facts {
 		t := strings.TrimSpace(f)
-		if t == "" || !strings.Contains(t, " ") ||
-			strings.HasPrefix(t, "native memory:") || strings.HasPrefix(t, "absorbed from") {
+		if t == "" || !strings.Contains(t, " ") || domain.IsNativeMemoryProvenanceFact(t) {
 			continue
 		}
 		out = append(out, t)
@@ -819,14 +817,12 @@ func seedWorthyFacts(facts []string) []string {
 
 // loadMemory performs memory-form restoration: native-first ingestion → distillation → provider memory file injection.
 func (s *LoadSessionService) loadMemory(ctx context.Context, cir domain.CIRDocument, snap domain.Snapshot, target domain.ProviderKind, cwd string) (inbound.LoadOutput, error) {
-	var native *domain.NativeMemory
-	if src, ok := s.memSources[target]; ok &&
-		(cir.Envelope.SourceProvider == "" || target == cir.Envelope.SourceProvider) {
-		if nm, found, _ := src.ReadNative(ctx, cwd, cir.Envelope.SessionOriginID); found {
-			native = &nm
-		}
+	targetNative, _ := readTargetNativeMemory(ctx, s.memSources, target, cwd, cir.Envelope.SessionOriginID)
+	var distillNative *domain.NativeMemory
+	if cir.Envelope.SourceProvider == "" || target == cir.Envelope.SourceProvider {
+		distillNative = targetNative
 	}
-	digest, err := s.distiller.Distill(ctx, cir.EffectiveContext(), native)
+	digest, err := s.distiller.Distill(ctx, cir.EffectiveContext(), distillNative)
 	if err != nil {
 		return inbound.LoadOutput{}, err
 	}
@@ -838,6 +834,7 @@ func (s *LoadSessionService) loadMemory(ctx context.Context, cir domain.CIRDocum
 		prior = boundCarriedDigest(prior)
 		digest = domain.MergeDigests(prior, digest)
 	}
+	digest = projectAutoLoadedNative(digest, targetNative)
 	if digest.Provider == "" {
 		digest.Provider = target
 	}

--- a/cli/internal/app/native_memory_projection.go
+++ b/cli/internal/app/native_memory_projection.go
@@ -1,0 +1,45 @@
+package app
+
+import (
+	"context"
+	"strings"
+
+	"github.com/wnsdy95/cxthub/cli/internal/domain"
+	"github.com/wnsdy95/cxthub/cli/internal/ports/outbound"
+)
+
+// readTargetNativeMemory reads provider-owned memory for projection decisions.
+// Failure is deliberately fail-open: keeping a possibly duplicated baseline is
+// safer than deleting the portable copy when its provider ownership cannot be
+// proven.
+func readTargetNativeMemory(
+	ctx context.Context,
+	sources map[domain.ProviderKind]outbound.MemorySource,
+	target domain.ProviderKind,
+	cwd, sessionID string,
+) (*domain.NativeMemory, bool) {
+	source, ok := sources[target]
+	if !ok {
+		return nil, false
+	}
+	native, found, err := source.ReadNative(ctx, cwd, sessionID)
+	if err != nil || !found || strings.TrimSpace(native.Text) == "" {
+		return nil, false
+	}
+	if native.Provider != "" && native.Provider != target {
+		return nil, false
+	}
+	return &native, true
+}
+
+// projectAutoLoadedNative removes only a working-tree-scoped baseline from a
+// provider-visible copy. Session-scoped memory (notably Codex stage1 memory)
+// must cross the materialization boundary because the new session gets a new
+// provider ID.
+func projectAutoLoadedNative(digest domain.MemoryDigest, native *domain.NativeMemory) domain.MemoryDigest {
+	if native == nil || native.Scope != domain.NativeMemoryScopeWorkingTree ||
+		strings.TrimSpace(native.AutoLoadedPrefix) == "" {
+		return digest
+	}
+	return domain.WithoutAutoLoadedSummaryPrefix(digest, native.Text, native.AutoLoadedPrefix)
+}

--- a/cli/internal/app/restore_test.go
+++ b/cli/internal/app/restore_test.go
@@ -461,7 +461,10 @@ func TestLoadMemoryMode(t *testing.T) {
 		t.Fatal(err)
 	}
 	if !strings.HasPrefix(string(data), userInstructions) || !strings.Contains(string(data), "cxt memory") || !strings.Contains(string(data), "NEWEST-NATIVE") || !strings.Contains(string(data), "do it") {
-		t.Fatalf("CLAUDE.md did not preserve user instructions and bounded latest memory")
+		t.Fatalf("CLAUDE.md did not preserve user instructions and current conversation")
+	}
+	if strings.Contains(string(data), "OLDEST-NATIVE") {
+		t.Fatalf("CLAUDE.md duplicated the safe cwd-native prefix that Claude already auto-loads")
 	}
 	if strings.Contains(string(data), "[cxt conversation delta v1]") {
 		t.Fatal("private memory marker leaked into provider instruction file")

--- a/cli/internal/app/seed_digest_test.go
+++ b/cli/internal/app/seed_digest_test.go
@@ -25,11 +25,23 @@ func (failingDistiller) Distill(_ context.Context, _ domain.CIRDocument, _ *doma
 	return domain.MemoryDigest{}, errors.New("distillation unavailable")
 }
 
+type recordingNativeDistiller struct {
+	native *domain.NativeMemory
+}
+
+func (d *recordingNativeDistiller) Distill(_ context.Context, _ domain.CIRDocument, native *domain.NativeMemory) (domain.MemoryDigest, error) {
+	d.native = native
+	return domain.MemoryDigest{Summary: "loaded memory"}, nil
+}
+
 type stubMemSource struct{ text string }
 
 func (s stubMemSource) Provider() domain.ProviderKind { return domain.ProviderClaude }
 func (s stubMemSource) ReadNative(_ context.Context, _, _ string) (domain.NativeMemory, bool, error) {
-	return domain.NativeMemory{Source: "claude:MEMORY.md", Text: s.text}, s.text != "", nil
+	return domain.NativeMemory{
+		Provider: domain.ProviderClaude, Source: "claude:MEMORY.md",
+		Scope: domain.NativeMemoryScopeWorkingTree, AutoLoadedPrefix: s.text, Text: s.text,
+	}, s.text != "", nil
 }
 
 type recordingSessionMemSource struct {
@@ -43,13 +55,27 @@ func (s *recordingSessionMemSource) ReadNative(_ context.Context, cwd, sessionID
 	s.calls++
 	s.gotCwd = cwd
 	s.gotSessionID = sessionID
-	return domain.NativeMemory{Source: "codex:rollout_summary", Text: "exact session memory"}, true, nil
+	return domain.NativeMemory{
+		Provider: s.provider, Source: "codex:rollout_summary",
+		Scope: domain.NativeMemoryScopeSession, Text: "exact session memory",
+	}, true, nil
 }
 
 type recordingMemorySink struct{ provider domain.ProviderKind }
 
 func (s recordingMemorySink) Provider() domain.ProviderKind { return s.provider }
 func (s recordingMemorySink) Inject(_ context.Context, _ domain.MemoryDigest, cwd string) (string, error) {
+	return cwd + "/managed-memory", nil
+}
+
+type recordingDigestSink struct {
+	provider domain.ProviderKind
+	digest   domain.MemoryDigest
+}
+
+func (s *recordingDigestSink) Provider() domain.ProviderKind { return s.provider }
+func (s *recordingDigestSink) Inject(_ context.Context, digest domain.MemoryDigest, cwd string) (string, error) {
+	s.digest = digest
 	return cwd + "/managed-memory", nil
 }
 
@@ -106,7 +132,7 @@ func TestMemorizeReadsNativeMemoryForExactProviderSession(t *testing.T) {
 	}
 }
 
-func TestLoadMemoryScopesNativeLookupToSameProviderSession(t *testing.T) {
+func TestLoadMemorySeparatesTargetProjectionLookupFromSourceDistillation(t *testing.T) {
 	ctx := context.Background()
 	cwd := t.TempDir()
 	cir := domain.CIRDocument{Envelope: domain.Envelope{
@@ -117,27 +143,74 @@ func TestLoadMemoryScopesNativeLookupToSameProviderSession(t *testing.T) {
 	snap := domain.Snapshot{ID: domain.HashContent([]byte("load-memory-session-scope"))}
 
 	for _, tc := range []struct {
-		name        string
-		target      domain.ProviderKind
-		wantCalls   int
-		wantSession string
+		name       string
+		target     domain.ProviderKind
+		wantNative bool
 	}{
-		{name: "same provider", target: domain.ProviderCodex, wantCalls: 1, wantSession: "codex-session-exact"},
-		{name: "cross provider", target: domain.ProviderClaude, wantCalls: 0, wantSession: ""},
+		{name: "same provider", target: domain.ProviderCodex, wantNative: true},
+		{name: "cross provider", target: domain.ProviderClaude, wantNative: false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			source := &recordingSessionMemSource{provider: tc.target}
+			distiller := &recordingNativeDistiller{}
 			service := NewLoadSessionService(
 				storage.NewFileStore(t.TempDir()), nil, nil,
 				map[domain.ProviderKind]outbound.MemorySource{tc.target: source},
-				stubDistiller{d: domain.MemoryDigest{Summary: "loaded memory"}},
+				distiller,
 				map[domain.ProviderKind]outbound.MemorySink{tc.target: recordingMemorySink{provider: tc.target}},
 			)
 			if _, err := service.loadMemory(ctx, cir, snap, tc.target, cwd); err != nil {
 				t.Fatal(err)
 			}
-			if source.calls != tc.wantCalls || source.gotSessionID != tc.wantSession {
-				t.Fatalf("native memory lookup calls=%d session=%q, want calls=%d session=%q", source.calls, source.gotSessionID, tc.wantCalls, tc.wantSession)
+			if source.calls != 1 || source.gotSessionID != "codex-session-exact" {
+				t.Fatalf("target projection lookup calls=%d session=%q", source.calls, source.gotSessionID)
+			}
+			if got := distiller.native != nil; got != tc.wantNative {
+				t.Fatalf("native memory passed to source distillation=%v, want %v", got, tc.wantNative)
+			}
+		})
+	}
+}
+
+func TestLoadMemoryProjectsNativeBaselineByScope(t *testing.T) {
+	ctx := context.Background()
+	const currentDecision = "CURRENT MEMORY-MODE DECISION"
+	for _, tc := range []struct {
+		name         string
+		provider     domain.ProviderKind
+		source       outbound.MemorySource
+		nativeText   string
+		wantBaseline bool
+	}{
+		{
+			name: "Claude working-tree memory is already auto-loaded", provider: domain.ProviderClaude,
+			source: stubMemSource{text: "CLAUDE MEMORY MODE BASELINE"}, nativeText: "CLAUDE MEMORY MODE BASELINE",
+		},
+		{
+			name: "Codex thread memory must cross into the new session", provider: domain.ProviderCodex,
+			source: &recordingSessionMemSource{provider: domain.ProviderCodex}, nativeText: "exact session memory", wantBaseline: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cwd := t.TempDir()
+			sink := &recordingDigestSink{provider: tc.provider}
+			service := NewLoadSessionService(
+				storage.NewFileStore(t.TempDir()), nil, nil,
+				map[domain.ProviderKind]outbound.MemorySource{tc.provider: tc.source},
+				memory.NewRuleDistiller(),
+				map[domain.ProviderKind]outbound.MemorySink{tc.provider: sink},
+			)
+			cir := domain.CIRDocument{Envelope: domain.Envelope{
+				SourceProvider: tc.provider, SessionOriginID: "codex-session-exact",
+			}, Events: []domain.Event{seedMessage("user", currentDecision, 0)}}
+			if _, err := service.loadMemory(ctx, cir, domain.Snapshot{}, tc.provider, cwd); err != nil {
+				t.Fatal(err)
+			}
+			if got := strings.Contains(sink.digest.Summary, tc.nativeText); got != tc.wantBaseline {
+				t.Fatalf("managed memory baseline present=%v, want %v:\n%s", got, tc.wantBaseline, sink.digest.Summary)
+			}
+			if !strings.Contains(sink.digest.Summary, currentDecision) {
+				t.Fatalf("managed memory lost current conversation:\n%s", sink.digest.Summary)
 			}
 		})
 	}
@@ -171,7 +244,7 @@ func TestPrependTrimDigestCompactSummary(t *testing.T) {
 
 	svc := mk(domain.MemoryDigest{
 		Summary:  "did X, decided Y",
-		KeyFacts: []string{"apply_patch", "unknown:Agent", "native memory: claude:MEMORY.md", "absorbed from claude:MEMORY.md", "budget is 400KB per seed"},
+		KeyFacts: []string{"apply_patch", "unknown:Agent", "native memory: claude:MEMORY.md", "absorbed from claude:MEMORY.md", "ingested from codex:memories_1.sqlite", "budget is 400KB per seed"},
 	}, "")
 	out, err := svc.prependTrimDigest(ctx, full, seed, domain.Snapshot{}, domain.ProviderClaude, t.TempDir())
 	if err != nil {
@@ -190,7 +263,7 @@ func TestPrependTrimDigestCompactSummary(t *testing.T) {
 		t.Fatalf("Missing summary body: %q", text)
 	}
 	if strings.Contains(text, "apply_patch") || strings.Contains(text, "unknown:Agent") ||
-		strings.Contains(text, "native memory:") || strings.Contains(text, "absorbed from") {
+		strings.Contains(text, "native memory:") || strings.Contains(text, "absorbed from") || strings.Contains(text, "ingested from") {
 		t.Fatalf("KeyFacts noise included in seed: %q", text)
 	}
 	if !strings.Contains(text, "budget is 400KB per seed") {
@@ -208,6 +281,110 @@ func TestPrependTrimDigestCompactSummary(t *testing.T) {
 	}
 	if strings.Contains(out.Events[0].Blocks[0].Text, "MEMROOT") {
 		t.Fatalf("Native memory text re-injected into seed: %q", out.Events[0].Blocks[0].Text)
+	}
+}
+
+func TestPrependTrimDigestRemovesClaudeNativeBaselineInsideMergedProjection(t *testing.T) {
+	ctx := context.Background()
+	st := storage.NewFileStore(t.TempDir())
+	snapshotID := domain.HashContent([]byte("claude-native-current-snapshot"))
+	ancestorID := domain.HashContent([]byte("claude-native-ancestor-snapshot"))
+	const nativeBaseline = "CLAUDE CWD NATIVE BASELINE"
+	ancestor := domain.MemoryDigest{
+		SnapshotID: ancestorID,
+		Summary: domain.AppendExtractiveConversationDelta(nativeBaseline,
+			domain.RenderExtractiveFallbackSummary([]string{"ANCESTOR DECISION MUST REMAIN"}, nil)),
+	}
+	ancestor = domain.MergeDigests(domain.MemoryDigest{}, ancestor)
+	ancestorMemoryHash, err := st.PutMemory(ctx, ancestor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.PutSnapshot(ctx, domain.Snapshot{
+		ID: ancestorID, DocHash: ancestorID, MemoryHash: ancestorMemoryHash,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	stored := domain.MemoryDigest{
+		SnapshotID: snapshotID,
+		Fragments: []domain.MemoryFragment{
+			{
+				SourceSnapshot: snapshotID,
+				Summary: domain.AppendExtractiveConversationDelta(nativeBaseline,
+					domain.RenderExtractiveFallbackSummary([]string{"CURRENT RAW TURN"}, nil)),
+			},
+		},
+	}
+	stored = domain.MergeDigests(domain.MemoryDigest{}, stored)
+	memoryHash, err := st.PutMemory(ctx, stored)
+	if err != nil {
+		t.Fatal(err)
+	}
+	snap := domain.Snapshot{
+		ID: snapshotID, DocHash: snapshotID, MemoryHash: memoryHash,
+		Parents: []domain.ContentHash{ancestorID},
+	}
+	if err := st.PutSnapshot(ctx, snap); err != nil {
+		t.Fatal(err)
+	}
+
+	svc := NewLoadSessionService(st, nil, nil,
+		map[domain.ProviderKind]outbound.MemorySource{
+			domain.ProviderClaude: stubMemSource{text: nativeBaseline},
+		},
+		stubDistiller{d: domain.MemoryDigest{Summary: "FRESH OMITTED DECISION"}}, nil,
+	)
+	omitted := domain.CIRDocument{Envelope: domain.Envelope{
+		SourceProvider: domain.ProviderClaude, SessionOriginID: "claude-source-session",
+	}, Events: []domain.Event{seedMessage("user", "old request", 0)}}
+	seed := domain.CIRDocument{Events: []domain.Event{seedMessage("user", "RECENT RAW TURN", 1)}}
+
+	out, err := svc.prependTrimDigest(ctx, omitted, seed, snap, domain.ProviderClaude, t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var prompt strings.Builder
+	for _, event := range out.Events {
+		for _, block := range event.Blocks {
+			prompt.WriteString(block.Text)
+		}
+	}
+	if strings.Contains(prompt.String(), nativeBaseline) {
+		t.Fatalf("cwd-native baseline was injected even though Claude loads it automatically:\n%s", prompt.String())
+	}
+	for _, want := range []string{"ANCESTOR DECISION MUST REMAIN", "FRESH OMITTED DECISION", "RECENT RAW TURN"} {
+		if !strings.Contains(prompt.String(), want) {
+			t.Fatalf("native baseline projection lost %q:\n%s", want, prompt.String())
+		}
+	}
+	if strings.Contains(prompt.String(), "CURRENT RAW TURN") {
+		t.Fatalf("current source delta was duplicated into the summary:\n%s", prompt.String())
+	}
+}
+
+func TestPrependTrimDigestKeepsCodexThreadNativeMemoryForNewSession(t *testing.T) {
+	ctx := context.Background()
+	st := storage.NewFileStore(t.TempDir())
+	source := &recordingSessionMemSource{provider: domain.ProviderCodex}
+	svc := NewLoadSessionService(st, nil, nil,
+		map[domain.ProviderKind]outbound.MemorySource{domain.ProviderCodex: source},
+		stubDistiller{d: domain.MemoryDigest{Summary: "exact session memory"}}, nil,
+	)
+	omitted := domain.CIRDocument{Envelope: domain.Envelope{
+		SourceProvider: domain.ProviderCodex, SessionOriginID: "codex-session-exact",
+	}, Events: []domain.Event{seedMessage("user", "old request", 0)}}
+	seed := domain.CIRDocument{Events: []domain.Event{seedMessage("user", "recent request", 1)}}
+
+	out, err := svc.prependTrimDigest(ctx, omitted, seed, domain.Snapshot{}, domain.ProviderCodex, t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if source.calls != 1 || source.gotSessionID != "codex-session-exact" {
+		t.Fatalf("native lookup calls=%d session=%q", source.calls, source.gotSessionID)
+	}
+	if len(out.Events) == 0 || len(out.Events[0].Blocks) == 0 ||
+		!strings.Contains(out.Events[0].Blocks[0].Text, "exact session memory") {
+		t.Fatalf("thread-scoped Codex memory was dropped before materializing a new thread: %+v", out.Events)
 	}
 }
 

--- a/cli/internal/domain/entities.go
+++ b/cli/internal/domain/entities.go
@@ -350,6 +350,66 @@ func WithoutConversationDeltaFromSource(d MemoryDigest, source ContentHash) Memo
 	return d
 }
 
+// WithoutExactSummaryBaseline returns a provider-visible copy with one exact
+// baseline removed from every provenance fragment. Canonical conversation
+// deltas attached to that baseline remain, as do unrelated provider text,
+// facts, and tasks. Stored MemoryDigest objects must never use this projection:
+// it is only safe when the target provider independently auto-loads the exact
+// same baseline for the working tree.
+func WithoutExactSummaryBaseline(d MemoryDigest, exact string) MemoryDigest {
+	return WithoutAutoLoadedSummaryPrefix(d, exact, exact)
+}
+
+// WithoutAutoLoadedSummaryPrefix removes a provider-guaranteed prefix from an
+// otherwise exact native baseline. The suffix stays in the provider-visible
+// digest. Callers supply a conservative prefix consisting only of content the
+// target will load independently; fuzzy or partial baseline matches are never
+// accepted.
+func WithoutAutoLoadedSummaryPrefix(d MemoryDigest, full, loadedPrefix string) MemoryDigest {
+	full = strings.TrimSpace(full)
+	loadedPrefix = strings.TrimSpace(loadedPrefix)
+	if full == "" || loadedPrefix == "" || !strings.HasPrefix(full, loadedPrefix) {
+		return d
+	}
+	remaining := strings.TrimSpace(strings.TrimPrefix(full, loadedPrefix))
+	strip := func(summary string) string {
+		baseline, users, assistants, ok := splitExtractiveFallbackSummary(summary)
+		if ok {
+			if strings.TrimSpace(baseline) != full {
+				return summary
+			}
+			delta := RenderExtractiveFallbackSummary(users, assistants)
+			return AppendExtractiveConversationDelta(remaining, delta)
+		}
+		if strings.TrimSpace(summary) == full {
+			return remaining
+		}
+		return summary
+	}
+	if len(d.Fragments) == 0 {
+		d.Summary = strip(d.Summary)
+		return d
+	}
+	fragments := append([]MemoryFragment(nil), d.Fragments...)
+	for i := range fragments {
+		fragments[i].Summary = strip(fragments[i].Summary)
+	}
+	d.Fragments = fragments
+	renderMemoryFragments(&d)
+	return d
+}
+
+// IsNativeMemoryProvenanceFact recognizes source labels emitted by older cxt
+// distillers. They are transport metadata, not project knowledge, and should
+// be excluded only when rendering provider-visible prompts or instruction
+// files. Immutable stored digests retain them for compatibility.
+func IsNativeMemoryProvenanceFact(fact string) bool {
+	fact = strings.ToLower(strings.TrimSpace(fact))
+	return strings.HasPrefix(fact, "native memory:") ||
+		strings.HasPrefix(fact, "absorbed from") ||
+		strings.HasPrefix(fact, "ingested from")
+}
+
 const (
 	extractiveFallbackHeader           = "Conversation digest (extractive fallback; provider compaction summary unavailable):"
 	extractiveFallbackUsersHeader      = "Recent user intent:"
@@ -493,6 +553,17 @@ func dedupStrings(lists ...[]string) []string {
 	return out
 }
 
+// NativeMemoryScope describes whether provider-owned memory follows a working
+// tree or one provider session. The distinction controls prompt projection:
+// only WorkingTree memory is guaranteed to be loaded again in a newly
+// materialized session.
+type NativeMemoryScope string
+
+const (
+	NativeMemoryScopeWorkingTree NativeMemoryScope = "working_tree"
+	NativeMemoryScopeSession     NativeMemoryScope = "session"
+)
+
 // NativeMemory is a native memory value object created by the provider CLI (Section compatibility rules).
 // MemorySource.ReadNative returns the ingestion source used as the native-first input to MemoryDistiller.Distill.
 type NativeMemory struct {
@@ -500,6 +571,13 @@ type NativeMemory struct {
 	Provider ProviderKind `json:"provider"`
 	// Source is the origin identifier. Example: "claude:MEMORY.md", "codex:rollout_summary".
 	Source string `json:"source"`
+	// Scope states whether the provider auto-loads this value for every new
+	// session in the working tree or keeps it bound to the source session.
+	Scope NativeMemoryScope `json:"scope,omitempty"`
+	// AutoLoadedPrefix is a conservative, complete-line prefix guaranteed to be
+	// loaded in a new session. It may be shorter than Text when the provider has
+	// a startup memory limit. Empty means no bytes may be removed from prompts.
+	AutoLoadedPrefix string `json:"auto_loaded_prefix,omitempty"`
 	// Text is the native memory body (narrative text).
 	Text string `json:"text"`
 	// Structured is an optional structured key-value map (optional, can be nil).

--- a/cli/internal/domain/merge_digests_test.go
+++ b/cli/internal/domain/merge_digests_test.go
@@ -147,6 +147,83 @@ func TestWithoutConversationDeltaLeavesUnstructuredProviderTextUntouched(t *test
 	}
 }
 
+func TestWithoutExactSummaryBaselinePreservesDeltasAndUnrelatedFragments(t *testing.T) {
+	leftID := ContentHash("sha256:" + strings.Repeat("1", 64))
+	rightID := ContentHash("sha256:" + strings.Repeat("2", 64))
+	otherID := ContentHash("sha256:" + strings.Repeat("3", 64))
+	const baseline = "EXACT AUTO-LOADED PROVIDER BASELINE"
+	digest := MemoryDigest{Fragments: []MemoryFragment{
+		{
+			SourceSnapshot: leftID,
+			Summary: AppendExtractiveConversationDelta(baseline, RenderExtractiveFallbackSummary(
+				[]string{"Left lineage decision remains."}, nil)),
+		},
+		{
+			SourceSnapshot: rightID,
+			Summary: AppendExtractiveConversationDelta(baseline, RenderExtractiveFallbackSummary(
+				nil, []string{"Right lineage result remains."})),
+		},
+		{SourceSnapshot: otherID, Summary: "UNRELATED PROVIDER BASELINE"},
+	}}
+	digest = MergeDigests(MemoryDigest{}, digest)
+
+	got := WithoutExactSummaryBaseline(digest, baseline)
+	if strings.Contains(got.Summary, baseline) {
+		t.Fatalf("exact auto-loaded baseline remains:\n%s", got.Summary)
+	}
+	for _, want := range []string{
+		"Left lineage decision remains.", "Right lineage result remains.", "UNRELATED PROVIDER BASELINE",
+	} {
+		if !strings.Contains(got.Summary, want) {
+			t.Fatalf("baseline projection lost %q:\n%s", want, got.Summary)
+		}
+	}
+	if !strings.Contains(digest.Summary, baseline) {
+		t.Fatal("prompt projection mutated the stored digest")
+	}
+
+	legacy := MemoryDigest{SnapshotID: leftID, Summary: baseline}
+	if stripped := WithoutExactSummaryBaseline(legacy, baseline); stripped.Summary != "" {
+		t.Fatalf("legacy exact baseline = %q, want empty", stripped.Summary)
+	}
+	containing := MemoryDigest{SnapshotID: leftID, Summary: "prefix " + baseline}
+	if kept := WithoutExactSummaryBaseline(containing, baseline); kept.Summary != containing.Summary {
+		t.Fatalf("non-exact provider text changed: got %q want %q", kept.Summary, containing.Summary)
+	}
+}
+
+func TestWithoutAutoLoadedSummaryPrefixKeepsNativeTail(t *testing.T) {
+	id := ContentHash("sha256:" + strings.Repeat("4", 64))
+	const (
+		loadedPrefix = "AUTO-LOADED LINE ONE\nAUTO-LOADED LINE TWO"
+		nativeTail   = "NATIVE TAIL NOT LOADED BY PROVIDER"
+	)
+	full := loadedPrefix + "\n" + nativeTail
+	digest := MemoryDigest{
+		SnapshotID: id,
+		Summary: AppendExtractiveConversationDelta(full, RenderExtractiveFallbackSummary(
+			[]string{"Conversation delta remains."}, nil)),
+	}
+	digest = MergeDigests(MemoryDigest{}, digest)
+
+	got := WithoutAutoLoadedSummaryPrefix(digest, full, loadedPrefix)
+	if strings.Contains(got.Summary, loadedPrefix) {
+		t.Fatalf("safe auto-loaded prefix remains:\n%s", got.Summary)
+	}
+	for _, want := range []string{nativeTail, "Conversation delta remains."} {
+		if !strings.Contains(got.Summary, want) {
+			t.Fatalf("partial native projection lost %q:\n%s", want, got.Summary)
+		}
+	}
+	if !strings.Contains(digest.Summary, loadedPrefix) {
+		t.Fatal("partial prompt projection mutated stored digest")
+	}
+
+	if unchanged := WithoutAutoLoadedSummaryPrefix(digest, full, "not an exact prefix"); unchanged.Summary != digest.Summary {
+		t.Fatalf("non-prefix projection changed digest: got %q want %q", unchanged.Summary, digest.Summary)
+	}
+}
+
 func TestMergeDigestsPreservesUniqueSiblingFallbackItems(t *testing.T) {
 	left := MemoryDigest{
 		SnapshotID: ContentHash("sha256:" + strings.Repeat("c", 64)),

--- a/cli/internal/ports/outbound/ports.go
+++ b/cli/internal/ports/outbound/ports.go
@@ -254,13 +254,16 @@ type PushObjectNegotiator interface {
 // MemorySource is a port that absorbs provider native memory (compatibility rules).
 //
 // Absorb if available: Claude MEMORY.md, Codex rollout_summary, etc. Input source for native-first strategy.
+// NativeMemory.Scope states whether that value is automatically available to
+// a new session in the working tree or remains bound to the source session.
 type MemorySource interface {
 	// Provider returns the provider this source is responsible for (claude|codex).
 	Provider() domain.ProviderKind
 
 	// ReadNative reads provider native memory for the exact provider session when
 	// sessionID is available. An empty sessionID falls back to the newest memory
-	// associated with cwd. Returns found=false if not found (no error).
+	// associated with cwd. Implementations must set NativeMemory.Scope. Returns
+	// found=false if not found (no error).
 	ReadNative(ctx context.Context, cwd, sessionID string) (native domain.NativeMemory, found bool, err error)
 }
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -252,6 +252,11 @@ operations without enlarging the provider prompt budget. When current
 conversation events are also replayed verbatim, their extractive memory delta
 is removed only from the prompt projection, so the new session receives each
 turn once while the full digest remains attached to the seed.
+Provider-native baselines follow the same prompt-only rule with an explicit
+scope. For Claude `MEMORY.md`, cxt removes only a conservative complete-line
+prefix (at most 199 lines and 24 KiB) inside Claude's documented startup limit
+and carries any remaining tail. Codex `memories_1.sqlite` memory is retained
+because it belongs to the source thread and the seed receives a new thread ID.
 
 ### `cxt switch`
 
@@ -299,6 +304,11 @@ The mode priority is:
 refreshes one marked region in `CLAUDE.md` or `AGENTS.md`; text and permissions
 outside that region are preserved. Malformed or duplicate cxt markers fail
 closed instead of guessing a destructive replacement range.
+The provider-visible projection does not repeat a working-tree-scoped native
+prefix that is guaranteed to auto-load, but it preserves the un-loaded suffix,
+its conversation delta, and every unrelated lineage fragment. Session-scoped
+native memory is carried into the managed region so a newly materialized
+provider session cannot lose it.
 
 ### `cxt memorize` and `cxt memory`
 


### PR DESCRIPTION
## What changed

- distinguish working-tree and session-scoped provider memory
- carry a conservative `AutoLoadedPrefix` instead of assuming an entire native file is loaded
- remove only complete Claude MEMORY.md lines within 199 lines / 24KiB; preserve the un-loaded tail and conversation deltas
- retain Codex stage1 memory across newly materialized thread IDs
- apply the same prompt-only projection to reconstructed load, branch seed, and memory-mode load
- keep immutable stored digests unchanged and filter legacy native provenance from provider-visible facts

## Why

The previous aggregate equality check missed Claude duplicates after lineage/delta merging and could delete Codex thread memory. During review, the current Claude contract also showed that only the first 200 lines or 25KB of auto memory loads at startup, so removing an entire MEMORY.md would lose its tail.

Official Claude contract: https://code.claude.com/docs/en/memory

## Verification

- focused native projection tests x20
- `go test ./...`
- `go vet ./...`
- `go test -race ./...`
- `make e2e`
- `make e2e-sync`
- `bash scripts/public-preflight.sh`

Closes #92
