### PR TITLE
fix: preserve portable memory on full replay

### DIFF
--- a/cli/internal/adapters/memory/distiller.go
+++ b/cli/internal/adapters/memory/distiller.go
@@ -122,7 +122,6 @@ func (d *RuleDistiller) Distill(_ context.Context, cir domain.CIRDocument, nativ
 
 const (
 	extractiveDigestMaxRunes = 16000
-	extractiveItemMaxRunes   = 2000
 	extractiveItemsPerRole   = 6
 )
 
@@ -190,8 +189,7 @@ func containsSyntheticSeedText(text string) bool {
 }
 
 func appendRecentDistinct(items []string, text string, limit int) []string {
-	text = strings.Join(strings.Fields(text), " ")
-	text = truncate(text, extractiveItemMaxRunes)
+	text = domain.NormalizeExtractiveConversationItem(text)
 	if text == "" || (len(items) > 0 && items[len(items)-1] == text) {
 		return items
 	}

--- a/cli/internal/app/load_session.go
+++ b/cli/internal/app/load_session.go
@@ -31,8 +31,9 @@ import (
 //     full (or reconstructed):
 //     a. ProviderCodec[TargetProvider].Encode(cir, TargetProvider)
 //     b. SessionMaterializer[TargetProvider].Materialize(cir, Cwd) → (sessionPath, resumeCmd)
-//     c. LoadOutput{WrittenPath: sessionPath, ResumeCmd, Fidelity: full/reconstructed}
-//     d. **Fallback to memory mode automatically on Materialize failure** (Fidelity downgrade → memory).
+//     c. Prepend bounded portable memory not already represented by the replay.
+//     d. LoadOutput{WrittenPath: sessionPath, ResumeCmd, Fidelity: full/reconstructed}
+//     e. **Fallback to memory mode automatically on Materialize failure** (Fidelity downgrade → memory).
 //     memory:
 //     a. For same-provider or legacy replay, MemorySource[TargetProvider].ReadNative(Cwd, SessionOriginID) → (native, found)
 //     b. MemoryDistiller.Distill(cir, native) → MemoryDigest (native==nil fallback to CIR distillation)
@@ -120,7 +121,20 @@ func (s *LoadSessionService) Load(ctx context.Context, in inbound.LoadInput) (in
 	var omitted []domain.Event
 	keptReplacement := preserveCodexReplacement
 	totalBudget, digestBudget := seedBudgets(target)
-	if eventsJSONBytes(seedCIR.Events) > totalBudget {
+	portableSeed, hasPortableSeed := s.portableReplaySeed(
+		ctx, seedCIR, snap, target, in.Cwd, digestBudget,
+	)
+	projectedSeedCIR := seedCIR
+	if hasPortableSeed {
+		insertAfter := 0
+		if preserveCodexReplacement {
+			insertAfter = replacementCount
+		}
+		projectedSeedCIR.Events = replaceSyntheticSeedSummary(seedCIR.Events, portableSeed, insertAfter)
+	}
+	requiresTrim := eventsJSONBytes(seedCIR.Events) > totalBudget ||
+		(hasPortableSeed && eventsJSONBytes(projectedSeedCIR.Events) > totalBudget)
+	if requiresTrim {
 		conversationBudget := totalBudget - digestBudget
 		if preserveCodexReplacement {
 			seedCIR, omitted, keptReplacement = trimEventsForSeedKeepingPrefix(seedCIR, replacementCount, conversationBudget)
@@ -144,6 +158,8 @@ func (s *LoadSessionService) Load(ctx context.Context, in inbound.LoadInput) (in
 		if digestErr != nil {
 			return inbound.LoadOutput{}, fmt.Errorf("distill omitted context: %w", digestErr)
 		}
+	} else if hasPortableSeed {
+		seedCIR = projectedSeedCIR
 	}
 	// A restored session belongs to the working tree it is being restored into,
 	// not the machine/path where the source snapshot was captured. Codex active
@@ -544,6 +560,15 @@ func renderSeedBulletSection(title string, items []string, maxBytes int) string 
 
 func renderSeedDigest(digest domain.MemoryDigest, dropped, budget int) string {
 	header := fmt.Sprintf("%s %d events were omitted to fit the context window; below is a bounded memory summary of the omitted span. The recent history follows verbatim.\n", seedSummaryPrefix, dropped)
+	return renderSeedDigestWithHeader(digest, header, budget)
+}
+
+func renderPortableReplayDigest(digest domain.MemoryDigest, budget int) string {
+	header := seedSummaryPrefix + " Portable memory from the source context is included below. The full source conversation follows verbatim.\n"
+	return renderSeedDigestWithHeader(digest, header, budget)
+}
+
+func renderSeedDigestWithHeader(digest domain.MemoryDigest, header string, budget int) string {
 	if len(header) >= budget {
 		return truncateUTF8Prefix(header, budget)
 	}
@@ -560,6 +585,128 @@ func renderSeedDigest(digest domain.MemoryDigest, dropped, budget int) string {
 	out := header + summaryBlock + facts + tasks
 	if len(out) > budget {
 		return truncateUTF8Prefix(out, budget)
+	}
+	return out
+}
+
+// portableReplaySeed projects memory that is not already represented by the
+// verbatim current conversation. A full-fidelity materialization still starts
+// a new provider session, so provider/native baselines and inherited lineage
+// memory must cross that boundary unless the target proves it auto-loads the
+// exact bytes. The immutable stored digest remains untouched.
+func (s *LoadSessionService) portableReplaySeed(
+	ctx context.Context,
+	seed domain.CIRDocument,
+	snap domain.Snapshot,
+	target domain.ProviderKind,
+	cwd string,
+	budget int,
+) (domain.Event, bool) {
+	digest, ok := snapshotMemoryProjection(ctx, s.store, snap)
+	if !ok {
+		return domain.Event{}, false
+	}
+	// Normalize legacy opaque digests before prompt-only projections. Besides
+	// attaching provenance, this removes the private conversation-delta marker
+	// from provider-visible rendering.
+	digest = domain.MergeDigests(domain.MemoryDigest{}, digest)
+	digest = domain.WithoutConversationDeltaFromSource(digest, snap.ID)
+	replayedUsers, replayedAssistants := replayedConversationTexts(seed.Events)
+	digest = domain.WithoutExactReplayedConversationItems(digest, replayedUsers, replayedAssistants)
+	for _, event := range seed.Events {
+		if !event.CompactSummary || isSeedSummaryEvent(event) {
+			continue
+		}
+		for _, block := range event.Blocks {
+			digest = domain.WithoutExactReplayedSummary(digest, block.Text)
+		}
+	}
+	digest = boundCarriedDigest(digest)
+	if carried, found := syntheticSeedMemoryProjection(seed.Events, snap.ID); found {
+		// A materialized seed can be the only remaining representation of older
+		// context even when the snapshot also has a narrower stored digest. Fold
+		// it into the normalized replacement before removing the old event.
+		digest = domain.MergeDigests(carried, digest)
+		digest = boundCarriedDigest(digest)
+	}
+	if native, found := readTargetNativeMemory(
+		ctx, s.memSources, target, cwd, seed.Envelope.SessionOriginID,
+	); found {
+		digest = projectAutoLoadedNative(digest, native)
+	}
+	if !memoryDigestHasProjection(digest) {
+		return domain.Event{}, false
+	}
+	return domain.Event{
+		Kind:           domain.EventMessage,
+		Role:           "user",
+		CompactSummary: true,
+		Blocks: []domain.ContentBlock{{
+			Type: "text",
+			Text: renderPortableReplayDigest(digest, budget),
+		}},
+	}, true
+}
+
+func replayedConversationTexts(events []domain.Event) (users, assistants []string) {
+	for _, event := range events {
+		if event.Kind != domain.EventMessage || event.CompactSummary || isSeedSummaryEvent(event) {
+			continue
+		}
+		parts := make([]string, 0, len(event.Blocks))
+		for _, block := range event.Blocks {
+			if block.Type == "text" && strings.TrimSpace(block.Text) != "" {
+				parts = append(parts, strings.TrimSpace(block.Text))
+			}
+		}
+		text := strings.Join(parts, "\n")
+		if text == "" {
+			continue
+		}
+		switch event.Role {
+		case "user":
+			users = append(users, text)
+		case "assistant":
+			assistants = append(assistants, text)
+		}
+	}
+	return users, assistants
+}
+
+func replaceSyntheticSeedSummary(events []domain.Event, seed domain.Event, insertAfter int) []domain.Event {
+	if insertAfter < 0 || insertAfter > len(events) {
+		insertAfter = 0
+	}
+	out := make([]domain.Event, 0, len(events)+1)
+	for i, event := range events {
+		if i == insertAfter {
+			out = append(out, seed)
+		}
+		if isSeedSummaryEvent(event) {
+			continue
+		}
+		out = append(out, event)
+	}
+	if insertAfter == len(events) {
+		out = append(out, seed)
+	}
+	seedAt := -1
+	for i := range out {
+		if out[i].CompactSummary && isSeedSummaryEvent(out[i]) {
+			seedAt = i
+			break
+		}
+	}
+	if seedAt >= 0 {
+		switch {
+		case seedAt+1 < len(out):
+			out[seedAt].Ts = out[seedAt+1].Ts
+		case seedAt > 0:
+			out[seedAt].Ts = out[seedAt-1].Ts
+		}
+	}
+	for i := range out {
+		out[i].Seq = i
 	}
 	return out
 }
@@ -667,7 +814,7 @@ func (s *LoadSessionService) prependTrimDigestWithStatus(ctx context.Context, om
 }
 
 func memoryDigestHasProjection(d domain.MemoryDigest) bool {
-	return strings.TrimSpace(d.Summary) != "" || len(d.KeyFacts) > 0 || len(d.OpenTasks) > 0 || len(d.Fragments) > 0
+	return strings.TrimSpace(d.Summary) != "" || len(d.KeyFacts) > 0 || len(d.OpenTasks) > 0
 }
 
 func (s *LoadSessionService) insertTrimDigestAfterPrefix(ctx context.Context, omitted, seed domain.CIRDocument, prefixCount int, snap domain.Snapshot, target domain.ProviderKind, cwd string) (domain.CIRDocument, error) {
@@ -746,6 +893,7 @@ func syntheticSeedMemoryProjection(events []domain.Event, source domain.ContentH
 	}
 	summary := strings.Join(summaries, "\n\n")
 	facts, tasks, tasksAuthoritative := syntheticSeedStructuredProjection(summary)
+	summary = withoutSyntheticSeedStructuredSections(summary)
 	return boundCarriedDigest(domain.MemoryDigest{
 		SnapshotID:         source,
 		Summary:            summary,
@@ -753,6 +901,36 @@ func syntheticSeedMemoryProjection(events []domain.Event, source domain.ContentH
 		OpenTasks:          tasks,
 		TasksAuthoritative: tasksAuthoritative,
 	}), true
+}
+
+func withoutSyntheticSeedStructuredSections(text string) string {
+	const (
+		sectionNone = iota
+		sectionFacts
+		sectionTasks
+	)
+	section := sectionNone
+	lines := strings.Split(text, "\n")
+	out := make([]string, 0, len(lines))
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		switch trimmed {
+		case "Key facts:":
+			section = sectionFacts
+			continue
+		case "Open tasks:":
+			section = sectionTasks
+			continue
+		}
+		if section != sectionNone {
+			if trimmed == "" || strings.HasPrefix(trimmed, "- ") {
+				continue
+			}
+			section = sectionNone
+		}
+		out = append(out, line)
+	}
+	return strings.TrimSpace(strings.Join(out, "\n"))
 }
 
 // syntheticSeedStructuredProjection recovers the newest rendered cxt bullet

--- a/cli/internal/app/memorize.go
+++ b/cli/internal/app/memorize.go
@@ -827,7 +827,7 @@ func boundCarriedDigest(d domain.MemoryDigest) domain.MemoryDigest {
 			fragment.Summary = truncateUTF8Tail(fragment.Summary, remainingSummary)
 			fragment.KeyFacts = boundStringListTail(fragment.KeyFacts, remainingFacts)
 			fragment.OpenTasks = boundStringListTail(fragment.OpenTasks, remainingTasks)
-			if fragment.Summary == "" && len(fragment.KeyFacts) == 0 && len(fragment.OpenTasks) == 0 {
+			if fragment.Summary == "" && len(fragment.KeyFacts) == 0 && len(fragment.OpenTasks) == 0 && !fragment.TasksAuthoritative {
 				continue
 			}
 			remainingSummary -= len(fragment.Summary)

--- a/cli/internal/app/restore_test.go
+++ b/cli/internal/app/restore_test.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -94,6 +95,220 @@ func TestLoadFullSameProvider(t *testing.T) {
 	}
 }
 
+func TestLoadFullUntrimmedCarriesPortableMemoryWithoutDuplicatingConversation(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	ctx := context.Background()
+	store := storage.NewFileStore(t.TempDir())
+	snapshotID := seedClaudeSnapshot(t, store)
+	const baseline = "PORTABLE PROVIDER BASELINE"
+	memoryHash, err := store.PutMemory(ctx, domain.MemoryDigest{
+		SnapshotID: snapshotID,
+		Summary: domain.AppendExtractiveConversationDelta(baseline,
+			domain.RenderExtractiveFallbackSummary([]string{"do it"}, []string{"working"})),
+		Provider: domain.ProviderClaude,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	snap, err := store.GetSnapshot(ctx, snapshotID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	snap.MemoryHash = memoryHash
+	if err := store.PutSnapshot(ctx, snap); err != nil {
+		t.Fatal(err)
+	}
+
+	svc := NewLoadSessionService(
+		store,
+		map[domain.ProviderKind]outbound.ProviderCodec{domain.ProviderClaude: codec.NewClaudeCodec()},
+		map[domain.ProviderKind]outbound.SessionMaterializer{domain.ProviderClaude: session.NewClaudeMaterializer()},
+		map[domain.ProviderKind]outbound.MemorySource{
+			domain.ProviderClaude: stubMemSource{text: "DIFFERENT TARGET MEMORY"},
+		},
+		memory.NewRuleDistiller(), nil,
+	)
+	out, err := svc.Load(ctx, inbound.LoadInput{
+		Ref: "main", TargetProvider: domain.ProviderClaude, Mode: domain.FidelityFull, Cwd: t.TempDir(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.TrimmedEvents != 0 {
+		t.Fatalf("small full replay trimmed %d events, want none", out.TrimmedEvents)
+	}
+	raw, err := os.ReadFile(out.WrittenPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	restored, err := codec.NewClaudeCodec().Decode(ctx, raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var prompt strings.Builder
+	seedCount := 0
+	for _, ev := range restored.EffectiveContext().Events {
+		if isSeedSummaryEvent(ev) {
+			seedCount++
+		}
+		for _, block := range ev.Blocks {
+			prompt.WriteString(block.Text)
+		}
+	}
+	if got := strings.Count(prompt.String(), baseline); got != 1 {
+		t.Fatalf("portable baseline count=%d, want one:\n%s", got, prompt.String())
+	}
+	if seedCount != 1 {
+		t.Fatalf("portable seed count=%d, want one", seedCount)
+	}
+	for _, current := range []string{"do it", "working"} {
+		if got := strings.Count(prompt.String(), current); got != 1 {
+			t.Fatalf("raw conversation count(%q)=%d, want one:\n%s", current, got, prompt.String())
+		}
+	}
+}
+
+func TestLoadFullUntrimmedDoesNotDuplicateAncestorConversationDelta(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	ctx := context.Background()
+	store := storage.NewFileStore(t.TempDir())
+	cir, err := codec.NewClaudeCodec().Decode(ctx, []byte(claudeFixtureWithSig))
+	if err != nil {
+		t.Fatal(err)
+	}
+	currentID, err := store.PutDoc(ctx, domain.SessionDoc{CIR: cir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ancestorID := domain.HashContent([]byte("ancestor-conversation-already-in-current-replay"))
+	const baseline = "ANCESTOR PORTABLE BASELINE"
+	ancestorMemory, err := store.PutMemory(ctx, domain.MemoryDigest{
+		SnapshotID: ancestorID,
+		Summary: domain.AppendExtractiveConversationDelta(baseline,
+			domain.RenderExtractiveFallbackSummary([]string{"do it"}, []string{"working"})),
+		Provider: domain.ProviderClaude,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.PutSnapshot(ctx, domain.Snapshot{
+		ID: ancestorID, DocHash: ancestorID, Branch: "main", Provider: domain.ProviderClaude,
+		Fidelity: domain.FidelityFull, MemoryHash: ancestorMemory,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.PutSnapshot(ctx, domain.Snapshot{
+		ID: currentID, DocHash: currentID, Branch: "main", Provider: domain.ProviderClaude,
+		Fidelity: domain.FidelityFull, Parents: []domain.ContentHash{ancestorID},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.PutRef(ctx, domain.Ref{Kind: domain.RefBranch, Name: "main", Target: currentID}); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := newLoadSvc(store).Load(ctx, inbound.LoadInput{
+		Ref: "main", TargetProvider: domain.ProviderClaude, Mode: domain.FidelityFull, Cwd: t.TempDir(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := os.ReadFile(out.WrittenPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	restored, err := codec.NewClaudeCodec().Decode(ctx, raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var prompt strings.Builder
+	for _, event := range restored.EffectiveContext().Events {
+		for _, block := range event.Blocks {
+			prompt.WriteString(block.Text)
+		}
+	}
+	for _, want := range []string{baseline, "do it", "working"} {
+		if got := strings.Count(prompt.String(), want); got != 1 {
+			t.Fatalf("ancestor replay count(%q)=%d, want one:\n%s", want, got, prompt.String())
+		}
+	}
+	if strings.Contains(prompt.String(), "[cxt conversation delta v1]") {
+		t.Fatalf("private memory marker leaked into full replay:\n%s", prompt.String())
+	}
+}
+
+func TestLoadFullUntrimmedDoesNotDuplicateReplayedProviderCompaction(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	ctx := context.Background()
+	store := storage.NewFileStore(t.TempDir())
+	const compactBaseline = "PROVIDER COMPACTION ALREADY IN RAW REPLAY"
+	cir := domain.CIRDocument{
+		Envelope: domain.Envelope{
+			CIRVersion: domain.CIRVersionV1, SourceProvider: domain.ProviderClaude,
+			Cwd: "/source", GitBranch: "main", SessionOriginID: "compact-source",
+		},
+		Events: []domain.Event{
+			{Kind: domain.EventMessage, Role: "user", CompactSummary: true, Blocks: []domain.ContentBlock{{Type: "text", Text: compactBaseline}}},
+			{Kind: domain.EventMessage, Role: "user", Blocks: []domain.ContentBlock{{Type: "text", Text: "POST COMPACTION REQUEST"}}},
+			{Kind: domain.EventMessage, Role: "assistant", Blocks: []domain.ContentBlock{{Type: "text", Text: "POST COMPACTION RESULT"}}},
+		},
+	}
+	snapshotID, err := store.PutDoc(ctx, domain.SessionDoc{CIR: cir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest, err := memory.NewRuleDistiller().Distill(ctx, cir, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest.SnapshotID = snapshotID
+	digest = domain.MergeDigests(domain.MemoryDigest{}, digest)
+	memoryHash, err := store.PutMemory(ctx, digest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.PutSnapshot(ctx, domain.Snapshot{
+		ID: snapshotID, DocHash: snapshotID, Branch: "main", Provider: domain.ProviderClaude,
+		Fidelity: domain.FidelityFull, MemoryHash: memoryHash,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.PutRef(ctx, domain.Ref{Kind: domain.RefBranch, Name: "main", Target: snapshotID}); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := newLoadSvc(store).Load(ctx, inbound.LoadInput{
+		Ref: "main", TargetProvider: domain.ProviderClaude, Mode: domain.FidelityFull, Cwd: t.TempDir(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := os.ReadFile(out.WrittenPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	restored, err := codec.NewClaudeCodec().Decode(ctx, raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var prompt strings.Builder
+	seedCount := 0
+	for _, ev := range restored.EffectiveContext().Events {
+		if isSeedSummaryEvent(ev) {
+			seedCount++
+		}
+		for _, block := range ev.Blocks {
+			prompt.WriteString(block.Text)
+		}
+	}
+	if got := strings.Count(prompt.String(), compactBaseline); got != 1 {
+		t.Fatalf("replayed provider compaction count=%d, want one:\n%s", got, prompt.String())
+	}
+	if seedCount != 0 {
+		t.Fatalf("provider compaction alone created %d redundant cxt seeds", seedCount)
+	}
+}
+
 // Cross-provider full request: claude → codex, reconstructed fallback + claude signature masked.
 func TestLoadCrossProvider(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
@@ -128,6 +343,132 @@ func TestLoadCrossProvider(t *testing.T) {
 	}
 	if restored.Envelope.Cwd != cwd {
 		t.Fatalf("restored Codex session cwd = %q, want target %q", restored.Envelope.Cwd, cwd)
+	}
+}
+
+func TestLoadCrossProviderUntrimmedCarriesPortableMemory(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	ctx := context.Background()
+	store := storage.NewFileStore(t.TempDir())
+	snapshotID := seedClaudeSnapshot(t, store)
+	const baseline = "CROSS PROVIDER PORTABLE BASELINE"
+	memoryHash, err := store.PutMemory(ctx, domain.MemoryDigest{
+		SnapshotID: snapshotID,
+		Summary: domain.AppendExtractiveConversationDelta(baseline,
+			domain.RenderExtractiveFallbackSummary([]string{"do it"}, []string{"working"})),
+		Provider: domain.ProviderClaude,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	snap, err := store.GetSnapshot(ctx, snapshotID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	snap.MemoryHash = memoryHash
+	if err := store.PutSnapshot(ctx, snap); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := newLoadSvc(store).Load(ctx, inbound.LoadInput{
+		Ref: "main", TargetProvider: domain.ProviderCodex, Mode: domain.FidelityFull, Cwd: t.TempDir(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Fidelity != domain.FidelityReconstructed || out.TrimmedEvents != 0 {
+		t.Fatalf("cross-provider output=%+v, want untrimmed reconstructed", out)
+	}
+	raw, err := os.ReadFile(out.WrittenPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	restored, err := codec.NewCodexCodec().Decode(ctx, raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var prompt strings.Builder
+	for _, event := range restored.EffectiveContext().Events {
+		for _, block := range event.Blocks {
+			prompt.WriteString(block.Text)
+		}
+	}
+	for _, want := range []string{baseline, "do it", "working"} {
+		if got := strings.Count(prompt.String(), want); got != 1 {
+			t.Fatalf("cross-provider count(%q)=%d, want one:\n%s", want, got, prompt.String())
+		}
+	}
+}
+
+func TestLoadPortableMemoryTriggersBoundedTurnTrimOnlyWhenCombinedSeedExceedsBudget(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	ctx := context.Background()
+	store := storage.NewFileStore(t.TempDir())
+	events := make([]domain.Event, 0, 20)
+	for i := 0; i < 10; i++ {
+		events = append(events,
+			domain.Event{Kind: domain.EventMessage, Seq: len(events), Role: "user", Blocks: []domain.ContentBlock{{
+				Type: "text", Text: fmt.Sprintf("BUDGET REQUEST %02d ", i) + strings.Repeat("u", 8<<10),
+			}}},
+			domain.Event{Kind: domain.EventMessage, Seq: len(events) + 1, Role: "assistant", Blocks: []domain.ContentBlock{{
+				Type: "text", Text: fmt.Sprintf("BUDGET RESULT %02d ", i) + strings.Repeat("a", 8<<10),
+			}}},
+		)
+	}
+	cir := domain.CIRDocument{
+		Envelope: domain.Envelope{
+			CIRVersion: domain.CIRVersionV1, SourceProvider: domain.ProviderClaude,
+			Cwd: "/source", GitBranch: "main", SessionOriginID: "portable-budget",
+		},
+		Events: events,
+	}
+	snapshotID, err := store.PutDoc(ctx, domain.SessionDoc{CIR: cir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	const baselineMarker = "LARGE PORTABLE BASELINE END"
+	baseline := strings.Repeat("m", 40<<10) + " " + baselineMarker
+	memoryHash, err := store.PutMemory(ctx, domain.MemoryDigest{
+		SnapshotID: snapshotID,
+		Summary: domain.AppendExtractiveConversationDelta(baseline,
+			domain.RenderExtractiveFallbackSummary([]string{"BUDGET REQUEST 09"}, []string{"BUDGET RESULT 09"})),
+		Provider: domain.ProviderClaude,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.PutSnapshot(ctx, domain.Snapshot{
+		ID: snapshotID, DocHash: snapshotID, Branch: "main", Provider: domain.ProviderClaude,
+		Fidelity: domain.FidelityFull, MemoryHash: memoryHash,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.PutRef(ctx, domain.Ref{Kind: domain.RefBranch, Name: "main", Target: snapshotID}); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := newLoadSvc(store).Load(ctx, inbound.LoadInput{
+		Ref: "main", TargetProvider: domain.ProviderClaude, Mode: domain.FidelityFull, Cwd: t.TempDir(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.TrimmedEvents == 0 {
+		t.Fatal("combined replay plus portable memory exceeded the budget without trimming")
+	}
+	raw, err := os.ReadFile(out.WrittenPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	totalBudget, _ := seedBudgets(domain.ProviderClaude)
+	if len(raw) > totalBudget+(32<<10) {
+		t.Fatalf("materialized seed=%d bytes, want bounded near %d", len(raw), totalBudget)
+	}
+	if got := strings.Count(string(raw), baselineMarker); got != 1 {
+		t.Fatalf("bounded replay baseline count=%d, want one", got)
+	}
+	if !strings.Contains(string(raw), "BUDGET REQUEST 09") || !strings.Contains(string(raw), "BUDGET RESULT 09") {
+		t.Fatal("bounded replay lost the newest complete turn")
 	}
 }
 
@@ -258,7 +599,16 @@ func TestLoadFullReplaysCodexReplacementInsteadOfPreCompactionArchive(t *testing
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := store.PutSnapshot(ctx, domain.Snapshot{ID: hash, Branch: "main", DocHash: hash, Provider: domain.ProviderCodex, Fidelity: domain.FidelityFull}); err != nil {
+	memoryHash, err := store.PutMemory(ctx, domain.MemoryDigest{
+		SnapshotID: hash, Summary: "CODEX PORTABLE MEMORY AFTER REPLACEMENT", Provider: domain.ProviderCodex,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.PutSnapshot(ctx, domain.Snapshot{
+		ID: hash, Branch: "main", DocHash: hash, Provider: domain.ProviderCodex,
+		Fidelity: domain.FidelityFull, MemoryHash: memoryHash,
+	}); err != nil {
 		t.Fatal(err)
 	}
 	if err := store.PutRef(ctx, domain.Ref{Kind: domain.RefBranch, Name: "main", Target: hash}); err != nil {
@@ -284,7 +634,7 @@ func TestLoadFullReplaysCodexReplacementInsteadOfPreCompactionArchive(t *testing
 	if strings.Contains(string(raw), `"type":"response_item","payload":{"type":"compaction"`) {
 		t.Fatalf("encrypted compaction state was flattened into an unsupported top-level response item:\n%s", raw)
 	}
-	for _, want := range []string{"active compacted request", "ACTIVE-ENC", "active answer"} {
+	for _, want := range []string{"active compacted request", "ACTIVE-ENC", "CODEX PORTABLE MEMORY AFTER REPLACEMENT", "active answer"} {
 		if !strings.Contains(string(raw), want) {
 			t.Fatalf("load lost active replacement %q", want)
 		}
@@ -297,8 +647,30 @@ func TestLoadFullReplaysCodexReplacementInsteadOfPreCompactionArchive(t *testing
 		t.Fatalf("restored archive does not contain one authoritative boundary: %+v", restored.Events)
 	}
 	active := restored.EffectiveContext()
-	if len(active.Events) != 3 || active.Events[1].Kind != domain.EventCompaction || active.Events[1].Locked == nil {
+	if len(active.Events) != 4 {
 		t.Fatalf("restored active context = %+v", active.Events)
+	}
+	requestAt, lockedAt, memoryAt, answerAt := -1, -1, -1, -1
+	for i, event := range active.Events {
+		if event.Kind == domain.EventCompaction && event.Locked != nil && event.Locked.Blob == "ACTIVE-ENC" {
+			lockedAt = i
+		}
+		for _, block := range event.Blocks {
+			switch block.Text {
+			case "active compacted request":
+				requestAt = i
+			case "active answer":
+				answerAt = i
+			default:
+				if strings.Contains(block.Text, "CODEX PORTABLE MEMORY AFTER REPLACEMENT") {
+					memoryAt = i
+				}
+			}
+		}
+	}
+	if !(requestAt >= 0 && requestAt < lockedAt && lockedAt < memoryAt && memoryAt < answerAt) {
+		t.Fatalf("replay order is not replacement → memory → suffix: request=%d locked=%d memory=%d answer=%d events=%+v",
+			requestAt, lockedAt, memoryAt, answerAt, active.Events)
 	}
 }
 

--- a/cli/internal/app/seed_digest_test.go
+++ b/cli/internal/app/seed_digest_test.go
@@ -34,13 +34,16 @@ func (d *recordingNativeDistiller) Distill(_ context.Context, _ domain.CIRDocume
 	return domain.MemoryDigest{Summary: "loaded memory"}, nil
 }
 
-type stubMemSource struct{ text string }
+type stubMemSource struct {
+	text             string
+	autoLoadedPrefix string
+}
 
 func (s stubMemSource) Provider() domain.ProviderKind { return domain.ProviderClaude }
 func (s stubMemSource) ReadNative(_ context.Context, _, _ string) (domain.NativeMemory, bool, error) {
 	return domain.NativeMemory{
 		Provider: domain.ProviderClaude, Source: "claude:MEMORY.md",
-		Scope: domain.NativeMemoryScopeWorkingTree, Text: s.text,
+		Scope: domain.NativeMemoryScopeWorkingTree, Text: s.text, AutoLoadedPrefix: s.autoLoadedPrefix,
 	}, s.text != "", nil
 }
 
@@ -385,6 +388,124 @@ func TestPrependTrimDigestKeepsCodexThreadNativeMemoryForNewSession(t *testing.T
 	if len(out.Events) == 0 || len(out.Events[0].Blocks) == 0 ||
 		!strings.Contains(out.Events[0].Blocks[0].Text, "exact session memory") {
 		t.Fatalf("thread-scoped Codex memory was dropped before materializing a new thread: %+v", out.Events)
+	}
+}
+
+func TestPortableReplaySeedCarriesExistingSyntheticMemoryBeforeReplacement(t *testing.T) {
+	ctx := context.Background()
+	st := storage.NewFileStore(t.TempDir())
+	snapshotID := domain.HashContent([]byte("portable-replay-existing-seed"))
+	memoryHash, err := st.PutMemory(ctx, domain.MemoryDigest{
+		SnapshotID: snapshotID,
+		Summary:    "PORTABLE PROVIDER BASELINE",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	snap := domain.Snapshot{ID: snapshotID, DocHash: snapshotID, MemoryHash: memoryHash}
+	if err := st.PutSnapshot(ctx, snap); err != nil {
+		t.Fatal(err)
+	}
+	oldSeed := seedSummaryPrefix + " 50 events were omitted\n" +
+		"SOLE SURVIVING PROJECT MEMORY\n\n" +
+		"Key facts:\n- Preserve the only prior decision.\n\n" +
+		"Open tasks:\n- Verify replacement without recursion."
+	seed := domain.CIRDocument{Events: []domain.Event{
+		{Kind: domain.EventMessage, Role: "user", CompactSummary: true, Blocks: []domain.ContentBlock{{Type: "text", Text: oldSeed}}},
+		{Kind: domain.EventMessage, Role: "user", Blocks: []domain.ContentBlock{{Type: "text", Text: "CURRENT RAW REQUEST"}}},
+	}}
+	svc := NewLoadSessionService(st, nil, nil, nil, nil, nil)
+
+	event, ok := svc.portableReplaySeed(ctx, seed, snap, domain.ProviderClaude, t.TempDir(), seedDigestBudgetBytes)
+	if !ok || len(event.Blocks) == 0 {
+		t.Fatal("portable replay seed was not produced")
+	}
+	text := event.Blocks[0].Text
+	for _, want := range []string{
+		"PORTABLE PROVIDER BASELINE",
+		"SOLE SURVIVING PROJECT MEMORY",
+		"Preserve the only prior decision.",
+		"Verify replacement without recursion.",
+	} {
+		if got := strings.Count(text, want); got != 1 {
+			t.Fatalf("portable replacement count(%q)=%d, want one:\n%s", want, got, text)
+		}
+	}
+	if got := strings.Count(text, seedSummaryPrefix); got != 1 {
+		t.Fatalf("portable replacement retained %d recursive seed markers, want one:\n%s", got, text)
+	}
+}
+
+func TestPortableReplaySeedOmitsExactlyAttestedWorkingTreeBaseline(t *testing.T) {
+	ctx := context.Background()
+	st := storage.NewFileStore(t.TempDir())
+	snapshotID := domain.HashContent([]byte("portable-replay-attested-baseline"))
+	const baseline = "EXACTLY ATTESTED WORKING TREE BASELINE"
+	memoryHash, err := st.PutMemory(ctx, domain.MemoryDigest{
+		SnapshotID: snapshotID,
+		Summary:    baseline,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	snap := domain.Snapshot{ID: snapshotID, DocHash: snapshotID, MemoryHash: memoryHash}
+	if err := st.PutSnapshot(ctx, snap); err != nil {
+		t.Fatal(err)
+	}
+	svc := NewLoadSessionService(st, nil, nil,
+		map[domain.ProviderKind]outbound.MemorySource{
+			domain.ProviderClaude: stubMemSource{text: baseline, autoLoadedPrefix: baseline},
+		}, nil, nil,
+	)
+
+	if event, ok := svc.portableReplaySeed(
+		ctx, domain.CIRDocument{}, snap, domain.ProviderClaude, t.TempDir(), seedDigestBudgetBytes,
+	); ok {
+		t.Fatalf("exact auto-load attestation produced redundant seed: %+v", event)
+	}
+}
+
+func TestPortableReplaySeedKeepsReplayedAuthoritativeTaskTombstone(t *testing.T) {
+	ctx := context.Background()
+	st := storage.NewFileStore(t.TempDir())
+	snapshotID := domain.HashContent([]byte("portable-replay-task-tombstone"))
+	const compactSummary = "CURRENT PROVIDER SUMMARY WITH AUTHORITATIVE TASKS"
+	digest := domain.MergeDigests(domain.MemoryDigest{}, domain.MemoryDigest{
+		SnapshotID:         snapshotID,
+		Summary:            compactSummary,
+		TasksAuthoritative: true,
+	})
+	memoryHash, err := st.PutMemory(ctx, digest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	snap := domain.Snapshot{ID: snapshotID, DocHash: snapshotID, MemoryHash: memoryHash}
+	if err := st.PutSnapshot(ctx, snap); err != nil {
+		t.Fatal(err)
+	}
+	oldSeed := seedSummaryPrefix + " old generation\n" +
+		"OLDER PROJECT NARRATIVE MUST REMAIN\n\n" +
+		"Open tasks:\n- Superseded task must not revive."
+	seed := domain.CIRDocument{Events: []domain.Event{
+		{Kind: domain.EventMessage, Role: "user", CompactSummary: true, Blocks: []domain.ContentBlock{{Type: "text", Text: compactSummary}}},
+		{Kind: domain.EventMessage, Role: "user", CompactSummary: true, Blocks: []domain.ContentBlock{{Type: "text", Text: oldSeed}}},
+		{Kind: domain.EventMessage, Role: "user", Blocks: []domain.ContentBlock{{Type: "text", Text: "CURRENT RAW REQUEST"}}},
+	}}
+	svc := NewLoadSessionService(st, nil, nil, nil, nil, nil)
+
+	event, ok := svc.portableReplaySeed(ctx, seed, snap, domain.ProviderClaude, t.TempDir(), seedDigestBudgetBytes)
+	if !ok || len(event.Blocks) == 0 {
+		t.Fatal("portable replay seed was not produced")
+	}
+	text := event.Blocks[0].Text
+	if !strings.Contains(text, "OLDER PROJECT NARRATIVE MUST REMAIN") {
+		t.Fatalf("portable replay lost prior narrative:\n%s", text)
+	}
+	if strings.Contains(text, "Superseded task must not revive.") {
+		t.Fatalf("replayed authoritative task tombstone was lost:\n%s", text)
+	}
+	if strings.Contains(text, compactSummary) {
+		t.Fatalf("provider summary already in raw replay was duplicated:\n%s", text)
 	}
 }
 

--- a/cli/internal/domain/entities.go
+++ b/cli/internal/domain/entities.go
@@ -350,6 +350,118 @@ func WithoutConversationDeltaFromSource(d MemoryDigest, source ContentHash) Memo
 	return d
 }
 
+// WithoutExactReplayedConversationItems removes deterministic extractive
+// user/assistant items that are already present verbatim in the materialized
+// replay. Provider/native baselines, structured facts/tasks, and conversation
+// from other lineages that is not in the replay remain portable.
+func WithoutExactReplayedConversationItems(d MemoryDigest, replayedUsers, replayedAssistants []string) MemoryDigest {
+	normalizedSet := func(items []string) map[string]bool {
+		out := make(map[string]bool, len(items))
+		for _, item := range items {
+			if item = NormalizeExtractiveConversationItem(item); item != "" {
+				out[item] = true
+			}
+		}
+		return out
+	}
+	users := normalizedSet(replayedUsers)
+	assistants := normalizedSet(replayedAssistants)
+	filter := func(summary string) string {
+		baseline, fallbackUsers, fallbackAssistants, ok := splitExtractiveFallbackSummary(summary)
+		if !ok {
+			return summary
+		}
+		keptUsers := make([]string, 0, len(fallbackUsers))
+		for _, item := range fallbackUsers {
+			if !users[NormalizeExtractiveConversationItem(item)] {
+				keptUsers = append(keptUsers, item)
+			}
+		}
+		keptAssistants := make([]string, 0, len(fallbackAssistants))
+		for _, item := range fallbackAssistants {
+			if !assistants[NormalizeExtractiveConversationItem(item)] {
+				keptAssistants = append(keptAssistants, item)
+			}
+		}
+		delta := ""
+		if len(keptUsers) > 0 || len(keptAssistants) > 0 {
+			delta = RenderExtractiveFallbackSummary(keptUsers, keptAssistants)
+		}
+		return AppendExtractiveConversationDelta(baseline, delta)
+	}
+	if len(d.Fragments) == 0 {
+		d.Summary = filter(d.Summary)
+		return d
+	}
+	fragments := append([]MemoryFragment(nil), d.Fragments...)
+	for i := range fragments {
+		fragments[i].Summary = filter(fragments[i].Summary)
+	}
+	d.Fragments = fragments
+	renderMemoryFragments(&d)
+	return d
+}
+
+// WithoutExactReplayedSummary removes an exact baseline and its derived
+// facts/tasks from every provenance fragment when the provider summary is
+// already present verbatim in the replay. Canonical conversation deltas stay
+// attached until exact raw-message projection removes only those that are also
+// replayed. Task authority tombstones remain so superseded work cannot revive.
+func WithoutExactReplayedSummary(d MemoryDigest, exact string) MemoryDigest {
+	exact = strings.TrimSpace(exact)
+	if exact == "" {
+		return d
+	}
+	strip := func(summary string) (string, bool) {
+		baseline, _, _, ok := splitExtractiveFallbackSummary(summary)
+		if ok {
+			if strings.TrimSpace(baseline) != exact {
+				return summary, false
+			}
+			_, users, assistants, _ := splitExtractiveFallbackSummary(summary)
+			delta := ""
+			if len(users) > 0 || len(assistants) > 0 {
+				delta = RenderExtractiveFallbackSummary(users, assistants)
+			}
+			return delta, true
+		}
+		if strings.TrimSpace(summary) == exact {
+			return "", true
+		}
+		return summary, false
+	}
+	if len(d.Fragments) == 0 {
+		if summary, matched := strip(d.Summary); matched {
+			authoritative := d.TasksAuthoritative
+			d.Summary = summary
+			d.KeyFacts = nil
+			d.OpenTasks = nil
+			if authoritative && summary == "" && d.SnapshotID != "" {
+				d.Fragments = []MemoryFragment{{
+					SourceSnapshot: d.SnapshotID, TasksAuthoritative: true,
+				}}
+			}
+		}
+		return d
+	}
+
+	fragments := append([]MemoryFragment(nil), d.Fragments...)
+	changed := false
+	for i := range fragments {
+		if summary, matched := strip(fragments[i].Summary); matched {
+			changed = true
+			fragments[i].Summary = summary
+			fragments[i].KeyFacts = nil
+			fragments[i].OpenTasks = nil
+		}
+	}
+	if changed {
+		d.Fragments = fragments
+		renderMemoryFragments(&d)
+	}
+	return d
+}
+
 // WithoutExactSummaryBaseline returns a provider-visible copy with one exact
 // baseline removed from every provenance fragment. Canonical conversation
 // deltas attached to that baseline remain, as do unrelated provider text,
@@ -429,6 +541,20 @@ func AppendExtractiveConversationDelta(baseline, delta string) string {
 		return delta
 	}
 	return baseline + "\n\n" + extractiveFallbackDeltaMarker + "\n" + delta
+}
+
+const extractiveConversationItemMaxRunes = 2000
+
+// NormalizeExtractiveConversationItem is the canonical representation stored
+// in deterministic fallback digests. Replay projection uses the same function
+// so even long raw messages can be removed by exact, not fuzzy, comparison.
+func NormalizeExtractiveConversationItem(text string) string {
+	text = strings.Join(strings.Fields(text), " ")
+	runes := []rune(text)
+	if len(runes) <= extractiveConversationItemMaxRunes {
+		return text
+	}
+	return string(runes[:extractiveConversationItemMaxRunes]) + "…"
 }
 
 // RenderExtractiveFallbackSummary is the canonical text representation of the

--- a/cli/internal/domain/merge_digests_test.go
+++ b/cli/internal/domain/merge_digests_test.go
@@ -224,6 +224,97 @@ func TestWithoutAutoLoadedSummaryPrefixKeepsNativeTail(t *testing.T) {
 	}
 }
 
+func TestWithoutExactReplayedSummaryDropsMatchingBaselinesAndKeepsOtherLineages(t *testing.T) {
+	currentID := ContentHash("sha256:" + strings.Repeat("a", 64))
+	ancestorID := ContentHash("sha256:" + strings.Repeat("b", 64))
+	matchingAncestorID := ContentHash("sha256:" + strings.Repeat("e", 64))
+	const replayed = "PROVIDER COMPACTION ALREADY REPLAYED"
+	digest := MergeDigests(
+		MergeDigests(
+			MemoryDigest{
+				SnapshotID: ancestorID,
+				Summary:    "ANCESTOR MEMORY MUST REMAIN",
+				KeyFacts:   []string{"Ancestor fact remains."},
+				OpenTasks:  []string{"Superseded ancestor task must not revive."},
+			},
+			MemoryDigest{
+				SnapshotID: matchingAncestorID,
+				Summary: AppendExtractiveConversationDelta(replayed,
+					RenderExtractiveFallbackSummary([]string{"teammate request remains"}, []string{"teammate result remains"})),
+			},
+		),
+		MemoryDigest{
+			SnapshotID: currentID,
+			Summary: AppendExtractiveConversationDelta(replayed,
+				RenderExtractiveFallbackSummary([]string{"current request"}, []string{"current result"})),
+			KeyFacts:           []string{"Fact already inside replayed summary."},
+			OpenTasks:          []string{"Task already inside replayed summary."},
+			TasksAuthoritative: true,
+		},
+	)
+
+	got := WithoutExactReplayedSummary(digest, replayed)
+	got = WithoutExactReplayedConversationItems(got, []string{"current request"}, []string{"current result"})
+	for _, removed := range []string{
+		replayed, "current request", "current result",
+		"Fact already inside replayed summary.", "Task already inside replayed summary.",
+	} {
+		if strings.Contains(got.Summary, removed) || containsString(got.KeyFacts, removed) || containsString(got.OpenTasks, removed) {
+			t.Fatalf("replayed current contribution retained %q: %+v", removed, got)
+		}
+	}
+	for _, kept := range []string{
+		"ANCESTOR MEMORY MUST REMAIN", "Ancestor fact remains.",
+		"teammate request remains", "teammate result remains",
+	} {
+		if !strings.Contains(got.Summary, kept) && !containsString(got.KeyFacts, kept) {
+			t.Fatalf("replayed projection lost %q: %+v", kept, got)
+		}
+	}
+	if !strings.Contains(digest.Summary, replayed) || !containsString(digest.KeyFacts, "Fact already inside replayed summary.") {
+		t.Fatalf("projection mutated immutable input: %+v", digest)
+	}
+	if len(got.OpenTasks) != 0 || !got.TasksAuthoritative {
+		t.Fatalf("replayed authoritative task tombstone was lost: %+v", got)
+	}
+}
+
+func TestWithoutExactReplayedConversationItemsKeepsOnlyNonReplayLineageDelta(t *testing.T) {
+	ancestorID := ContentHash("sha256:" + strings.Repeat("c", 64))
+	siblingID := ContentHash("sha256:" + strings.Repeat("d", 64))
+	longRaw := strings.Repeat("L", extractiveConversationItemMaxRunes+100)
+	digest := MergeDigests(
+		MemoryDigest{
+			SnapshotID: ancestorID,
+			Summary: AppendExtractiveConversationDelta("PORTABLE BASELINE",
+				RenderExtractiveFallbackSummary(
+					[]string{"raw request", NormalizeExtractiveConversationItem(longRaw)},
+					[]string{"raw result"},
+				)),
+		},
+		MemoryDigest{
+			SnapshotID: siblingID,
+			Summary: AppendExtractiveConversationDelta("PORTABLE BASELINE",
+				RenderExtractiveFallbackSummary([]string{"teammate request"}, []string{"teammate result"})),
+		},
+	)
+
+	got := WithoutExactReplayedConversationItems(digest, []string{" raw   request ", longRaw}, []string{"raw result"})
+	for _, removed := range []string{"raw request", "raw result", strings.Repeat("L", 64)} {
+		if strings.Contains(got.Summary, removed) {
+			t.Fatalf("replayed conversation item retained %q:\n%s", removed, got.Summary)
+		}
+	}
+	for _, kept := range []string{"PORTABLE BASELINE", "teammate request", "teammate result"} {
+		if !strings.Contains(got.Summary, kept) {
+			t.Fatalf("portable projection lost %q:\n%s", kept, got.Summary)
+		}
+	}
+	if !strings.Contains(digest.Summary, "raw request") {
+		t.Fatalf("projection mutated immutable input: %+v", digest)
+	}
+}
+
 func TestMergeDigestsPreservesUniqueSiblingFallbackItems(t *testing.T) {
 	left := MemoryDigest{
 		SnapshotID: ContentHash("sha256:" + strings.Repeat("c", 64)),

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -306,7 +306,15 @@ current context head. `--provider` enables supported cross-provider
 materialization. If an oversized conversation must be trimmed, cxt first
 distills the exact omitted span and fails without creating a provider session
 file if that projection is unavailable; it never resumes from an unexplained
-recent tail.
+recent tail. A new full or reconstructed provider session also receives the
+bounded portable-memory projection when the conversation itself fits. The
+current snapshot's conversation delta and exact ancestor user/assistant items
+already present in the replay are excluded because those turns follow
+verbatim; conversation from sibling/team lineages that is absent from the raw
+replay remains portable. An exact provider compaction summary already present
+in the replay is not repeated. cxt trims at a user-turn boundary only when the
+combined verbatim conversation and portable projection exceed the provider's
+seed budget.
 
 The mode priority is:
 


### PR DESCRIPTION
Closes #98.

## Root cause

LoadSessionService projected stored memory only when conversation events were trimmed. Small full-fidelity and reconstructed replays encoded EffectiveContext directly, so a new provider session could receive the raw conversation but lose provider-native memory and inherited lineage decisions. A naive prepend would also duplicate current and ancestor conversation, recursively retain old cxt seed sections, violate Codex replacement order, and trigger avoidable trimming.

## Fix

- Build a bounded portable-memory seed for untrimmed full and reconstructed loads.
- Remove exact raw-replayed current and ancestor conversation items while retaining sibling/team lineage deltas absent from the replay.
- Remove exact provider compaction baselines already present in raw context, preserving task-authority tombstones.
- Normalize old cxt seed facts/tasks into structured fields before replacement, preventing recursive and narrative duplication.
- Keep Codex authoritative replacement state before the portable seed.
- Trim only when raw conversation plus the actual portable projection exceeds the provider seed budget.
- Share canonical long-message normalization between distillation and replay projection.

## Verification

- CLI unit, vet, full race, and focused tests repeated 20 times
- backend build, postgres-tag build, vet, and tests
- web install, audit, i18n, Vercel check, typecheck, and production build
- public tree and full-history secret scans
- basic E2E and sync E2E
- govulncheck for CLI and backend: no vulnerabilities

Installed-binary dogfood will be repeated after merge against the original #98 fixture.