### PR TITLE
fix: keep unattested Claude baselines portable

### DIFF
--- a/cli/internal/adapters/memory/claude_memory.go
+++ b/cli/internal/adapters/memory/claude_memory.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"unicode/utf8"
 
 	"github.com/wnsdy95/cxthub/cli/internal/adapters/providerfs"
 	"github.com/wnsdy95/cxthub/cli/internal/domain"
@@ -41,48 +40,13 @@ func (s *ClaudeMemorySource) ReadNative(ctx context.Context, cwd, _ string) (dom
 		Provider: domain.ProviderClaude,
 		Source:   "claude:MEMORY.md",
 		Scope:    domain.NativeMemoryScopeWorkingTree,
-		// Claude currently loads the first 200 lines or 25KB of auto memory
-		// (https://code.claude.com/docs/en/memory).
-		// Use lower bounds and complete lines only so a provider-visible suffix
-		// is never removed on an ambiguous boundary.
-		AutoLoadedPrefix: claudeAutoLoadedPrefix(text),
-		Text:             text,
+		// Resolving the correct file does not prove that the target runtime
+		// loaded these exact bytes. Claude can disable auto memory after settings
+		// resolution and the file can change before startup, while its transcript
+		// exposes no exact-content acknowledgement. Keep the baseline portable
+		// until the provider offers such an attestation.
+		Text: text,
 	}, true, nil
-}
-
-const (
-	claudeAutoMemorySafeLines = 199
-	claudeAutoMemorySafeBytes = 24 << 10
-)
-
-func claudeAutoLoadedPrefix(text string) string {
-	text = strings.TrimSpace(text)
-	if text == "" {
-		return ""
-	}
-	if len(text) <= claudeAutoMemorySafeBytes && strings.Count(text, "\n")+1 <= claudeAutoMemorySafeLines {
-		return text
-	}
-	end := len(text)
-	if end > claudeAutoMemorySafeBytes {
-		end = claudeAutoMemorySafeBytes
-	}
-	for end > 0 && !utf8.ValidString(text[:end]) {
-		end--
-	}
-	lines := 0
-	lastCompleteLine := 0
-	for i := 0; i < end; i++ {
-		if text[i] != '\n' {
-			continue
-		}
-		lines++
-		lastCompleteLine = i + 1
-		if lines >= claudeAutoMemorySafeLines {
-			break
-		}
-	}
-	return strings.TrimSpace(text[:lastCompleteLine])
 }
 
 // ClaudeMemorySink implements MemorySink by writing a MemoryDigest to the Claude project instructions file (CLAUDE.md) (compatibility rules).

--- a/cli/internal/adapters/memory/claude_memory_test.go
+++ b/cli/internal/adapters/memory/claude_memory_test.go
@@ -111,33 +111,6 @@ func readClaudeNativeWithoutRefreshingProfile(t *testing.T, cwd string) (string,
 	return native.Text, true
 }
 
-func TestClaudeAutoLoadedPrefixUsesConservativeCompleteLines(t *testing.T) {
-	t.Run("small memory is fully loaded", func(t *testing.T) {
-		const text = "first memory\nsecond memory"
-		if got := claudeAutoLoadedPrefix(text); got != text {
-			t.Fatalf("prefix=%q want full memory", got)
-		}
-	})
-
-	t.Run("line-limited memory retains the unproven tail", func(t *testing.T) {
-		lines := make([]string, 250)
-		for i := range lines {
-			lines[i] = fmt.Sprintf("memory-line-%03d", i)
-		}
-		got := claudeAutoLoadedPrefix(strings.Join(lines, "\n"))
-		if !strings.Contains(got, "memory-line-198") || strings.Contains(got, "memory-line-199") {
-			t.Fatalf("line-safe prefix ended at the wrong boundary: lines=%d tail=%q", strings.Count(got, "\n")+1, got[len(got)-32:])
-		}
-	})
-
-	t.Run("byte-limited memory never cuts a long line", func(t *testing.T) {
-		text := "safe complete line\n" + strings.Repeat("x", 30<<10) + "\nUNLOADED TAIL"
-		if got := claudeAutoLoadedPrefix(text); got != "safe complete line" {
-			t.Fatalf("prefix cut an incomplete line: bytes=%d tail=%q", len(got), got[max(0, len(got)-32):])
-		}
-	})
-}
-
 func TestClaudeProjectKeyMatchesProviderLongUnicodeEncoding(t *testing.T) {
 	root := "/" + strings.Repeat("very-long-segment/", 20) + "😀"
 	want := "-very-long-segment-very-long-segment-very-long-segment-very-long-segment-very-long-segment-very-long-segment-very-long-segment-very-long-segment-very-long-segment-very-long-segment-very-long-segment-v-2g816y"
@@ -188,6 +161,25 @@ func TestClaudeReadNativeUsesRepositoryIdentityAcrossSubdirsAndWorktrees(t *test
 				t.Fatalf("found=%v text=%q, want repository memory", found, got)
 			}
 		})
+	}
+}
+
+func TestClaudeReadNativeDoesNotClaimRuntimeAutoLoadWithoutAttestation(t *testing.T) {
+	_, repo, _ := newClaudeMemoryRepo(t)
+	const baseline = "PORTABLE CLAUDE MEMORY BASELINE"
+	resolution := resolveClaudeAutoMemory(context.Background(), repo)
+	writeClaudeMemory(t, resolution.memoryDir, baseline)
+	t.Setenv("CXT_CLAUDE_MEMORY_CONFIG_FINGERPRINT", ClaudeMemoryConfigFingerprint(context.Background(), repo))
+
+	native, found, err := NewClaudeMemorySource().ReadNative(context.Background(), repo, "")
+	if err != nil || !found {
+		t.Fatalf("ReadNative found=%v err=%v", found, err)
+	}
+	if native.Text != baseline {
+		t.Fatalf("native text=%q, want %q", native.Text, baseline)
+	}
+	if native.AutoLoadedPrefix != "" {
+		t.Fatalf("unattested auto-loaded prefix=%q, want empty", native.AutoLoadedPrefix)
 	}
 }
 

--- a/cli/internal/app/branch_seed_inheritance_test.go
+++ b/cli/internal/app/branch_seed_inheritance_test.go
@@ -333,7 +333,7 @@ func TestBranchSeedFromMainIncludesStoredMemoryAndFullSession(t *testing.T) {
 	}
 }
 
-func TestBranchSeedProjectsClaudeCwdNativeOnlyFromPrompt(t *testing.T) {
+func TestBranchSeedKeepsClaudeCwdNativeWithoutRuntimeAttestation(t *testing.T) {
 	ctx := context.Background()
 	store := storage.NewFileStore(t.TempDir())
 	repo := domain.Repo{ID: "repo-claude-native-seed", DefaultBranch: "main", LocalPath: t.TempDir()}
@@ -367,12 +367,21 @@ func TestBranchSeedProjectsClaudeCwdNativeOnlyFromPrompt(t *testing.T) {
 			prompt.WriteString(block.Text)
 		}
 	}
-	if strings.Contains(prompt.String(), nativeBaseline) {
-		t.Fatalf("branch prompt duplicated Claude cwd memory:\n%s", prompt.String())
+	if got := strings.Count(prompt.String(), nativeBaseline); got != 1 {
+		t.Fatalf("portable Claude cwd memory count=%d, want one:\n%s", got, prompt.String())
 	}
 	for _, want := range []string{"FRESH LINEAGE SUMMARY", "RAW DEPARTURE REQUEST", "RAW DEPARTURE RESULT"} {
 		if !strings.Contains(prompt.String(), want) {
 			t.Fatalf("branch prompt lost %q:\n%s", want, prompt.String())
+		}
+	}
+	// The target runtime may disable auto memory after configuration or load a
+	// later file version. The seed must still carry the source baseline.
+	const targetRuntimeMemory = "DIFFERENT TARGET-RUNTIME MEMORY"
+	targetVisible := prompt.String() + targetRuntimeMemory
+	for _, want := range []string{nativeBaseline, targetRuntimeMemory} {
+		if !strings.Contains(targetVisible, want) {
+			t.Fatalf("target context lost %q after runtime memory changed:\n%s", want, targetVisible)
 		}
 	}
 	seedSnap, err := store.GetSnapshot(ctx, out.SnapshotID)

--- a/cli/internal/app/seed_digest_test.go
+++ b/cli/internal/app/seed_digest_test.go
@@ -40,7 +40,7 @@ func (s stubMemSource) Provider() domain.ProviderKind { return domain.ProviderCl
 func (s stubMemSource) ReadNative(_ context.Context, _, _ string) (domain.NativeMemory, bool, error) {
 	return domain.NativeMemory{
 		Provider: domain.ProviderClaude, Source: "claude:MEMORY.md",
-		Scope: domain.NativeMemoryScopeWorkingTree, AutoLoadedPrefix: s.text, Text: s.text,
+		Scope: domain.NativeMemoryScopeWorkingTree, Text: s.text,
 	}, s.text != "", nil
 }
 
@@ -183,8 +183,8 @@ func TestLoadMemoryProjectsNativeBaselineByScope(t *testing.T) {
 		wantBaseline bool
 	}{
 		{
-			name: "Claude working-tree memory is already auto-loaded", provider: domain.ProviderClaude,
-			source: stubMemSource{text: "CLAUDE MEMORY MODE BASELINE"}, nativeText: "CLAUDE MEMORY MODE BASELINE",
+			name: "Claude working-tree memory stays portable without runtime attestation", provider: domain.ProviderClaude,
+			source: stubMemSource{text: "CLAUDE MEMORY MODE BASELINE"}, nativeText: "CLAUDE MEMORY MODE BASELINE", wantBaseline: true,
 		},
 		{
 			name: "Codex thread memory must cross into the new session", provider: domain.ProviderCodex,
@@ -220,7 +220,7 @@ func TestLoadMemoryProjectsNativeBaselineByScope(t *testing.T) {
 // (1) Synthetic events are marked with CompactSummary (viewer ◈ collapsible distillation last-wins),
 // (2) Previous generation seed summaries [cxt] are removed (preventing generation accumulation),
 // (3) tool names and ingestion markers in KeyFacts are excluded,
-// (4) Omit summaries if they match native memory text (agent self-load — preventing double injection).
+// (4) Keep native memory portable when the target runtime did not attest an exact load.
 func TestPrependTrimDigestCompactSummary(t *testing.T) {
 	ctx := context.Background()
 	st := storage.NewFileStore(t.TempDir())
@@ -273,18 +273,18 @@ func TestPrependTrimDigestCompactSummary(t *testing.T) {
 		t.Fatalf("Tail preservation failed: %+v", out.Events[1])
 	}
 
-	// (4) Omit summary of native memory text as-is.
+	// (4) Keep native memory text as a portable fallback.
 	svc = mk(domain.MemoryDigest{Summary: "MEMROOT\nfacts"}, "MEMROOT\nfacts")
 	out, err = svc.prependTrimDigest(ctx, full, seed, domain.Snapshot{}, domain.ProviderClaude, t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
-	if strings.Contains(out.Events[0].Blocks[0].Text, "MEMROOT") {
-		t.Fatalf("Native memory text re-injected into seed: %q", out.Events[0].Blocks[0].Text)
+	if !strings.Contains(out.Events[0].Blocks[0].Text, "MEMROOT") {
+		t.Fatalf("Portable native memory missing from seed: %q", out.Events[0].Blocks[0].Text)
 	}
 }
 
-func TestPrependTrimDigestRemovesClaudeNativeBaselineInsideMergedProjection(t *testing.T) {
+func TestPrependTrimDigestKeepsOneClaudeNativeBaselineInsideMergedProjection(t *testing.T) {
 	ctx := context.Background()
 	st := storage.NewFileStore(t.TempDir())
 	snapshotID := domain.HashContent([]byte("claude-native-current-snapshot"))
@@ -349,8 +349,8 @@ func TestPrependTrimDigestRemovesClaudeNativeBaselineInsideMergedProjection(t *t
 			prompt.WriteString(block.Text)
 		}
 	}
-	if strings.Contains(prompt.String(), nativeBaseline) {
-		t.Fatalf("cwd-native baseline was injected even though Claude loads it automatically:\n%s", prompt.String())
+	if got := strings.Count(prompt.String(), nativeBaseline); got != 1 {
+		t.Fatalf("portable cwd-native baseline count=%d, want one copy:\n%s", got, prompt.String())
 	}
 	for _, want := range []string{"ANCESTOR DECISION MUST REMAIN", "FRESH OMITTED DECISION", "RECENT RAW TURN"} {
 		if !strings.Contains(prompt.String(), want) {

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -257,17 +257,20 @@ conversation events are also replayed verbatim, their extractive memory delta
 is removed only from the prompt projection, so the new session receives each
 turn once while the full digest remains attached to the seed.
 Provider-native baselines follow the same prompt-only rule with an explicit
-scope. For Claude `MEMORY.md`, cxt removes only a conservative complete-line
-prefix (at most 199 lines and 24 KiB) inside Claude's documented startup limit
-and carries any remaining tail. Claude auto memory is resolved from the
-canonical Git repository, so linked worktrees and subdirectories share the
-same source. `CLAUDE_CONFIG_DIR`, safe `CLAUDE_CODE_PROJECT_DIR_NAME`, isolated
+scope. Claude auto memory is resolved from the canonical Git repository, so
+linked worktrees and subdirectories share the same source.
+`CLAUDE_CONFIG_DIR`, safe `CLAUDE_CODE_PROJECT_DIR_NAME`, isolated
 user/inline-flag/managed `autoMemoryDirectory`, settings precedence, and
 auto-memory disablement are honored. The supervised wrapper fingerprints every
 observable settings input at launch; if the profile is absent, changes later,
 uses an external or mixed-purpose settings document, invokes a policy helper,
-or uses an unmodeled remote memory store, cxt does not read or remove native
-memory and keeps the portable baseline instead. Codex
+or uses an unmodeled remote memory store, cxt does not ingest that native file.
+Even after the file is resolved, cxt does not selectively strip the Claude
+`MEMORY.md` baseline from the normal budgeted projection: configuration cannot
+attest that the target runtime loaded those exact bytes, because model/runtime
+gates and a startup-time file change remain possible. Exact-baseline merge
+deduplication keeps one copy rather than recursively nesting it across seed
+generations. Codex
 `memories_1.sqlite` memory is retained because it belongs to the source thread
 and the seed receives a new thread ID.
 
@@ -317,14 +320,12 @@ The mode priority is:
 refreshes one marked region in `CLAUDE.md` or `AGENTS.md`; text and permissions
 outside that region are preserved. Malformed or duplicate cxt markers fail
 closed instead of guessing a destructive replacement range.
-The provider-visible projection does not repeat a working-tree-scoped native
-prefix that is guaranteed to auto-load, but it preserves the un-loaded suffix,
-its conversation delta, and every unrelated lineage fragment. Session-scoped
-native memory is carried into the managed region so a newly materialized
-provider session cannot lose it. “Guaranteed” is intentionally limited to a
-live `cxt claude` launch profile whose settings fingerprint still matches;
-direct or ambiguous provider launches retain the portable copy rather than
-guessing and slicing context.
+The provider-visible projection may remove a working-tree-scoped native prefix
+only when the provider supplies an exact runtime load attestation. Claude does
+not currently expose one, so its full resolved baseline, conversation delta,
+and every unrelated lineage fragment remain portable. Session-scoped native
+memory is likewise carried into the managed region so a newly materialized
+provider session cannot lose it.
 
 ### `cxt memorize` and `cxt memory`
 


### PR DESCRIPTION
Closes #96

## Root cause

Resolving the correct Claude `MEMORY.md` and settings is not a runtime load attestation. Claude Code 2.1.241 can still disable auto memory through current-model/server gates after configuration, and the file can change between cxt seed materialization and provider startup. The transcript and hook payload do not identify the exact loaded memory bytes.

The previous non-empty `AutoLoadedPrefix` therefore allowed a false-positive prompt projection: cxt could remove a baseline that the target session never loaded.

## Decision

Claude native memory remains portable until the provider exposes an exact runtime acknowledgement.

- keep the #95 repository/settings resolver for correct native-memory ingestion
- leave Claude `AutoLoadedPrefix` empty
- retain the baseline in normal budgeted prompt projections and in the immutable attached digest
- rely on exact-baseline fragment deduplication from #93 so sibling lineages and seed generations produce one copy, not recursive nesting
- leave the generic attested-prefix projection and Codex session-scoped behavior unchanged

This trades at most the formerly removed startup prefix for zero silent omission risk. The existing seed and memory budgets still cap provider-visible payloads.

## Verification

- `make test`
- `make lint`
- focused race tests
- focused tests repeated 10 times
- `make test-postgres`
- `make typecheck`
- `make web`
- `make e2e`
- `make e2e-sync`
- `make public-check-full`
- `npm audit`: 0 vulnerabilities

Regression coverage verifies that a branch seed keeps exactly one Claude baseline and remains complete when the target runtime loads different memory content.
