### PR TITLE
fix: resolve Claude auto memory safely

### DIFF
--- a/cli/internal/adapters/delivery/cli/agent_wrapper.go
+++ b/cli/internal/adapters/delivery/cli/agent_wrapper.go
@@ -20,6 +20,7 @@ import (
 	"github.com/wnsdy95/cxthub/cli/internal/adapters/boundary"
 	"github.com/wnsdy95/cxthub/cli/internal/adapters/capture"
 	"github.com/wnsdy95/cxthub/cli/internal/adapters/codec"
+	memoryadapter "github.com/wnsdy95/cxthub/cli/internal/adapters/memory"
 	"github.com/wnsdy95/cxthub/cli/internal/adapters/providerfs"
 	"github.com/wnsdy95/cxthub/cli/internal/domain"
 	"github.com/wnsdy95/cxthub/cli/internal/ports/inbound"
@@ -62,6 +63,19 @@ func runAgentWrapper(ctx context.Context, c *Container, cwd, agent string, args 
 			fmt.Sprintf("CXT_WRAPPER_PID=%d", os.Getpid()),
 			"CXT_WRAPPED_AGENT="+agent,
 		)
+		var childMemoryEnv []string
+		if agent == "claude" {
+			// Derive the profile from this exact child invocation. A context
+			// transition may replace an old --resume command and drop flags that
+			// are no longer passed; retaining their memory settings could make cxt
+			// remove a baseline Claude will not auto-load.
+			childMemoryEnv = claudeMemoryProfileEnv(cwd, args)
+		}
+		if len(childMemoryEnv) > 0 && childMemoryEnv[0] == "CXT_CLAUDE_MEMORY_PROFILE=v1" {
+			childMemoryEnv = append(childMemoryEnv,
+				"CXT_CLAUDE_MEMORY_CONFIG_FINGERPRINT="+memoryadapter.ClaudeMemoryConfigFingerprint(ctx, cwd))
+		}
+		child.Env = append(child.Env, childMemoryEnv...)
 		if err := child.Start(); err != nil {
 			return err
 		}

--- a/cli/internal/adapters/delivery/cli/agent_wrapper_memory_profile.go
+++ b/cli/internal/adapters/delivery/cli/agent_wrapper_memory_profile.go
@@ -1,0 +1,182 @@
+package cli
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+const maxClaudeFlagSettingsBytes = 1 << 20
+
+type claudeFlagMemorySettings struct {
+	AutoMemoryDirectory *string `json:"autoMemoryDirectory"`
+	AutoMemoryEnabled   *bool   `json:"autoMemoryEnabled"`
+}
+
+// claudeMemoryProfileEnv projects only auto-memory-relevant launch options
+// into the supervised child. Hook subprocesses can then reproduce the exact
+// settings sources without copying arbitrary --settings JSON (which may
+// contain credentials) into their environment.
+func claudeMemoryProfileEnv(cwd string, args []string) []string {
+	unknown := func() []string {
+		return []string{
+			"CXT_CLAUDE_MEMORY_PROFILE=unknown",
+			"CXT_CLAUDE_SETTING_SOURCES=",
+			"CXT_CLAUDE_BARE=",
+			"CXT_CLAUDE_SAFE_MODE=",
+			"CXT_CLAUDE_FLAG_AUTO_MEMORY_DIRECTORY=",
+			"CXT_CLAUDE_FLAG_AUTO_MEMORY_ENABLED=",
+			"CXT_CLAUDE_MEMORY_CONFIG_FINGERPRINT=",
+		}
+	}
+	profile := claudeFlagMemorySettings{}
+	sources := "user,project,local"
+	bare := false
+	safeMode := false
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if arg == "--" {
+			break
+		}
+		switch {
+		case arg == "--bare":
+			bare = true
+		case arg == "--safe-mode":
+			safeMode = true
+		case arg == "--settings":
+			if i+1 >= len(args) {
+				return unknown()
+			}
+			i++
+			settings, ok := readClaudeFlagMemorySettings(cwd, args[i])
+			if !ok {
+				return unknown()
+			}
+			mergeClaudeFlagMemorySettings(&profile, settings)
+		case strings.HasPrefix(arg, "--settings="):
+			settings, ok := readClaudeFlagMemorySettings(cwd, strings.TrimPrefix(arg, "--settings="))
+			if !ok {
+				return unknown()
+			}
+			mergeClaudeFlagMemorySettings(&profile, settings)
+		case arg == "--setting-sources":
+			if i+1 >= len(args) {
+				return unknown()
+			}
+			i++
+			var ok bool
+			sources, ok = normalizeClaudeSettingSources(args[i])
+			if !ok {
+				return unknown()
+			}
+		case strings.HasPrefix(arg, "--setting-sources="):
+			var ok bool
+			sources, ok = normalizeClaudeSettingSources(strings.TrimPrefix(arg, "--setting-sources="))
+			if !ok {
+				return unknown()
+			}
+		}
+	}
+
+	directory := ""
+	if profile.AutoMemoryDirectory != nil {
+		directory = *profile.AutoMemoryDirectory
+	}
+	enabled := ""
+	if profile.AutoMemoryEnabled != nil {
+		enabled = "false"
+		if *profile.AutoMemoryEnabled {
+			enabled = "true"
+		}
+	}
+	bareValue := ""
+	if bare {
+		bareValue = "true"
+	}
+	safeModeValue := ""
+	if safeMode {
+		safeModeValue = "true"
+	}
+	return []string{
+		"CXT_CLAUDE_MEMORY_PROFILE=v1",
+		"CXT_CLAUDE_SETTING_SOURCES=" + sources,
+		"CXT_CLAUDE_BARE=" + bareValue,
+		"CXT_CLAUDE_SAFE_MODE=" + safeModeValue,
+		"CXT_CLAUDE_FLAG_AUTO_MEMORY_DIRECTORY=" + directory,
+		"CXT_CLAUDE_FLAG_AUTO_MEMORY_ENABLED=" + enabled,
+		"CXT_CLAUDE_MEMORY_CONFIG_FINGERPRINT=",
+	}
+}
+
+func readClaudeFlagMemorySettings(_ string, value string) (claudeFlagMemorySettings, bool) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return claudeFlagMemorySettings{}, false
+	}
+	var data []byte
+	if strings.HasPrefix(value, "{") {
+		data = []byte(value)
+	} else {
+		// Claude reads external --settings files after cxt builds this
+		// profile. Without a provider acknowledgement there is no way to
+		// prove both processes observed the same bytes, so retain the portable
+		// baseline instead of projecting a potentially stale path.
+		return claudeFlagMemorySettings{}, false
+	}
+	if len(data) > maxClaudeFlagSettingsBytes {
+		return claudeFlagMemorySettings{}, false
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return claudeFlagMemorySettings{}, false
+	}
+	relevant := false
+	unmodeled := false
+	for key := range raw {
+		switch key {
+		case "autoMemoryDirectory", "autoMemoryEnabled":
+			relevant = true
+		default:
+			if !strings.HasPrefix(key, "$") {
+				unmodeled = true
+			}
+		}
+	}
+	if relevant && unmodeled {
+		return claudeFlagMemorySettings{}, false
+	}
+	var settings claudeFlagMemorySettings
+	if err := json.Unmarshal(data, &settings); err != nil {
+		return claudeFlagMemorySettings{}, false
+	}
+	return settings, true
+}
+
+func mergeClaudeFlagMemorySettings(dst *claudeFlagMemorySettings, src claudeFlagMemorySettings) {
+	if src.AutoMemoryDirectory != nil {
+		dst.AutoMemoryDirectory = src.AutoMemoryDirectory
+	}
+	if src.AutoMemoryEnabled != nil {
+		dst.AutoMemoryEnabled = src.AutoMemoryEnabled
+	}
+}
+
+func normalizeClaudeSettingSources(value string) (string, bool) {
+	if strings.TrimSpace(value) == "" {
+		return "none", true
+	}
+	seen := map[string]bool{}
+	var out []string
+	for _, source := range strings.Split(value, ",") {
+		source = strings.TrimSpace(source)
+		switch source {
+		case "user", "project", "local":
+			if !seen[source] {
+				seen[source] = true
+				out = append(out, source)
+			}
+		default:
+			return "", false
+		}
+	}
+	return strings.Join(out, ","), true
+}

--- a/cli/internal/adapters/delivery/cli/agent_wrapper_memory_profile_test.go
+++ b/cli/internal/adapters/delivery/cli/agent_wrapper_memory_profile_test.go
@@ -1,0 +1,132 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func profileEnvMap(values []string) map[string]string {
+	out := map[string]string{}
+	for _, value := range values {
+		key, val, ok := strings.Cut(value, "=")
+		if ok {
+			out[key] = val
+		}
+	}
+	return out
+}
+
+func TestClaudeMemoryProfileEnvProjectsOnlyMemorySettings(t *testing.T) {
+	env := profileEnvMap(claudeMemoryProfileEnv(t.TempDir(), []string{
+		"--settings", `{"autoMemoryDirectory":"/tmp/claude-memory","autoMemoryEnabled":false}`,
+		"--setting-sources", "local,user",
+	}))
+	if env["CXT_CLAUDE_MEMORY_PROFILE"] != "v1" {
+		t.Fatalf("profile=%q", env["CXT_CLAUDE_MEMORY_PROFILE"])
+	}
+	if env["CXT_CLAUDE_SETTING_SOURCES"] != "local,user" {
+		t.Fatalf("sources=%q", env["CXT_CLAUDE_SETTING_SOURCES"])
+	}
+	if env["CXT_CLAUDE_FLAG_AUTO_MEMORY_DIRECTORY"] != "/tmp/claude-memory" ||
+		env["CXT_CLAUDE_FLAG_AUTO_MEMORY_ENABLED"] != "false" {
+		t.Fatalf("projected profile=%v", env)
+	}
+	if strings.Contains(strings.Join(claudeMemoryProfileEnv(t.TempDir(), []string{
+		"--settings", `{"apiKey":"DO-NOT-LEAK"}`,
+	}), "\n"), "DO-NOT-LEAK") {
+		t.Fatal("unrelated settings secret leaked into child environment")
+	}
+}
+
+func TestClaudeMemoryProfileEnvProjectsInlineSettingsAndRuntimeModes(t *testing.T) {
+	dir := t.TempDir()
+	env := profileEnvMap(claudeMemoryProfileEnv(dir, []string{
+		"--bare", "--safe-mode", "--settings", `{"autoMemoryDirectory":"~/memory-inline","autoMemoryEnabled":true}`,
+	}))
+	if env["CXT_CLAUDE_FLAG_AUTO_MEMORY_DIRECTORY"] != "~/memory-inline" {
+		t.Fatalf("directory=%q", env["CXT_CLAUDE_FLAG_AUTO_MEMORY_DIRECTORY"])
+	}
+	if env["CXT_CLAUDE_FLAG_AUTO_MEMORY_ENABLED"] != "true" {
+		t.Fatalf("settings enabled=%q, want the projected flag value", env["CXT_CLAUDE_FLAG_AUTO_MEMORY_ENABLED"])
+	}
+	if env["CXT_CLAUDE_BARE"] != "true" {
+		t.Fatalf("bare=%q, want an independent runtime disable", env["CXT_CLAUDE_BARE"])
+	}
+	if env["CXT_CLAUDE_SAFE_MODE"] != "true" {
+		t.Fatalf("safe mode=%q, want an independent runtime disable", env["CXT_CLAUDE_SAFE_MODE"])
+	}
+}
+
+func TestClaudeMemoryProfileEnvFailsClosedForUnprovableSettings(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "launch-settings.json")
+	if err := os.WriteFile(path, []byte(`{"autoMemoryDirectory":"~/memory-from-file"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for name, args := range map[string][]string{
+		"external file can race provider read": {"--settings", path},
+		"mixed document needs provider schema": {"--settings", `{"autoMemoryDirectory":"~/memory-inline","permissions":"invalid"}`},
+	} {
+		t.Run(name, func(t *testing.T) {
+			env := profileEnvMap(claudeMemoryProfileEnv(dir, args))
+			if env["CXT_CLAUDE_MEMORY_PROFILE"] != "unknown" {
+				t.Fatalf("profile=%v, want fail-closed unknown", env)
+			}
+		})
+	}
+}
+
+func TestClaudeMemoryProfileEnvClearsInheritedOverrides(t *testing.T) {
+	env := profileEnvMap(claudeMemoryProfileEnv(t.TempDir(), nil))
+	for _, key := range []string{
+		"CXT_CLAUDE_BARE",
+		"CXT_CLAUDE_SAFE_MODE",
+		"CXT_CLAUDE_FLAG_AUTO_MEMORY_DIRECTORY",
+		"CXT_CLAUDE_FLAG_AUTO_MEMORY_ENABLED",
+		"CXT_CLAUDE_MEMORY_CONFIG_FINGERPRINT",
+	} {
+		if value, ok := env[key]; !ok || value != "" {
+			t.Fatalf("%s=%q present=%v, want an explicit empty override", key, value, ok)
+		}
+	}
+
+	unknown := profileEnvMap(claudeMemoryProfileEnv(t.TempDir(), []string{"--settings"}))
+	if unknown["CXT_CLAUDE_MEMORY_PROFILE"] != "unknown" {
+		t.Fatalf("unknown profile=%v", unknown)
+	}
+	for _, key := range []string{
+		"CXT_CLAUDE_SETTING_SOURCES",
+		"CXT_CLAUDE_BARE",
+		"CXT_CLAUDE_SAFE_MODE",
+		"CXT_CLAUDE_FLAG_AUTO_MEMORY_DIRECTORY",
+		"CXT_CLAUDE_FLAG_AUTO_MEMORY_ENABLED",
+		"CXT_CLAUDE_MEMORY_CONFIG_FINGERPRINT",
+	} {
+		if value, ok := unknown[key]; !ok || value != "" {
+			t.Fatalf("unknown %s=%q present=%v, want an explicit empty override", key, value, ok)
+		}
+	}
+}
+
+func TestClaudeMemoryProfileEnvFailsClosed(t *testing.T) {
+	for name, args := range map[string][]string{
+		"missing settings value": {"--settings"},
+		"invalid settings JSON":  {"--settings", "{"},
+		"invalid setting source": {"--setting-sources", "user,repo"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			env := profileEnvMap(claudeMemoryProfileEnv(t.TempDir(), args))
+			if env["CXT_CLAUDE_MEMORY_PROFILE"] != "unknown" {
+				t.Fatalf("profile=%v", env)
+			}
+		})
+	}
+}
+
+func TestNormalizeClaudeSettingSourcesSupportsExplicitNone(t *testing.T) {
+	if got, ok := normalizeClaudeSettingSources(""); !ok || got != "none" {
+		t.Fatalf("empty sources=%q ok=%v", got, ok)
+	}
+}

--- a/cli/internal/adapters/memory/claude_memory.go
+++ b/cli/internal/adapters/memory/claude_memory.go
@@ -2,6 +2,7 @@ package memory
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"strings"
 	"unicode/utf8"
@@ -20,20 +21,19 @@ func NewClaudeMemorySource() *ClaudeMemorySource { return &ClaudeMemorySource{} 
 // Provider returns claude.
 func (s *ClaudeMemorySource) Provider() domain.ProviderKind { return domain.ProviderClaude }
 
-// ReadNative reads ~/.claude/projects/<cwd-encoded>/memory/MEMORY.md.
+// ReadNative reads Claude's repository-scoped auto-memory entrypoint.
 // A missing or inaccessible file returns found=false so the caller can fall back to CIR distillation.
-func (s *ClaudeMemorySource) ReadNative(_ context.Context, cwd, _ string) (domain.NativeMemory, bool, error) {
-	abs, err := filepath.Abs(cwd)
-	if err != nil {
-		abs = cwd
+func (s *ClaudeMemorySource) ReadNative(ctx context.Context, cwd, _ string) (domain.NativeMemory, bool, error) {
+	resolution := resolveClaudeAutoMemory(ctx, cwd)
+	if !resolution.proven || !resolution.enabled || resolution.memoryDir == "" {
+		return domain.NativeMemory{}, false, nil
 	}
-	root, err := providerfs.ClaudeProjectsDir()
+	p := filepath.Join(resolution.memoryDir, "MEMORY.md")
+	data, err := providerfs.ReadRegularFile(p)
 	if err != nil {
 		return domain.NativeMemory{}, false, nil
 	}
-	p := filepath.Join(root, providerfs.EncodeCwd(abs), "memory", "MEMORY.md")
-	data, err := providerfs.ReadRegularFile(p)
-	if err != nil {
+	if strings.TrimSpace(os.Getenv("CXT_CLAUDE_MEMORY_CONFIG_FINGERPRINT")) != ClaudeMemoryConfigFingerprint(ctx, cwd) {
 		return domain.NativeMemory{}, false, nil
 	}
 	text := string(data)

--- a/cli/internal/adapters/memory/claude_memory_resolver.go
+++ b/cli/internal/adapters/memory/claude_memory_resolver.go
@@ -1,0 +1,640 @@
+package memory
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+	"unicode/utf16"
+
+	"github.com/wnsdy95/cxthub/cli/internal/adapters/providerfs"
+)
+
+const maxClaudeSettingsBytes = 1 << 20
+
+var (
+	claudeProjectNamePattern  = regexp.MustCompile(`^[A-Za-z0-9_-]{1,64}$`)
+	claudeReservedProjectName = regexp.MustCompile(`(?i)^(?:con|prn|aux|nul|com[0-9]|lpt[0-9])$`)
+	errClaudeSettingsTooLarge = errors.New("Claude settings exceed safe read limit")
+)
+
+type claudeMemorySettings struct {
+	AutoMemoryDirectory *string         `json:"autoMemoryDirectory"`
+	AutoMemoryEnabled   *bool           `json:"autoMemoryEnabled"`
+	PolicyHelper        json.RawMessage `json:"policyHelper"`
+}
+
+type claudeMemoryResolution struct {
+	memoryDir string
+	enabled   bool
+	proven    bool
+}
+
+// resolveClaudeAutoMemory mirrors Claude Code's repository-scoped auto-memory
+// identity. The working-tree root remains separate because project/local
+// settings are worktree-specific even though the memory directory is shared.
+func resolveClaudeAutoMemory(ctx context.Context, cwd string) claudeMemoryResolution {
+	identityRoot, worktreeRoot := claudeRepositoryRoots(ctx, cwd)
+	configRoot, customConfig := claudeConfigRoot()
+	if configRoot == "" {
+		return claudeMemoryResolution{enabled: false, proven: false}
+	}
+	settings, proven := effectiveClaudeMemorySettings(ctx, configRoot, worktreeRoot)
+	if !claudeAutoMemoryRuntimeProven() {
+		proven = false
+	}
+	launchFingerprint := strings.TrimSpace(os.Getenv("CXT_CLAUDE_MEMORY_CONFIG_FINGERPRINT"))
+	if launchFingerprint == "" || launchFingerprint != ClaudeMemoryConfigFingerprint(ctx, cwd) {
+		proven = false
+	}
+
+	if claudeAutoMemoryDisabledByEnv() {
+		return claudeMemoryResolution{enabled: false, proven: proven}
+	}
+	if settings.AutoMemoryEnabled != nil && !*settings.AutoMemoryEnabled {
+		return claudeMemoryResolution{enabled: false, proven: proven}
+	}
+
+	memoryDir := ""
+	if settings.AutoMemoryDirectory != nil {
+		var ok bool
+		memoryDir, ok = resolveClaudeMemoryDirectory(*settings.AutoMemoryDirectory)
+		if !ok {
+			return claudeMemoryResolution{enabled: false, proven: false}
+		}
+	} else {
+		projectKey := claudeProjectKey(identityRoot)
+		if customConfig {
+			if override, ok := validClaudeProjectName(os.Getenv("CLAUDE_CODE_PROJECT_DIR_NAME")); ok {
+				projectKey = override
+			}
+		}
+		memoryDir = filepath.Join(configRoot, "projects", projectKey, "memory")
+	}
+	return claudeMemoryResolution{memoryDir: memoryDir, enabled: true, proven: proven}
+}
+
+// ClaudeMemoryConfigFingerprint binds a supervised Claude launch to every
+// observable input that can change auto-memory enablement or location. It
+// contains no settings values; only the SHA-256 digest crosses into the child
+// environment. A later mismatch makes native-memory projection fail closed.
+func ClaudeMemoryConfigFingerprint(ctx context.Context, cwd string) string {
+	_, worktreeRoot := claudeRepositoryRoots(ctx, cwd)
+	configRoot, _ := claudeConfigRoot()
+	hash := sha256.New()
+	write := func(value string) {
+		_, _ = hash.Write([]byte(value))
+		_, _ = hash.Write([]byte{0})
+	}
+	for _, name := range []string{
+		"CLAUDE_CONFIG_DIR",
+		"CLAUDE_CODE_PROJECT_DIR_NAME",
+		"CLAUDE_CODE_DISABLE_AUTO_MEMORY",
+		"CLAUDE_CODE_SIMPLE",
+		"CLAUDE_CODE_SAFE_MODE",
+		"CLAUDE_CODE_MANAGED_SETTINGS_PATH",
+		"CLAUDE_CODE_REMOTE",
+		"CLAUDE_CODE_REMOTE_MEMORY_DIR",
+		"CLAUDE_COWORK_MEMORY_PATH_OVERRIDE",
+		"CLAUDE_MEMORY_STORES",
+	} {
+		write(name + "=" + os.Getenv(name))
+	}
+	if _, _, mdm, err := readClaudeMDMMemorySettings(ctx); err != nil {
+		write("mdm-error:" + err.Error())
+	} else if len(mdm) > 0 {
+		digest := sha256.Sum256(mdm)
+		write(fmt.Sprintf("mdm-sha256:%x", digest[:]))
+	}
+	var paths []string
+	if configRoot == "" {
+		write("config-root-unavailable")
+	} else {
+		paths = append(paths,
+			filepath.Join(configRoot, "settings.json"),
+			filepath.Join(configRoot, "remote-settings.json"),
+		)
+	}
+	if worktreeRoot != "" {
+		paths = append(paths,
+			filepath.Join(worktreeRoot, ".claude", "settings.json"),
+			filepath.Join(worktreeRoot, ".claude", "settings.local.json"),
+		)
+	}
+	if managed := knownClaudeManagedSettingsPath(); managed != "" {
+		paths = append(paths, managed)
+		dropinDir := filepath.Join(filepath.Dir(managed), "managed-settings.d")
+		entries, err := os.ReadDir(dropinDir)
+		if err != nil {
+			write("dir:" + dropinDir + ":" + err.Error())
+		} else {
+			for _, entry := range entries {
+				if strings.HasSuffix(entry.Name(), ".json") {
+					paths = append(paths, filepath.Join(dropinDir, entry.Name()))
+				}
+			}
+		}
+	}
+	sort.Strings(paths)
+	for _, path := range paths {
+		write("path:" + path)
+		data, err := readClaudeRegularSettingsFile(path)
+		if err != nil {
+			write("error:" + err.Error())
+			continue
+		}
+		digest := sha256.Sum256(data)
+		write(fmt.Sprintf("sha256:%x", digest[:]))
+	}
+	return fmt.Sprintf("%x", hash.Sum(nil))
+}
+
+func claudeRepositoryRoots(ctx context.Context, cwd string) (identityRoot, worktreeRoot string) {
+	canonical := canonicalClaudePath(cwd)
+	identityRoot, worktreeRoot = canonical, canonical
+
+	if top, err := gitPath(ctx, cwd, "rev-parse", "--show-toplevel"); err == nil && top != "" {
+		worktreeRoot = canonicalClaudePath(top)
+		identityRoot = worktreeRoot
+	}
+	if common, err := gitPath(ctx, cwd, "rev-parse", "--git-common-dir"); err == nil && common != "" {
+		if !filepath.IsAbs(common) {
+			common = filepath.Join(cwd, common)
+		}
+		common = canonicalClaudePath(common)
+		if filepath.Base(common) == ".git" {
+			identityRoot = filepath.Dir(common)
+		} else {
+			identityRoot = common
+		}
+	}
+	return identityRoot, worktreeRoot
+}
+
+func gitPath(ctx context.Context, cwd string, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, "git", append([]string{"-C", cwd}, args...)...)
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func canonicalClaudePath(path string) string {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		abs = path
+	}
+	if real, err := filepath.EvalSymlinks(abs); err == nil {
+		abs = real
+	}
+	return filepath.Clean(abs)
+}
+
+func claudeConfigRoot() (string, bool) {
+	if configured := strings.TrimSpace(os.Getenv("CLAUDE_CONFIG_DIR")); configured != "" {
+		return canonicalClaudePath(configured), true
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", false
+	}
+	return filepath.Join(home, ".claude"), false
+}
+
+func claudeProjectKey(root string) string {
+	encoded := claudeEncodeProjectRoot(root)
+	if len(encoded) <= 200 {
+		return encoded
+	}
+	return encoded[:200] + "-" + strconv.FormatUint(uint64(absJSStringHash(root)), 36)
+}
+
+func claudeEncodeProjectRoot(root string) string {
+	units := utf16.Encode([]rune(root))
+	var encoded strings.Builder
+	encoded.Grow(len(units))
+	for _, unit := range units {
+		if (unit >= 'a' && unit <= 'z') || (unit >= 'A' && unit <= 'Z') || (unit >= '0' && unit <= '9') {
+			encoded.WriteByte(byte(unit))
+		} else {
+			encoded.WriteByte('-')
+		}
+	}
+	return encoded.String()
+}
+
+// absJSStringHash matches Claude Code's 32-bit JavaScript string hash. JS
+// charCodeAt iterates UTF-16 code units, so non-BMP paths must not hash Go
+// runes or UTF-8 bytes.
+func absJSStringHash(value string) uint32 {
+	var hash int32
+	for _, unit := range utf16.Encode([]rune(value)) {
+		hash = hash*31 + int32(unit)
+	}
+	if hash < 0 {
+		return uint32(-int64(hash))
+	}
+	return uint32(hash)
+}
+
+func validClaudeProjectName(value string) (string, bool) {
+	if !claudeProjectNamePattern.MatchString(value) || claudeReservedProjectName.MatchString(value) {
+		return "", false
+	}
+	return value, true
+}
+
+func resolveClaudeMemoryDirectory(value string) (string, bool) {
+	value = strings.TrimSpace(value)
+	if strings.HasPrefix(value, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", false
+		}
+		value = filepath.Join(home, strings.TrimPrefix(value, "~/"))
+	}
+	if !filepath.IsAbs(value) || strings.ContainsRune(value, 0) {
+		return "", false
+	}
+	value = filepath.Clean(value)
+	if value == string(filepath.Separator) || value == "." {
+		return "", false
+	}
+	return value, true
+}
+
+func claudeAutoMemoryDisabledByEnv() bool {
+	return envTruthy("CLAUDE_CODE_DISABLE_AUTO_MEMORY") || envTruthy("CLAUDE_CODE_SIMPLE") || envTruthy("CLAUDE_CODE_SAFE_MODE") ||
+		envTruthy("CXT_CLAUDE_BARE") || envTruthy("CXT_CLAUDE_SAFE_MODE") ||
+		(os.Getenv("CLAUDE_CODE_REMOTE") != "" && os.Getenv("CLAUDE_CODE_REMOTE_MEMORY_DIR") == "" && os.Getenv("CLAUDE_COWORK_MEMORY_PATH_OVERRIDE") == "")
+}
+
+func claudeAutoMemoryRuntimeProven() bool {
+	return os.Getenv("CLAUDE_CODE_REMOTE_MEMORY_DIR") == "" &&
+		os.Getenv("CLAUDE_COWORK_MEMORY_PATH_OVERRIDE") == "" &&
+		os.Getenv("CLAUDE_MEMORY_STORES") == ""
+}
+
+func envTruthy(name string) bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(name))) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
+}
+
+// effectiveClaudeMemorySettings applies the documented user < project < local
+// precedence. autoMemoryDirectory is intentionally accepted only from the
+// trusted user layer; repository-controlled redirects are ignored.
+func effectiveClaudeMemorySettings(ctx context.Context, configRoot, worktreeRoot string) (claudeMemorySettings, bool) {
+	var effective claudeMemorySettings
+	profile, proven := claudeMemoryLaunchProfile()
+	if !proven {
+		return effective, false
+	}
+	apply := func(path string, trustedDirectory bool, repoRelative bool) {
+		settings, found, err := readClaudeMemorySettings(path, worktreeRoot, repoRelative)
+		if err != nil {
+			proven = false
+			return
+		}
+		if !found {
+			return
+		}
+		if trustedDirectory && settings.AutoMemoryDirectory != nil {
+			effective.AutoMemoryDirectory = settings.AutoMemoryDirectory
+		}
+		if settings.AutoMemoryEnabled != nil {
+			effective.AutoMemoryEnabled = settings.AutoMemoryEnabled
+		}
+	}
+	if profile.sources["user"] {
+		apply(filepath.Join(configRoot, "settings.json"), true, false)
+	}
+	if worktreeRoot != "" {
+		if profile.sources["project"] {
+			apply(filepath.Join(worktreeRoot, ".claude", "settings.json"), false, true)
+		}
+		if profile.sources["local"] {
+			apply(filepath.Join(worktreeRoot, ".claude", "settings.local.json"), false, true)
+		}
+	}
+	if profile.flag.AutoMemoryDirectory != nil {
+		effective.AutoMemoryDirectory = profile.flag.AutoMemoryDirectory
+	}
+	if profile.flag.AutoMemoryEnabled != nil {
+		effective.AutoMemoryEnabled = profile.flag.AutoMemoryEnabled
+	}
+	managed, found, err := readClaudeManagedMemorySettings(ctx, configRoot)
+	if err != nil {
+		proven = false
+	} else if found {
+		if managed.PolicyHelper != nil && string(managed.PolicyHelper) != "null" {
+			// The helper's runtime output replaces file-based policy. cxt cannot
+			// safely execute an administrator command while loading context.
+			proven = false
+		}
+		if managed.AutoMemoryDirectory != nil {
+			effective.AutoMemoryDirectory = managed.AutoMemoryDirectory
+		}
+		if managed.AutoMemoryEnabled != nil {
+			effective.AutoMemoryEnabled = managed.AutoMemoryEnabled
+		}
+	}
+	return effective, proven
+}
+
+type claudeLaunchProfile struct {
+	sources map[string]bool
+	flag    claudeMemorySettings
+}
+
+func claudeMemoryLaunchProfile() (claudeLaunchProfile, bool) {
+	profile := claudeLaunchProfile{sources: map[string]bool{}}
+	if os.Getenv("CXT_CLAUDE_MEMORY_PROFILE") != "v1" {
+		return profile, false
+	}
+	sources, sourcesSet := os.LookupEnv("CXT_CLAUDE_SETTING_SOURCES")
+	sources = strings.TrimSpace(sources)
+	if !sourcesSet {
+		sources = "user,project,local"
+	}
+	if sources == "none" {
+		return profile, true
+	}
+	for _, source := range strings.Split(sources, ",") {
+		source = strings.TrimSpace(source)
+		switch source {
+		case "user", "project", "local":
+			profile.sources[source] = true
+		case "":
+		default:
+			return profile, false
+		}
+	}
+	if value := os.Getenv("CXT_CLAUDE_FLAG_AUTO_MEMORY_DIRECTORY"); value != "" {
+		profile.flag.AutoMemoryDirectory = &value
+	}
+	if value := strings.TrimSpace(os.Getenv("CXT_CLAUDE_FLAG_AUTO_MEMORY_ENABLED")); value != "" {
+		switch value {
+		case "true":
+			enabled := true
+			profile.flag.AutoMemoryEnabled = &enabled
+		case "false":
+			enabled := false
+			profile.flag.AutoMemoryEnabled = &enabled
+		default:
+			return profile, false
+		}
+	}
+	return profile, true
+}
+
+func readClaudeMemorySettings(path, repoRoot string, repoRelative bool) (claudeMemorySettings, bool, error) {
+	var (
+		data []byte
+		err  error
+	)
+	if repoRelative {
+		rel, relErr := filepath.Rel(repoRoot, path)
+		if relErr != nil {
+			return claudeMemorySettings{}, false, relErr
+		}
+		data, err = readClaudeRepoSettingsFile(repoRoot, rel)
+	} else {
+		data, err = readClaudeRegularSettingsFile(path)
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		return claudeMemorySettings{}, false, nil
+	}
+	if err != nil {
+		return claudeMemorySettings{}, false, err
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return claudeMemorySettings{}, false, err
+	}
+	if err := validateClaudeMemoryFieldIsolation(raw, false); err != nil {
+		return claudeMemorySettings{}, false, err
+	}
+	var settings claudeMemorySettings
+	if err := json.Unmarshal(data, &settings); err != nil {
+		return claudeMemorySettings{}, false, err
+	}
+	return settings, true, nil
+}
+
+// readClaudeManagedMemorySettings follows the managed-source ordering that is
+// observable without executing administrator code: server cache first, then
+// the selected file-based policy and its sorted drop-ins. A policyHelper makes
+// the result unproven because its output replaces file policy at runtime.
+func readClaudeManagedMemorySettings(ctx context.Context, configRoot string) (claudeMemorySettings, bool, error) {
+	remotePath := filepath.Join(configRoot, "remote-settings.json")
+	remote, active, err := readClaudeManagedDocument(remotePath)
+	if errors.Is(err, os.ErrNotExist) {
+		err = nil
+	}
+	if err != nil {
+		return claudeMemorySettings{}, false, err
+	}
+	if active {
+		return remote, true, nil
+	}
+	mdm, active, _, err := readClaudeMDMMemorySettings(ctx)
+	if err != nil {
+		return claudeMemorySettings{}, false, err
+	}
+	if active {
+		return mdm, true, nil
+	}
+
+	base := knownClaudeManagedSettingsPath()
+	if base == "" {
+		return claudeMemorySettings{}, false, nil
+	}
+	var effective claudeMemorySettings
+	found := false
+	applyFile := func(path string, required bool) error {
+		settings, active, readErr := readClaudeManagedDocument(path)
+		if errors.Is(readErr, os.ErrNotExist) && !required {
+			return nil
+		}
+		if readErr != nil {
+			return readErr
+		}
+		if !active {
+			return nil
+		}
+		found = true
+		if settings.AutoMemoryDirectory != nil {
+			effective.AutoMemoryDirectory = settings.AutoMemoryDirectory
+		}
+		if settings.AutoMemoryEnabled != nil {
+			effective.AutoMemoryEnabled = settings.AutoMemoryEnabled
+		}
+		if settings.PolicyHelper != nil {
+			effective.PolicyHelper = settings.PolicyHelper
+		}
+		return nil
+	}
+	required := strings.TrimSpace(os.Getenv("CLAUDE_CODE_MANAGED_SETTINGS_PATH")) != ""
+	if err := applyFile(base, required); err != nil {
+		return claudeMemorySettings{}, false, err
+	}
+	dropinDir := filepath.Join(filepath.Dir(base), "managed-settings.d")
+	entries, err := os.ReadDir(dropinDir)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return claudeMemorySettings{}, false, err
+	}
+	var names []string
+	for _, entry := range entries {
+		if entry.Type().IsRegular() && strings.HasSuffix(entry.Name(), ".json") {
+			names = append(names, entry.Name())
+		}
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		if err := applyFile(filepath.Join(dropinDir, name), true); err != nil {
+			return claudeMemorySettings{}, false, err
+		}
+	}
+	return effective, found, nil
+}
+
+func readClaudeMDMMemorySettings(ctx context.Context) (claudeMemorySettings, bool, []byte, error) {
+	if runtime.GOOS != "darwin" {
+		return claudeMemorySettings{}, false, nil, nil
+	}
+	mdmCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	exported, err := exec.CommandContext(mdmCtx, "/usr/bin/defaults", "export", "com.anthropic.claudecode", "-").Output()
+	if err != nil {
+		return claudeMemorySettings{}, false, nil, err
+	}
+	if len(exported) > maxClaudeSettingsBytes {
+		return claudeMemorySettings{}, false, nil, errors.New("Claude MDM settings exceed safe read limit")
+	}
+	plutil := exec.CommandContext(mdmCtx, "/usr/bin/plutil", "-convert", "json", "-o", "-", "--", "-")
+	plutil.Stdin = bytes.NewReader(exported)
+	data, err := plutil.Output()
+	if err != nil {
+		return claudeMemorySettings{}, false, nil, err
+	}
+	settings, active, err := decodeClaudeManagedDocument(data)
+	return settings, active, data, err
+}
+
+func readClaudeManagedDocument(path string) (claudeMemorySettings, bool, error) {
+	data, err := readClaudeRegularSettingsFile(path)
+	if err != nil {
+		return claudeMemorySettings{}, false, err
+	}
+	return decodeClaudeManagedDocument(data)
+}
+
+func readClaudeRegularSettingsFile(path string) ([]byte, error) {
+	f, err := providerfs.OpenRegularFile(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return readClaudeSettingsBytes(f)
+}
+
+func readClaudeRepoSettingsFile(repoRoot, relative string) ([]byte, error) {
+	f, err := providerfs.OpenRepoFile(repoRoot, relative)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return readClaudeSettingsBytes(f)
+}
+
+func readClaudeSettingsBytes(r io.Reader) ([]byte, error) {
+	data, err := io.ReadAll(io.LimitReader(r, maxClaudeSettingsBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(data) > maxClaudeSettingsBytes {
+		return nil, errClaudeSettingsTooLarge
+	}
+	return data, nil
+}
+
+func decodeClaudeManagedDocument(data []byte) (claudeMemorySettings, bool, error) {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return claudeMemorySettings{}, false, err
+	}
+	if err := validateClaudeMemoryFieldIsolation(raw, true); err != nil {
+		return claudeMemorySettings{}, false, err
+	}
+	active := false
+	for key := range raw {
+		if !strings.HasPrefix(key, "$") || key == "$schema" {
+			active = true
+			break
+		}
+	}
+	if !active {
+		return claudeMemorySettings{}, false, nil
+	}
+	var settings claudeMemorySettings
+	if err := json.Unmarshal(data, &settings); err != nil {
+		return claudeMemorySettings{}, false, err
+	}
+	return settings, true, nil
+}
+
+func validateClaudeMemoryFieldIsolation(raw map[string]json.RawMessage, managed bool) error {
+	relevant := false
+	unmodeled := false
+	for key := range raw {
+		switch key {
+		case "autoMemoryDirectory", "autoMemoryEnabled":
+			relevant = true
+		case "policyHelper":
+			if managed {
+				relevant = true
+			} else {
+				unmodeled = true
+			}
+		default:
+			if !strings.HasPrefix(key, "$") {
+				unmodeled = true
+			}
+		}
+	}
+	if relevant && unmodeled {
+		return errors.New("Claude auto-memory settings share a document with fields requiring provider validation")
+	}
+	return nil
+}
+
+func knownClaudeManagedSettingsPath() string {
+	if path := strings.TrimSpace(os.Getenv("CLAUDE_CODE_MANAGED_SETTINGS_PATH")); path != "" {
+		return path
+	}
+	switch runtime.GOOS {
+	case "darwin":
+		return "/Library/Application Support/ClaudeCode/managed-settings.json"
+	case "linux":
+		return "/etc/claude-code/managed-settings.json"
+	default:
+		return ""
+	}
+}

--- a/cli/internal/adapters/memory/claude_memory_test.go
+++ b/cli/internal/adapters/memory/claude_memory_test.go
@@ -1,10 +1,115 @@
 package memory
 
 import (
+	"context"
+	"errors"
 	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/wnsdy95/cxthub/cli/internal/adapters/providerfs"
 )
+
+func gitFixture(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	cmd.Env = append(os.Environ(),
+		"GIT_CONFIG_NOSYSTEM=1",
+		"GIT_CONFIG_GLOBAL=/dev/null",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func newClaudeMemoryRepo(t *testing.T) (home, repo, linked string) {
+	t.Helper()
+	home = t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("CLAUDE_CONFIG_DIR", "")
+	t.Setenv("CLAUDE_CODE_PROJECT_DIR_NAME", "")
+	t.Setenv("CLAUDE_CODE_DISABLE_AUTO_MEMORY", "")
+	t.Setenv("CLAUDE_CODE_SIMPLE", "")
+	t.Setenv("CLAUDE_CODE_SAFE_MODE", "")
+	t.Setenv("CLAUDE_CODE_MANAGED_SETTINGS_PATH", "")
+	t.Setenv("CLAUDE_CODE_REMOTE", "")
+	t.Setenv("CLAUDE_CODE_REMOTE_MEMORY_DIR", "")
+	t.Setenv("CLAUDE_COWORK_MEMORY_PATH_OVERRIDE", "")
+	t.Setenv("CLAUDE_MEMORY_STORES", "")
+	t.Setenv("CXT_CLAUDE_MEMORY_PROFILE", "v1")
+	t.Setenv("CXT_CLAUDE_SETTING_SOURCES", "user,project,local")
+	t.Setenv("CXT_CLAUDE_BARE", "")
+	t.Setenv("CXT_CLAUDE_SAFE_MODE", "")
+	t.Setenv("CXT_CLAUDE_FLAG_AUTO_MEMORY_DIRECTORY", "")
+	t.Setenv("CXT_CLAUDE_FLAG_AUTO_MEMORY_ENABLED", "")
+	t.Setenv("CXT_CLAUDE_MEMORY_CONFIG_FINGERPRINT", "")
+
+	repo = filepath.Join(t.TempDir(), "repo")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	gitFixture(t, repo, "init", "-b", "main")
+	gitFixture(t, repo, "config", "core.hooksPath", "/dev/null")
+	gitFixture(t, repo, "config", "gc.auto", "0")
+	gitFixture(t, repo, "config", "maintenance.auto", "false")
+	gitFixture(t, repo, "-c", "user.name=cxt test", "-c", "user.email=cxt@example.test", "commit", "--allow-empty", "-m", "root")
+
+	linked = filepath.Join(t.TempDir(), "linked")
+	gitFixture(t, repo, "worktree", "add", "-b", "linked", linked)
+	return home, repo, linked
+}
+
+func canonicalPath(t *testing.T, path string) string {
+	t.Helper()
+	real, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	abs, err := filepath.Abs(real)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return filepath.Clean(abs)
+}
+
+func writeClaudeMemory(t *testing.T, dir, text string) string {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "MEMORY.md")
+	if err := os.WriteFile(path, []byte(text), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func defaultClaudeMemoryDir(home, projectRoot string) string {
+	return filepath.Join(home, ".claude", "projects", providerfs.EncodeCwd(projectRoot), "memory")
+}
+
+func readClaudeNative(t *testing.T, cwd string) (string, bool) {
+	t.Helper()
+	t.Setenv("CXT_CLAUDE_MEMORY_CONFIG_FINGERPRINT", ClaudeMemoryConfigFingerprint(context.Background(), cwd))
+	return readClaudeNativeWithoutRefreshingProfile(t, cwd)
+}
+
+func readClaudeNativeWithoutRefreshingProfile(t *testing.T, cwd string) (string, bool) {
+	t.Helper()
+	native, found, err := NewClaudeMemorySource().ReadNative(context.Background(), cwd, "")
+	if err != nil {
+		t.Fatalf("ReadNative(%s): %v", cwd, err)
+	}
+	if !found {
+		return "", false
+	}
+	return native.Text, true
+}
 
 func TestClaudeAutoLoadedPrefixUsesConservativeCompleteLines(t *testing.T) {
 	t.Run("small memory is fully loaded", func(t *testing.T) {
@@ -31,4 +136,313 @@ func TestClaudeAutoLoadedPrefixUsesConservativeCompleteLines(t *testing.T) {
 			t.Fatalf("prefix cut an incomplete line: bytes=%d tail=%q", len(got), got[max(0, len(got)-32):])
 		}
 	})
+}
+
+func TestClaudeProjectKeyMatchesProviderLongUnicodeEncoding(t *testing.T) {
+	root := "/" + strings.Repeat("very-long-segment/", 20) + "😀"
+	want := "-very-long-segment-very-long-segment-very-long-segment-very-long-segment-very-long-segment-very-long-segment-very-long-segment-very-long-segment-very-long-segment-very-long-segment-very-long-segment-v-2g816y"
+	if got := claudeProjectKey(root); got != want {
+		t.Fatalf("project key=%q\nwant=%q", got, want)
+	}
+	if got := claudeEncodeProjectRoot("/repo/😀"); got != "-repo---" {
+		t.Fatalf("non-BMP encoding=%q, want one replacement per UTF-16 unit", got)
+	}
+}
+
+func TestDecodeClaudeManagedDocument(t *testing.T) {
+	settings, active, err := decodeClaudeManagedDocument([]byte(`{"autoMemoryDirectory":"/managed/memory","autoMemoryEnabled":false}`))
+	if err != nil || !active || settings.AutoMemoryDirectory == nil || *settings.AutoMemoryDirectory != "/managed/memory" ||
+		settings.AutoMemoryEnabled == nil || *settings.AutoMemoryEnabled {
+		t.Fatalf("settings=%+v active=%v err=%v", settings, active, err)
+	}
+	if _, active, err := decodeClaudeManagedDocument([]byte(`{}`)); err != nil || active {
+		t.Fatalf("empty managed document active=%v err=%v", active, err)
+	}
+}
+
+func TestReadClaudeSettingsBytesStopsAtSafetyLimit(t *testing.T) {
+	reader := strings.NewReader(strings.Repeat("x", maxClaudeSettingsBytes+(32<<10)))
+	if _, err := readClaudeSettingsBytes(reader); !errors.Is(err, errClaudeSettingsTooLarge) {
+		t.Fatalf("oversized settings error=%v, want %v", err, errClaudeSettingsTooLarge)
+	}
+	consumed := maxClaudeSettingsBytes + (32 << 10) - reader.Len()
+	if consumed != maxClaudeSettingsBytes+1 {
+		t.Fatalf("consumed=%d bytes, want exactly max+1", consumed)
+	}
+}
+
+func TestClaudeReadNativeUsesRepositoryIdentityAcrossSubdirsAndWorktrees(t *testing.T) {
+	home, repo, linked := newClaudeMemoryRepo(t)
+	repo = canonicalPath(t, repo)
+	const wanted = "SHARED REPOSITORY MEMORY"
+	writeClaudeMemory(t, defaultClaudeMemoryDir(home, repo), wanted)
+
+	subdir := filepath.Join(repo, "nested", "package")
+	if err := os.MkdirAll(subdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for name, cwd := range map[string]string{"subdirectory": subdir, "linked worktree": linked} {
+		t.Run(name, func(t *testing.T) {
+			got, found := readClaudeNative(t, cwd)
+			if !found || got != wanted {
+				t.Fatalf("found=%v text=%q, want repository memory", found, got)
+			}
+		})
+	}
+}
+
+func TestClaudeReadNativeRejectsStaleWorktreeSpecificMemory(t *testing.T) {
+	home, repo, linked := newClaudeMemoryRepo(t)
+	repo = canonicalPath(t, repo)
+	linked = canonicalPath(t, linked)
+	writeClaudeMemory(t, defaultClaudeMemoryDir(home, repo), "CANONICAL MEMORY")
+	writeClaudeMemory(t, defaultClaudeMemoryDir(home, linked), "STALE WORKTREE MEMORY")
+
+	got, found := readClaudeNative(t, linked)
+	if !found || got != "CANONICAL MEMORY" {
+		t.Fatalf("found=%v text=%q, want canonical repository memory", found, got)
+	}
+}
+
+func TestClaudeReadNativeHonorsConfigRootAndSafeProjectName(t *testing.T) {
+	_, repo, _ := newClaudeMemoryRepo(t)
+	config := filepath.Join(t.TempDir(), "claude-config")
+	t.Setenv("CLAUDE_CONFIG_DIR", config)
+	t.Setenv("CLAUDE_CODE_PROJECT_DIR_NAME", "shared_project-42")
+	writeClaudeMemory(t, filepath.Join(config, "projects", "shared_project-42", "memory"), "CONFIG MEMORY")
+
+	got, found := readClaudeNative(t, repo)
+	if !found || got != "CONFIG MEMORY" {
+		t.Fatalf("found=%v text=%q, want config-root memory", found, got)
+	}
+}
+
+func TestClaudeReadNativeHonorsTrustedUserMemoryDirectory(t *testing.T) {
+	home, repo, _ := newClaudeMemoryRepo(t)
+	config := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(config, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(config, "settings.json"), []byte(`{"autoMemoryDirectory":"~/custom-claude-memory"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	writeClaudeMemory(t, filepath.Join(home, "custom-claude-memory"), "CUSTOM MEMORY")
+	writeClaudeMemory(t, defaultClaudeMemoryDir(home, canonicalPath(t, repo)), "STALE DEFAULT MEMORY")
+
+	got, found := readClaudeNative(t, repo)
+	if !found || got != "CUSTOM MEMORY" {
+		t.Fatalf("found=%v text=%q, want trusted custom memory", found, got)
+	}
+}
+
+func TestClaudeReadNativeFailsClosedForMixedRelevantSettings(t *testing.T) {
+	home, repo, _ := newClaudeMemoryRepo(t)
+	custom := filepath.Join(home, "custom-claude-memory")
+	writeClaudeMemory(t, custom, "CUSTOM MEMORY")
+	config := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(config, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	settings := fmt.Sprintf(`{"autoMemoryDirectory":%q,"permissions":"invalid"}`, custom)
+	if err := os.WriteFile(filepath.Join(config, "settings.json"), []byte(settings), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got, found := readClaudeNative(t, repo); found {
+		t.Fatalf("found memory from a settings document requiring provider-wide validation: %q", got)
+	}
+}
+
+func TestClaudeReadNativeDoesNotReadDisabledAutoMemory(t *testing.T) {
+	t.Run("environment override", func(t *testing.T) {
+		home, repo, _ := newClaudeMemoryRepo(t)
+		for _, root := range []string{repo, canonicalPath(t, repo)} {
+			writeClaudeMemory(t, defaultClaudeMemoryDir(home, root), "DISABLED MEMORY")
+		}
+		if got, found := readClaudeNative(t, repo); !found || got != "DISABLED MEMORY" {
+			t.Fatalf("enabled precondition found=%v text=%q", found, got)
+		}
+		t.Setenv("CLAUDE_CODE_DISABLE_AUTO_MEMORY", "1")
+		if got, found := readClaudeNative(t, repo); found {
+			t.Fatalf("found disabled memory %q", got)
+		}
+	})
+
+	t.Run("project setting", func(t *testing.T) {
+		home, repo, _ := newClaudeMemoryRepo(t)
+		for _, root := range []string{repo, canonicalPath(t, repo)} {
+			writeClaudeMemory(t, defaultClaudeMemoryDir(home, root), "DISABLED MEMORY")
+		}
+		if got, found := readClaudeNative(t, repo); !found || got != "DISABLED MEMORY" {
+			t.Fatalf("enabled precondition found=%v text=%q", found, got)
+		}
+		settingsDir := filepath.Join(repo, ".claude")
+		if err := os.MkdirAll(settingsDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(settingsDir, "settings.json"), []byte(`{"autoMemoryEnabled":false}`), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if got, found := readClaudeNative(t, repo); found {
+			t.Fatalf("found disabled memory %q", got)
+		}
+	})
+}
+
+func TestClaudeReadNativeBareModeCannotBeReenabledByManagedSettings(t *testing.T) {
+	home, repo, _ := newClaudeMemoryRepo(t)
+	writeClaudeMemory(t, defaultClaudeMemoryDir(home, canonicalPath(t, repo)), "BARE MEMORY")
+	config := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(config, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(config, "remote-settings.json"), []byte(`{"autoMemoryEnabled":true}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CXT_CLAUDE_BARE", "true")
+	if got, found := readClaudeNative(t, repo); found {
+		t.Fatalf("found managed-enabled memory in bare mode: %q", got)
+	}
+}
+
+func TestClaudeReadNativeSafeModeCannotBeReenabledByManagedSettings(t *testing.T) {
+	for name, env := range map[string]string{
+		"provider environment": "CLAUDE_CODE_SAFE_MODE",
+		"wrapper profile":      "CXT_CLAUDE_SAFE_MODE",
+	} {
+		t.Run(name, func(t *testing.T) {
+			home, repo, _ := newClaudeMemoryRepo(t)
+			writeClaudeMemory(t, defaultClaudeMemoryDir(home, canonicalPath(t, repo)), "SAFE MODE MEMORY")
+			config := filepath.Join(home, ".claude")
+			if err := os.MkdirAll(config, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(config, "remote-settings.json"), []byte(`{"autoMemoryEnabled":true}`), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv(env, "true")
+			if got, found := readClaudeNative(t, repo); found {
+				t.Fatalf("found managed-enabled memory in safe mode: %q", got)
+			}
+		})
+	}
+}
+
+func TestClaudeReadNativeIgnoresProjectMemoryDirectoryRedirect(t *testing.T) {
+	home, repo, _ := newClaudeMemoryRepo(t)
+	writeClaudeMemory(t, defaultClaudeMemoryDir(home, canonicalPath(t, repo)), "TRUSTED DEFAULT")
+	untrusted := filepath.Join(t.TempDir(), "untrusted-memory")
+	writeClaudeMemory(t, untrusted, "UNTRUSTED PROJECT REDIRECT")
+	settingsDir := filepath.Join(repo, ".claude")
+	if err := os.MkdirAll(settingsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	settings := fmt.Sprintf(`{"autoMemoryDirectory":%q}`, untrusted)
+	if err := os.WriteFile(filepath.Join(settingsDir, "settings.json"), []byte(settings), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, found := readClaudeNative(t, repo)
+	if !found || got != "TRUSTED DEFAULT" {
+		t.Fatalf("found=%v text=%q, want trusted default memory", found, got)
+	}
+}
+
+func TestClaudeReadNativeFailsClosedWithoutLaunchProfile(t *testing.T) {
+	home, repo, _ := newClaudeMemoryRepo(t)
+	writeClaudeMemory(t, defaultClaudeMemoryDir(home, canonicalPath(t, repo)), "UNPROVEN MEMORY")
+	t.Setenv("CXT_CLAUDE_MEMORY_PROFILE", "")
+	if got, found := readClaudeNative(t, repo); found {
+		t.Fatalf("found unproven memory %q", got)
+	}
+}
+
+func TestClaudeReadNativeFailsClosedWithoutConfigRoot(t *testing.T) {
+	_, repo, _ := newClaudeMemoryRepo(t)
+	t.Setenv("HOME", "")
+	t.Setenv("CLAUDE_CONFIG_DIR", "")
+	t.Setenv("CXT_CLAUDE_MEMORY_CONFIG_FINGERPRINT", ClaudeMemoryConfigFingerprint(context.Background(), repo))
+	resolution := resolveClaudeAutoMemory(context.Background(), repo)
+	if resolution.proven || resolution.memoryDir != "" {
+		t.Fatalf("resolution=%+v, want unproven empty path without a config root", resolution)
+	}
+}
+
+func TestClaudeReadNativeFailsClosedForUnmodeledRemoteMemoryRoots(t *testing.T) {
+	home, repo, _ := newClaudeMemoryRepo(t)
+	writeClaudeMemory(t, defaultClaudeMemoryDir(home, canonicalPath(t, repo)), "LOCAL MEMORY")
+	for name, env := range map[string]string{
+		"remote memory": "CLAUDE_CODE_REMOTE_MEMORY_DIR",
+		"cowork memory": "CLAUDE_COWORK_MEMORY_PATH_OVERRIDE",
+		"memory stores": "CLAUDE_MEMORY_STORES",
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv(env, filepath.Join(t.TempDir(), "provider-owned"))
+			if got, found := readClaudeNative(t, repo); found {
+				t.Fatalf("found local memory under unmodeled runtime %s: %q", env, got)
+			}
+		})
+	}
+}
+
+func TestClaudeReadNativeFailsClosedWhenSettingsChangeAfterLaunch(t *testing.T) {
+	home, repo, _ := newClaudeMemoryRepo(t)
+	writeClaudeMemory(t, defaultClaudeMemoryDir(home, canonicalPath(t, repo)), "LAUNCH MEMORY")
+	t.Setenv("CXT_CLAUDE_MEMORY_CONFIG_FINGERPRINT", ClaudeMemoryConfigFingerprint(context.Background(), repo))
+	config := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(config, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(config, "settings.json"), []byte(`{"autoMemoryEnabled":false}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got, found := readClaudeNativeWithoutRefreshingProfile(t, repo); found {
+		t.Fatalf("found memory after launch settings changed: %q", got)
+	}
+}
+
+func TestClaudeReadNativeAppliesFlagAndManagedPrecedence(t *testing.T) {
+	home, repo, _ := newClaudeMemoryRepo(t)
+	userDir := filepath.Join(home, "user-memory")
+	flagDir := filepath.Join(home, "flag-memory")
+	managedDir := filepath.Join(home, "managed-memory")
+	writeClaudeMemory(t, userDir, "USER MEMORY")
+	writeClaudeMemory(t, flagDir, "FLAG MEMORY")
+	writeClaudeMemory(t, managedDir, "MANAGED MEMORY")
+	config := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(config, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(config, "settings.json"), []byte(fmt.Sprintf(`{"autoMemoryDirectory":%q}`, userDir)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CXT_CLAUDE_FLAG_AUTO_MEMORY_DIRECTORY", flagDir)
+	if got, found := readClaudeNative(t, repo); !found || got != "FLAG MEMORY" {
+		t.Fatalf("flag precedence found=%v text=%q", found, got)
+	}
+
+	if err := os.WriteFile(filepath.Join(config, "remote-settings.json"), []byte(fmt.Sprintf(`{"autoMemoryDirectory":%q}`, managedDir)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got, found := readClaudeNative(t, repo); !found || got != "MANAGED MEMORY" {
+		t.Fatalf("managed precedence found=%v text=%q", found, got)
+	}
+}
+
+func TestClaudeReadNativeHonorsSettingSources(t *testing.T) {
+	home, repo, _ := newClaudeMemoryRepo(t)
+	defaultDir := defaultClaudeMemoryDir(home, canonicalPath(t, repo))
+	userDir := filepath.Join(home, "user-memory")
+	writeClaudeMemory(t, defaultDir, "DEFAULT MEMORY")
+	writeClaudeMemory(t, userDir, "USER MEMORY")
+	config := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(config, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(config, "settings.json"), []byte(fmt.Sprintf(`{"autoMemoryDirectory":%q}`, userDir)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CXT_CLAUDE_SETTING_SOURCES", "project,local")
+	if got, found := readClaudeNative(t, repo); !found || got != "DEFAULT MEMORY" {
+		t.Fatalf("setting-sources found=%v text=%q", found, got)
+	}
 }

--- a/cli/internal/app/restore_test.go
+++ b/cli/internal/app/restore_test.go
@@ -429,6 +429,8 @@ func TestLoadFullPinsCodexReplacementWhileTrimmingLongSuffix(t *testing.T) {
 func TestLoadMemoryMode(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("CXT_CLAUDE_MEMORY_PROFILE", "v1")
+	t.Setenv("CXT_CLAUDE_SETTING_SOURCES", "user,project,local")
 	ctx := context.Background()
 	store := storage.NewFileStore(t.TempDir())
 	seedClaudeSnapshot(t, store)
@@ -438,13 +440,18 @@ func TestLoadMemoryMode(t *testing.T) {
 		t.Fatal(err)
 	}
 	nativeText := "OLDEST-NATIVE\n" + strings.Repeat("é", 80<<10) + "\nNEWEST-NATIVE"
-	nativePath := filepath.Join(home, ".claude", "projects", providerfs.EncodeCwd(cwd), "memory", "MEMORY.md")
+	resolvedCwd, err := filepath.EvalSymlinks(cwd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	nativePath := filepath.Join(home, ".claude", "projects", providerfs.EncodeCwd(resolvedCwd), "memory", "MEMORY.md")
 	if err := os.MkdirAll(filepath.Dir(nativePath), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(nativePath, []byte(nativeText), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	t.Setenv("CXT_CLAUDE_MEMORY_CONFIG_FINGERPRINT", memory.ClaudeMemoryConfigFingerprint(ctx, cwd))
 
 	out, err := newLoadSvc(store).Load(ctx, inbound.LoadInput{Ref: "main", TargetProvider: domain.ProviderClaude, Mode: domain.FidelityMemory, Cwd: cwd})
 	if err != nil {

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -38,7 +38,11 @@ For installation and first-run setup, see
 - `cxt claude` and `cxt codex` pass provider-owned arguments through. Use a
   `--` separator when the provider itself should receive a help flag, for
   example `cxt codex -- --help`; without the separator, `--help` describes the
-  cxt wrapper command.
+  cxt wrapper command. The Claude wrapper forwards only auto-memory-relevant
+  launch metadata from isolated inline `--settings`, `--setting-sources`,
+  `--bare`, and `--safe-mode` to cxt hooks; unrelated settings values are never
+  copied into the environment. External or mixed-purpose `--settings` remain
+  provider-owned and make native-memory projection fail closed.
 
 ## Recommended onboarding
 
@@ -255,8 +259,17 @@ turn once while the full digest remains attached to the seed.
 Provider-native baselines follow the same prompt-only rule with an explicit
 scope. For Claude `MEMORY.md`, cxt removes only a conservative complete-line
 prefix (at most 199 lines and 24 KiB) inside Claude's documented startup limit
-and carries any remaining tail. Codex `memories_1.sqlite` memory is retained
-because it belongs to the source thread and the seed receives a new thread ID.
+and carries any remaining tail. Claude auto memory is resolved from the
+canonical Git repository, so linked worktrees and subdirectories share the
+same source. `CLAUDE_CONFIG_DIR`, safe `CLAUDE_CODE_PROJECT_DIR_NAME`, isolated
+user/inline-flag/managed `autoMemoryDirectory`, settings precedence, and
+auto-memory disablement are honored. The supervised wrapper fingerprints every
+observable settings input at launch; if the profile is absent, changes later,
+uses an external or mixed-purpose settings document, invokes a policy helper,
+or uses an unmodeled remote memory store, cxt does not read or remove native
+memory and keeps the portable baseline instead. Codex
+`memories_1.sqlite` memory is retained because it belongs to the source thread
+and the seed receives a new thread ID.
 
 ### `cxt switch`
 
@@ -308,7 +321,10 @@ The provider-visible projection does not repeat a working-tree-scoped native
 prefix that is guaranteed to auto-load, but it preserves the un-loaded suffix,
 its conversation delta, and every unrelated lineage fragment. Session-scoped
 native memory is carried into the managed region so a newly materialized
-provider session cannot lose it.
+provider session cannot lose it. “Guaranteed” is intentionally limited to a
+live `cxt claude` launch profile whose settings fingerprint still matches;
+direct or ambiguous provider launches retain the portable copy rather than
+guessing and slicing context.
 
 ### `cxt memorize` and `cxt memory`
 

--- a/scripts/e2e-sync.sh
+++ b/scripts/e2e-sync.sh
@@ -292,13 +292,15 @@ expect "isolated session holder killed" "$(kill -0 "$TPID" 2>/dev/null && echo a
 export CLAUDELOG="$TMP/agent.log"
 cat > "$TMP/bin/claude" <<'SH'
 #!/bin/bash
+echo "MEMORY_PROFILE ${CXT_CLAUDE_MEMORY_PROFILE:-missing} ${#CXT_CLAUDE_MEMORY_CONFIG_FINGERPRINT} ${CXT_CLAUDE_FLAG_AUTO_MEMORY_DIRECTORY:-default}" >> "$CLAUDELOG"
 echo "AGENT $*" >> "$CLAUDELOG"
 trap 'kill $SP 2>/dev/null; exit 0' TERM
 sleep 30 & SP=$!
 wait $SP
 SH
 chmod +x "$TMP/bin/claude"
-cxt claude >/dev/null 2>&1 &
+CLAUDE_MEMORY_OVERRIDE="$TMP/initial-claude-memory"
+cxt claude --resume "$SEEDID" --settings "{\"autoMemoryDirectory\":\"$CLAUDE_MEMORY_OVERRIDE\"}" >/dev/null 2>&1 &
 WPID=$!
 sleep 1.5
 session "$TMP/repo2" F
@@ -307,6 +309,9 @@ NEWSEEDID=$(python3 -c "import json;print(json.load(open('.cxt/boundary.json')).
 for i in $(seq 1 20); do grep -q -- "--resume $NEWSEEDID" "$CLAUDELOG" 2>/dev/null && break; sleep 0.5; done
 expect "wrapper automatically restarts as seed (--resume)" "$(grep -c -- "--resume $NEWSEEDID" "$CLAUDELOG")" 1
 expect "restart target = new seed ID" "$(tail -1 "$CLAUDELOG" | grep -c -- "--resume $NEWSEEDID")" 1
+expect "wrapper carries proven Claude memory profile" "$(grep -c '^MEMORY_PROFILE v1 64 ' "$CLAUDELOG")" 2
+expect "initial child carries its custom Claude memory directory" "$(grep -c "^MEMORY_PROFILE v1 64 $CLAUDE_MEMORY_OVERRIDE$" "$CLAUDELOG")" 1
+expect "restarted child drops settings no longer present in its arguments" "$(grep -c '^MEMORY_PROFILE v1 64 default$' "$CLAUDELOG")" 1
 kill "$WPID" 2>/dev/null; wait "$WPID" 2>/dev/null; pkill -f "sleep 30" 2>/dev/null
 
 echo "── H. Web personal settings(load_mode): PATCH /me → CLI consumption"


### PR DESCRIPTION
Closes #94

## Root cause

`ClaudeMemorySource` encoded the current working directory, while current Claude Code keys auto memory from the canonical Git repository. Linked worktrees and subdirectories could therefore select a stale file. The adapter also ignored configuration roots, settings precedence, runtime disable modes, and settings changes between launch and projection. Because cxt removes a proven provider-native prefix from the next prompt, a false positive could hide context that Claude did not auto-load.

## What changed

- resolve one repository-scoped auto-memory path across subdirectories and linked worktrees
- match Claude's project-key encoding, including long paths and UTF-16 hashing
- honor config-root, safe project-name, user/project/local/managed precedence, setting-source selection, and trusted memory-directory rules
- project only a complete supervised launch profile; clear inherited profile fields on every child start
- recompute the profile for each restarted child so dropped arguments cannot leave stale memory settings
- treat bare mode, safe mode, environment disables, remote/cowork stores, policy helpers, missing config roots, and changed settings as unproven
- accept only isolated inline auto-memory flag settings; external or mixed-purpose settings fail closed instead of guessing provider validation or read timing
- bound settings reads before allocation and recheck the configuration fingerprint after reading `MEMORY.md`
- keep stored digests unchanged and retain the portable baseline whenever proof is incomplete

## Verification

- `make test`
- `make lint`
- focused Go race tests
- focused tests repeated 10 and 20 times
- `make test-postgres`
- `make typecheck`
- `make web`
- `make e2e`
- `make e2e-sync`, including custom-setting removal across automatic restart
- `make public-check-full`
- `npm audit`: 0 vulnerabilities

The implementation was checked against Claude Code 2.1.241 and the current official memory, settings, directory, and environment contracts. Ambiguous or provider-internal states deliberately preserve more prompt text rather than slice unproven context.
