### PR TITLE
Fix manual capture provider and session ownership

### DIFF
--- a/cli/internal/adapters/capture/capture_test.go
+++ b/cli/internal/adapters/capture/capture_test.go
@@ -66,6 +66,35 @@ func TestClaudeLocateNoSession(t *testing.T) {
 	}
 }
 
+func TestClaudeLocateSessionUsesExactIDInsteadOfNewerSibling(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	cwd := "/Users/work/proj"
+	dir := filepath.Join(home, ".claude", "projects", encodeCwd(cwd))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	wantedID := "11111111-1111-4111-8111-111111111111"
+	wanted := filepath.Join(dir, wantedID+".jsonl")
+	newer := filepath.Join(dir, "22222222-2222-4222-8222-222222222222.jsonl")
+	if err := os.WriteFile(wanted, []byte(`{"type":"user"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(newer, []byte(`{"type":"user"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_ = os.Chtimes(wanted, time.Unix(1000, 0), time.Unix(1000, 0))
+	_ = os.Chtimes(newer, time.Unix(2000, 0), time.Unix(2000, 0))
+
+	got, err := NewClaudeCapture().LocateSession(context.Background(), cwd, wantedID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != wanted {
+		t.Fatalf("exact session = %q, want %q", got, wanted)
+	}
+}
+
 func TestCodexLocateActiveSession(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
@@ -89,5 +118,36 @@ func TestCodexLocateActiveSession(t *testing.T) {
 	}
 	if filepath.Base(got) != filepath.Base(match) {
 		t.Fatalf("expected cwd-matching rollout, got %s", got)
+	}
+}
+
+func TestCodexLocateSessionUsesExactIDAndCwd(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	cwd := "/Users/work/myrepo"
+	day := filepath.Join(home, ".codex", "sessions", "2026", "06", "30")
+	if err := os.MkdirAll(day, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	wantedID := "33333333-3333-4333-8333-333333333333"
+	wanted := filepath.Join(day, "rollout-old-"+wantedID+".jsonl")
+	newer := filepath.Join(day, "rollout-new-44444444-4444-4444-8444-444444444444.jsonl")
+	wrongCwd := filepath.Join(day, "rollout-wrong-"+wantedID+".jsonl")
+	for path, sessionCwd := range map[string]string{wanted: cwd, newer: cwd, wrongCwd: "/other"} {
+		line := `{"type":"session_meta","payload":{"cwd":"` + sessionCwd + `"}}` + "\n"
+		if err := os.WriteFile(path, []byte(line), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	_ = os.Chtimes(wanted, time.Unix(1000, 0), time.Unix(1000, 0))
+	_ = os.Chtimes(newer, time.Unix(3000, 0), time.Unix(3000, 0))
+	_ = os.Chtimes(wrongCwd, time.Unix(4000, 0), time.Unix(4000, 0))
+
+	got, err := NewCodexCapture().LocateSession(context.Background(), cwd, wantedID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != wanted {
+		t.Fatalf("exact session = %q, want %q", got, wanted)
 	}
 }

--- a/cli/internal/adapters/capture/claude_capture.go
+++ b/cli/internal/adapters/capture/claude_capture.go
@@ -77,6 +77,29 @@ func (c *ClaudeCaptureSource) LocateActiveSession(_ context.Context, cwd string)
 	return best, nil
 }
 
+// LocateSession returns the capture-eligible session with the exact native ID
+// in cwd. It is used by a live wrapper to avoid selecting a newer sibling
+// terminal merely because both provider files share the same worktree.
+func (c *ClaudeCaptureSource) LocateSession(_ context.Context, cwd, sessionID string) (string, error) {
+	if !providerfs.ValidSessionID(sessionID) {
+		return "", domain.ErrNoActiveSession
+	}
+	abs, err := filepath.Abs(cwd)
+	if err != nil {
+		abs = cwd
+	}
+	root, err := claudeProjectsDir()
+	if err != nil {
+		return "", err
+	}
+	path := filepath.Join(root, encodeCwd(abs), sessionID+".jsonl")
+	info, err := os.Lstat(path)
+	if err != nil || !info.Mode().IsRegular() || !providerfs.IsProviderSessionPath(path) || providerfs.CaptureExcluded(cwd, path, info.Size()) {
+		return "", domain.ErrNoActiveSession
+	}
+	return path, nil
+}
+
 // ReadSession reads the JSONL bytes from the given session file path.
 func (c *ClaudeCaptureSource) ReadSession(_ context.Context, path string) ([]byte, error) {
 	return providerfs.ReadRegularFile(path)

--- a/cli/internal/adapters/capture/codex_capture.go
+++ b/cli/internal/adapters/capture/codex_capture.go
@@ -102,6 +102,43 @@ func (c *CodexCaptureSource) LocateActiveSession(_ context.Context, cwd string) 
 	return best, nil
 }
 
+// LocateSession returns the capture-eligible rollout with the exact native ID
+// and cwd. The ID is validated before entering a glob so it cannot alter the
+// search pattern.
+func (c *CodexCaptureSource) LocateSession(_ context.Context, cwd, sessionID string) (string, error) {
+	if !providerfs.ValidSessionID(sessionID) {
+		return "", domain.ErrNoActiveSession
+	}
+	abs, err := filepath.Abs(cwd)
+	if err != nil {
+		abs = cwd
+	}
+	root, err := codexSessionsDir()
+	if err != nil {
+		return "", err
+	}
+	matches, err := filepath.Glob(filepath.Join(root, "*", "*", "*", "rollout-*-"+sessionID+".jsonl"))
+	if err != nil {
+		return "", err
+	}
+	candidates := map[string]int64{}
+	for _, path := range matches {
+		info, statErr := os.Lstat(path)
+		if statErr != nil || !info.Mode().IsRegular() || !providerfs.IsProviderSessionPath(path) {
+			continue
+		}
+		if sessionCwd, ok := rolloutCwd(path); !ok || sessionCwd != abs || providerfs.CaptureExcluded(cwd, path, info.Size()) {
+			continue
+		}
+		candidates[path] = info.ModTime().UnixNano()
+	}
+	best := pickLatest(candidates)
+	if best == "" {
+		return "", domain.ErrNoActiveSession
+	}
+	return best, nil
+}
+
 // SessionFilesForCwd returns all rollout session files in this cwd (for branch switch isolation). Unlike LocateActiveSession, it does not apply CaptureExcluded — isolation is unrelated to activity. Files already isolated are renamed with .jsonl.superseded and thus excluded.
 func (c *CodexCaptureSource) SessionFilesForCwd(_ context.Context, cwd string) []string {
 	abs, err := filepath.Abs(cwd)

--- a/cli/internal/adapters/delivery/cli/agent_wrapper.go
+++ b/cli/internal/adapters/delivery/cli/agent_wrapper.go
@@ -58,10 +58,12 @@ func runAgentWrapper(ctx context.Context, c *Container, cwd, agent string, args 
 		start := time.Now()
 		child := exec.Command(bin, args...)
 		child.Stdin, child.Stdout, child.Stderr = os.Stdin, os.Stdout, os.Stderr
+		ownedSessionID := sessionIDFromAgentArgs(agent, args)
 		child.Env = append(os.Environ(),
 			"CXT_WRAPPED=1",
 			fmt.Sprintf("CXT_WRAPPER_PID=%d", os.Getpid()),
 			"CXT_WRAPPED_AGENT="+agent,
+			"CXT_WRAPPED_SESSION_ID="+ownedSessionID,
 		)
 		var childMemoryEnv []string
 		if agent == "claude" {
@@ -147,6 +149,41 @@ func resumeArgs(agent, seedID string) []string {
 		return []string{"resume", seedID} // May not be supported in all versions — falls back to new session on failure
 	}
 	return []string{"--resume", seedID}
+}
+
+// sessionIDFromAgentArgs projects only an explicit native resume target into
+// the child environment. Descendant cxt commands can then bind capture to this
+// wrapper's exact session instead of the newest sibling terminal. Empty is
+// intentional for a provider-created fresh session; its first lifecycle hook
+// records terminal affinity.
+func sessionIDFromAgentArgs(agent string, args []string) string {
+	if agent == string(domain.ProviderCodex) {
+		if len(args) >= 2 && args[0] == "resume" && providerfs.ValidSessionID(args[1]) {
+			return args[1]
+		}
+		return ""
+	}
+	if agent != string(domain.ProviderClaude) {
+		return ""
+	}
+	for i, arg := range args {
+		if arg == "--resume" || arg == "-r" {
+			if i+1 < len(args) && providerfs.ValidSessionID(args[i+1]) {
+				return args[i+1]
+			}
+			return ""
+		}
+		for _, prefix := range []string{"--resume=", "-r="} {
+			if strings.HasPrefix(arg, prefix) {
+				id := strings.TrimPrefix(arg, prefix)
+				if providerfs.ValidSessionID(id) {
+					return id
+				}
+				return ""
+			}
+		}
+	}
+	return ""
 }
 
 // Registers the recently materialized session in the agent's session index.

--- a/cli/internal/adapters/delivery/cli/agent_wrapper_ancestry_test.go
+++ b/cli/internal/adapters/delivery/cli/agent_wrapper_ancestry_test.go
@@ -76,6 +76,27 @@ func TestProviderByRecency(t *testing.T) {
 	}
 }
 
+func TestSessionIDFromAgentArgs(t *testing.T) {
+	id := "11111111-1111-4111-8111-111111111111"
+	for name, tt := range map[string]struct {
+		agent string
+		args  []string
+		want  string
+	}{
+		"codex resume":          {agent: "codex", args: []string{"resume", id, "--yolo"}, want: id},
+		"claude resume":         {agent: "claude", args: []string{"--resume", id}, want: id},
+		"claude inline resume":  {agent: "claude", args: []string{"--resume=" + id}, want: id},
+		"fresh session unknown": {agent: "codex", args: []string{"--yolo"}},
+		"invalid id rejected":   {agent: "codex", args: []string{"resume", "../../other"}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := sessionIDFromAgentArgs(tt.agent, tt.args); got != tt.want {
+				t.Fatalf("session id = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestParsePIDTable(t *testing.T) {
 	table := parsePIDTable([]byte("  50   40\n40 30\ngarbage line here\n 30    1\n\n"))
 	if len(table) != 3 || table[50] != 40 || table[40] != 30 || table[30] != 1 {

--- a/cli/internal/adapters/delivery/cli/args.go
+++ b/cli/internal/adapters/delivery/cli/args.go
@@ -56,7 +56,7 @@ var commandArgSpecs = map[string]commandArgSpec{
 	"load":      {usage: "cxt load [<ref>] [--provider claude|codex] [--mode full|reconstructed|memory]", flags: commandFlags([]string{"--provider", "--mode"}, nil)},
 	"push":      {usage: "cxt push [--force|-f|--append]", flags: commandFlags(nil, []string{"--force", "-f", "--append"})},
 	"pull":      {usage: "cxt pull [--force|-f]", flags: commandFlags(nil, []string{"--force", "-f"})},
-	"stash":     {usage: "cxt stash [push [-m <message>]|pop|list]", flags: commandFlags([]string{"-m"}, nil)},
+	"stash":     {usage: "cxt stash [push [-m <message>] [--provider claude|codex]|pop|list]", flags: commandFlags([]string{"-m", "--provider"}, nil)},
 	"memorize":  {usage: "cxt memorize [<ref>] [--provider claude|codex]", flags: commandFlags([]string{"--provider"}, nil)},
 	"memory":    {usage: "cxt memory [<ref>] [--provider claude|codex]", flags: commandFlags([]string{"--provider"}, nil)},
 	"tag":       {usage: "cxt tag [<name> [ref]]"},
@@ -179,6 +179,9 @@ func validateCommandFlags(cmd string, args []string, spec commandArgSpec) error 
 	case "stash":
 		if flagVal(args, "-m") != "" && len(pos) > 0 && pos[0] != "push" {
 			return fmt.Errorf("stash: flag %q is only valid with push\nusage: %s", "-m", spec.usage)
+		}
+		if flagVal(args, "--provider") != "" && len(pos) > 0 && pos[0] != "push" {
+			return fmt.Errorf("stash: flag %q is only valid with push\nusage: %s", "--provider", spec.usage)
 		}
 	}
 	return nil

--- a/cli/internal/adapters/delivery/cli/githook.go
+++ b/cli/internal/adapters/delivery/cli/githook.go
@@ -385,6 +385,55 @@ func activeProviderForCwd(ctx context.Context, cwd string) domain.ProviderKind {
 	return providerByRecency(mtime(claudePath, claudeErr), mtime(codexPath, codexErr))
 }
 
+type commandCaptureTarget struct {
+	Provider    domain.ProviderKind
+	SessionPath string
+}
+
+// commandCapture resolves both provider and, when an owning wrapper exists,
+// its exact native session. Provider-only selection is insufficient because
+// two terminals can run the same provider in one worktree. Explicit choice of
+// another provider intentionally uses that provider's latest eligible file.
+func commandCapture(ctx context.Context, cwd, explicit string) (commandCaptureTarget, error) {
+	wrappedProvider, managed := supervisedProvider(ctx, cwd)
+	provider := domain.ProviderKind(explicit)
+	if provider == "" {
+		if managed {
+			provider = wrappedProvider
+		} else {
+			provider = activeProviderForCwd(ctx, cwd)
+		}
+	}
+	target := commandCaptureTarget{Provider: provider}
+	if !managed || provider != wrappedProvider {
+		return target, nil
+	}
+
+	sessionID := strings.TrimSpace(os.Getenv("CXT_WRAPPED_SESSION_ID"))
+	if !providerfs.ValidSessionID(sessionID) {
+		sessionID = capture.SessionAffinity(cwd, provider)
+	}
+	if !providerfs.ValidSessionID(sessionID) {
+		return commandCaptureTarget{}, fmt.Errorf("cannot identify the %s session owned by this cxt wrapper yet", provider)
+	}
+
+	var path string
+	var err error
+	switch provider {
+	case domain.ProviderClaude:
+		path, err = capture.NewClaudeCapture().LocateSession(ctx, cwd, sessionID)
+	case domain.ProviderCodex:
+		path, err = capture.NewCodexCapture().LocateSession(ctx, cwd, sessionID)
+	default:
+		return target, nil // the use case reports an explicit unsupported provider
+	}
+	if err != nil {
+		return commandCaptureTarget{}, fmt.Errorf("cannot locate the %s session %s owned by this cxt wrapper: %w", provider, sessionID, err)
+	}
+	target.SessionPath = path
+	return target, nil
+}
+
 func providerByRecency(claudeNewest, codexNewest int64) domain.ProviderKind {
 	if codexNewest > claudeNewest {
 		return domain.ProviderCodex

--- a/cli/internal/adapters/delivery/cli/root.go
+++ b/cli/internal/adapters/delivery/cli/root.go
@@ -580,17 +580,17 @@ func Run(c *Container, args []string) error {
 		return runGitHook(ctx, c, cwd, rest)
 
 	case "save":
-		provider := flagVal(rest, "--provider")
-		if provider == "" {
-			provider = domain.ProviderClaude
+		target, err := commandCapture(ctx, cwd, flagVal(rest, "--provider"))
+		if err != nil {
+			return err
 		}
-		out, err := c.Save.Save(ctx, inbound.SaveInput{Cwd: cwd, Provider: provider, Message: flagVal(rest, "-m"), Author: c.Identity})
+		out, err := c.Save.Save(ctx, inbound.SaveInput{Cwd: cwd, Provider: target.Provider, SessionPath: target.SessionPath, Message: flagVal(rest, "-m"), Author: c.Identity})
 		if err != nil {
 			return err
 		}
 		fmt.Printf("saved snapshot %s on branch %q\n", shortHash(out.SnapshotID), out.Branch)
 		// Automatically memorize the commit path (audit finding #5: consistency across storage paths). Best-effort.
-		if mout, merr := c.Memorize.Memorize(ctx, inbound.MemorizeInput{Cwd: cwd, Provider: provider, Ref: string(out.SnapshotID)}); merr == nil {
+		if mout, merr := c.Memorize.Memorize(ctx, inbound.MemorizeInput{Cwd: cwd, Provider: target.Provider, Ref: string(out.SnapshotID)}); merr == nil {
 			fmt.Printf("memorized → %s (included in next push)\n", shortHash(mout.MemoryHash))
 		}
 		return nil
@@ -697,7 +697,11 @@ func Run(c *Container, args []string) error {
 		// git stash equivalent: save active session and return to branch head (commit chain) context.
 		switch firstPositional(rest) {
 		case "", "push":
-			out, err := c.Stash.Stash(ctx, inbound.StashInput{Cwd: cwd, Message: flagVal(rest, "-m"), Author: c.Identity})
+			target, err := commandCapture(ctx, cwd, flagVal(rest, "--provider"))
+			if err != nil {
+				return err
+			}
+			out, err := c.Stash.Stash(ctx, inbound.StashInput{Cwd: cwd, Provider: target.Provider, SessionPath: target.SessionPath, Message: flagVal(rest, "-m"), Author: c.Identity})
 			if err != nil {
 				if err == domain.ErrNoActiveSession {
 					return fmt.Errorf("no active session to stash (Git equivalent: \"No local changes to save\")")
@@ -739,7 +743,7 @@ func Run(c *Container, args []string) error {
 			}
 			return nil
 		default:
-			return fmt.Errorf("usage: cxt stash [push [-m msg]|pop|list]")
+			return fmt.Errorf("usage: cxt stash [push [-m msg] [--provider claude|codex]|pop|list]")
 		}
 
 	case "memorize", "memory":
@@ -994,7 +998,7 @@ usage: cxt <command> [flags]
   push [--force|--append]   synchronize local context to origin
   pull [--force]            synchronize origin context locally
   tag [<name> [ref]]        list or create immutable tags (equivalent to Git tags)
-  stash [push|pop|list]     save or restore a session (equivalent to Git stash)
+  stash [push|pop|list]     save or restore a session (push accepts --provider)
 
   Context commands:
   save [-m msg] [--provider claude|codex]

--- a/cli/internal/adapters/delivery/cli/root_help_test.go
+++ b/cli/internal/adapters/delivery/cli/root_help_test.go
@@ -161,6 +161,7 @@ func TestSubcommandSpecificFlagRestrictions(t *testing.T) {
 		{"cxt", "remote", "add", "origin", "https://example.test/a/b", "-v"},
 		{"cxt", "secrets", "pull", "--rotate"},
 		{"cxt", "stash", "pop", "-m", "message"},
+		{"cxt", "stash", "list", "--provider", "codex"},
 	}
 	for _, args := range tests {
 		t.Run(strings.Join(args[1:], "/"), func(t *testing.T) {

--- a/cli/internal/adapters/delivery/cli/root_provider_test.go
+++ b/cli/internal/adapters/delivery/cli/root_provider_test.go
@@ -1,0 +1,239 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/wnsdy95/cxthub/cli/internal/adapters/capture"
+	"github.com/wnsdy95/cxthub/cli/internal/domain"
+	"github.com/wnsdy95/cxthub/cli/internal/ports/inbound"
+)
+
+type recordingSave struct {
+	in inbound.SaveInput
+}
+
+func (r *recordingSave) Save(_ context.Context, in inbound.SaveInput) (inbound.SaveOutput, error) {
+	r.in = in
+	return inbound.SaveOutput{
+		SnapshotID: domain.HashContent([]byte("saved")),
+		Branch:     "main",
+		SessionID:  "11111111-1111-4111-8111-111111111111",
+	}, nil
+}
+
+type recordingStash struct {
+	in inbound.StashInput
+}
+
+func (r *recordingStash) Stash(_ context.Context, in inbound.StashInput) (inbound.StashOutput, error) {
+	r.in = in
+	return inbound.StashOutput{
+		StashID: domain.HashContent([]byte("stash")),
+		Branch:  "main",
+	}, nil
+}
+
+func (*recordingStash) StashPop(context.Context, string) (inbound.StashPopOutput, error) {
+	return inbound.StashPopOutput{}, nil
+}
+
+func (*recordingStash) StashList(context.Context, string) ([]domain.StashEntry, error) {
+	return nil, nil
+}
+
+type noOpMemorize struct{}
+
+func (noOpMemorize) Memorize(_ context.Context, in inbound.MemorizeInput) (inbound.MemorizeOutput, error) {
+	return inbound.MemorizeOutput{
+		SnapshotID: domain.ContentHash(in.Ref),
+		MemoryHash: domain.HashContent([]byte("memory")),
+	}, nil
+}
+
+func TestSaveAndStashImplicitProviderFollowOwningWrapper(t *testing.T) {
+	cwd := t.TempDir()
+	t.Chdir(cwd)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("CXT_WRAPPED", "1")
+	t.Setenv("CXT_WRAPPED_AGENT", string(domain.ProviderCodex))
+	t.Setenv("CXT_WRAPPER_PID", strconv.Itoa(os.Getppid()))
+	sessionID := "11111111-1111-4111-8111-111111111111"
+	t.Setenv("CXT_WRAPPED_SESSION_ID", sessionID)
+	owned := writeCodexRollout(t, home, cwd, sessionID, time.Now())
+
+	save := &recordingSave{}
+	if err := Run(&Container{Save: save, Memorize: noOpMemorize{}}, []string{"cxt", "save"}); err != nil {
+		t.Fatal(err)
+	}
+	if save.in.Provider != domain.ProviderCodex {
+		t.Fatalf("save provider = %q, want codex", save.in.Provider)
+	}
+	if save.in.SessionPath != owned {
+		t.Fatalf("save session path = %q, want %q", save.in.SessionPath, owned)
+	}
+
+	stash := &recordingStash{}
+	if err := Run(&Container{Stash: stash}, []string{"cxt", "stash", "push"}); err != nil {
+		t.Fatal(err)
+	}
+	if stash.in.Provider != domain.ProviderCodex {
+		t.Fatalf("stash provider = %q, want codex", stash.in.Provider)
+	}
+	if stash.in.SessionPath != owned {
+		t.Fatalf("stash session path = %q, want %q", stash.in.SessionPath, owned)
+	}
+}
+
+func TestSaveExplicitProviderOverridesOwningWrapper(t *testing.T) {
+	t.Chdir(t.TempDir())
+	t.Setenv("CXT_WRAPPED", "1")
+	t.Setenv("CXT_WRAPPED_AGENT", string(domain.ProviderCodex))
+	t.Setenv("CXT_WRAPPER_PID", strconv.Itoa(os.Getppid()))
+
+	save := &recordingSave{}
+	if err := Run(&Container{Save: save, Memorize: noOpMemorize{}}, []string{"cxt", "save", "--provider", "claude"}); err != nil {
+		t.Fatal(err)
+	}
+	if save.in.Provider != domain.ProviderClaude {
+		t.Fatalf("save provider = %q, want explicit claude", save.in.Provider)
+	}
+}
+
+func TestStashExplicitProviderOverridesOwningWrapper(t *testing.T) {
+	t.Chdir(t.TempDir())
+	t.Setenv("CXT_WRAPPED", "1")
+	t.Setenv("CXT_WRAPPED_AGENT", string(domain.ProviderCodex))
+	t.Setenv("CXT_WRAPPER_PID", strconv.Itoa(os.Getppid()))
+
+	stash := &recordingStash{}
+	if err := Run(&Container{Stash: stash}, []string{"cxt", "stash", "push", "--provider", "claude"}); err != nil {
+		t.Fatal(err)
+	}
+	if stash.in.Provider != domain.ProviderClaude {
+		t.Fatalf("stash provider = %q, want explicit claude", stash.in.Provider)
+	}
+}
+
+func TestSaveStaleWrapperFallsBackToNewestCaptureEligibleProvider(t *testing.T) {
+	cwd := t.TempDir()
+	t.Chdir(cwd)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("CXT_WRAPPED", "1")
+	t.Setenv("CXT_WRAPPED_AGENT", string(domain.ProviderClaude))
+	t.Setenv("CXT_WRAPPER_PID", "99999999")
+
+	rollout := filepath.Join(home, ".codex", "sessions", "2026", "08", "28", "rollout-test.jsonl")
+	if err := os.MkdirAll(filepath.Dir(rollout), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	line := fmt.Sprintf("{\"type\":\"session_meta\",\"payload\":{\"cwd\":%q}}\n", cwd)
+	if err := os.WriteFile(rollout, []byte(line), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	save := &recordingSave{}
+	if err := Run(&Container{Save: save, Memorize: noOpMemorize{}}, []string{"cxt", "save"}); err != nil {
+		t.Fatal(err)
+	}
+	if save.in.Provider != domain.ProviderCodex {
+		t.Fatalf("save provider = %q, want newest capture-eligible codex", save.in.Provider)
+	}
+}
+
+func TestSaveOwningWrapperUsesItsExactSessionInsteadOfNewerSibling(t *testing.T) {
+	cwd := t.TempDir()
+	t.Chdir(cwd)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("CXT_WRAPPED", "1")
+	t.Setenv("CXT_WRAPPED_AGENT", string(domain.ProviderCodex))
+	t.Setenv("CXT_WRAPPER_PID", strconv.Itoa(os.Getppid()))
+	ownedID := "11111111-1111-4111-8111-111111111111"
+	t.Setenv("CXT_WRAPPED_SESSION_ID", ownedID)
+
+	owned := writeCodexRollout(t, home, cwd, ownedID, time.Now().Add(-time.Hour))
+	writeCodexRollout(t, home, cwd, "22222222-2222-4222-8222-222222222222", time.Now())
+
+	save := &recordingSave{}
+	if err := Run(&Container{Save: save, Memorize: noOpMemorize{}}, []string{"cxt", "save"}); err != nil {
+		t.Fatal(err)
+	}
+	if save.in.SessionPath != owned {
+		t.Fatalf("save session path = %q, want owning wrapper session %q", save.in.SessionPath, owned)
+	}
+}
+
+func TestSaveOwningWrapperUsesTerminalAffinityForPreUpgradeWrapper(t *testing.T) {
+	cwd := t.TempDir()
+	t.Chdir(cwd)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("TERM_SESSION_ID", "provider-affinity-test-terminal")
+	t.Setenv("CXT_WRAPPED", "1")
+	t.Setenv("CXT_WRAPPED_AGENT", string(domain.ProviderCodex))
+	t.Setenv("CXT_WRAPPER_PID", strconv.Itoa(os.Getppid()))
+	t.Setenv("CXT_WRAPPED_SESSION_ID", "")
+	ownedID := "33333333-3333-4333-8333-333333333333"
+
+	owned := writeCodexRollout(t, home, cwd, ownedID, time.Now().Add(-time.Hour))
+	writeCodexRollout(t, home, cwd, "44444444-4444-4444-8444-444444444444", time.Now())
+	if err := os.MkdirAll(filepath.Join(cwd, ".cxt"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	capture.RecordSessionAffinity(cwd, domain.ProviderCodex, ownedID)
+
+	save := &recordingSave{}
+	if err := Run(&Container{Save: save, Memorize: noOpMemorize{}}, []string{"cxt", "save"}); err != nil {
+		t.Fatal(err)
+	}
+	if save.in.SessionPath != owned {
+		t.Fatalf("save session path = %q, want terminal-affine session %q", save.in.SessionPath, owned)
+	}
+}
+
+func TestSaveOwningWrapperFailsClosedWithoutExactSessionIdentity(t *testing.T) {
+	cwd := t.TempDir()
+	t.Chdir(cwd)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("TERM_SESSION_ID", "unknown-wrapper-session-terminal")
+	t.Setenv("CXT_WRAPPED", "1")
+	t.Setenv("CXT_WRAPPED_AGENT", string(domain.ProviderCodex))
+	t.Setenv("CXT_WRAPPER_PID", strconv.Itoa(os.Getppid()))
+	t.Setenv("CXT_WRAPPED_SESSION_ID", "")
+	writeCodexRollout(t, home, cwd, "55555555-5555-4555-8555-555555555555", time.Now())
+
+	save := &recordingSave{}
+	err := Run(&Container{Save: save, Memorize: noOpMemorize{}}, []string{"cxt", "save"})
+	if err == nil || !strings.Contains(err.Error(), "cannot identify the codex session") {
+		t.Fatalf("save error = %v, want exact-session fail-closed error", err)
+	}
+	if save.in.Provider != "" {
+		t.Fatalf("save was dispatched to sibling session: %+v", save.in)
+	}
+}
+
+func writeCodexRollout(t *testing.T, home, cwd, sessionID string, mtime time.Time) string {
+	t.Helper()
+	path := filepath.Join(home, ".codex", "sessions", "2026", "08", "28", "rollout-test-"+sessionID+".jsonl")
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	line := fmt.Sprintf("{\"type\":\"session_meta\",\"payload\":{\"id\":%q,\"cwd\":%q}}\n", sessionID, cwd)
+	if err := os.WriteFile(path, []byte(line), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(path, mtime, mtime); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}

--- a/cli/internal/app/stash_session.go
+++ b/cli/internal/app/stash_session.go
@@ -2,11 +2,12 @@ package app
 
 import (
 	"context"
-
 	"fmt"
-	"github.com/wnsdy95/cxthub/cli/internal/adapters/capture"
+	"os"
 	"time"
 
+	"github.com/wnsdy95/cxthub/cli/internal/adapters/capture"
+	"github.com/wnsdy95/cxthub/cli/internal/adapters/providerfs"
 	"github.com/wnsdy95/cxthub/cli/internal/domain"
 	"github.com/wnsdy95/cxthub/cli/internal/ports/inbound"
 	"github.com/wnsdy95/cxthub/cli/internal/ports/outbound"
@@ -67,9 +68,17 @@ func (s *StashService) Stash(ctx context.Context, in inbound.StashInput) (inboun
 	}
 
 	// 1) Capture active session ("working tree") — if none, like git, "no changes to save".
-	path, err := capt.LocateActiveSession(ctx, in.Cwd)
-	if err != nil {
-		return inbound.StashOutput{}, err // ErrNoActiveSession included
+	path := in.SessionPath
+	if path == "" {
+		path, err = capt.LocateActiveSession(ctx, in.Cwd)
+		if err != nil {
+			return inbound.StashOutput{}, err // ErrNoActiveSession included
+		}
+	} else {
+		info, statErr := os.Stat(path)
+		if statErr != nil || providerfs.CaptureExcluded(in.Cwd, path, info.Size()) {
+			return inbound.StashOutput{}, domain.ErrNoActiveSession
+		}
 	}
 	raw, err := capt.ReadSession(ctx, path)
 	if err != nil {

--- a/cli/internal/app/stash_session_path_test.go
+++ b/cli/internal/app/stash_session_path_test.go
@@ -1,0 +1,73 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/wnsdy95/cxthub/cli/internal/adapters/capture"
+	"github.com/wnsdy95/cxthub/cli/internal/adapters/codec"
+	"github.com/wnsdy95/cxthub/cli/internal/adapters/gitctx"
+	"github.com/wnsdy95/cxthub/cli/internal/adapters/storage"
+	"github.com/wnsdy95/cxthub/cli/internal/domain"
+	"github.com/wnsdy95/cxthub/cli/internal/ports/inbound"
+	"github.com/wnsdy95/cxthub/cli/internal/ports/outbound"
+)
+
+func TestStashUsesExplicitWrapperOwnedSessionPath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	cwd := t.TempDir()
+	if err := exec.Command("git", "-C", cwd, "init", "-q", "-b", "main").Run(); err != nil {
+		t.Skipf("git usage not possible: %v", err)
+	}
+	dir := filepath.Join(home, ".claude", "projects", encodeCwdLocal(cwd))
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	ownedID := "11111111-1111-4111-8111-111111111111"
+	siblingID := "22222222-2222-4222-8222-222222222222"
+	owned := writeClaudeSession(t, dir, cwd, ownedID, "owned", time.Unix(1000, 0))
+	writeClaudeSession(t, dir, cwd, siblingID, "newer sibling", time.Unix(2000, 0))
+
+	store := storage.NewFileStore(t.TempDir())
+	service := NewStashService(
+		gitctx.NewGitContextAdapter(),
+		map[domain.ProviderKind]outbound.CaptureSource{domain.ProviderClaude: capture.NewClaudeCapture()},
+		map[domain.ProviderKind]outbound.ProviderCodec{domain.ProviderClaude: codec.NewClaudeCodec()},
+		store,
+		nil,
+	)
+	out, err := service.Stash(context.Background(), inbound.StashInput{
+		Cwd:         cwd,
+		Provider:    domain.ProviderClaude,
+		SessionPath: owned,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := store.GetSnapshot(context.Background(), out.StashID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if snapshot.SessionID != ownedID {
+		t.Fatalf("stashed session = %q, want wrapper-owned %q", snapshot.SessionID, ownedID)
+	}
+}
+
+func writeClaudeSession(t *testing.T, dir, cwd, sessionID, text string, mtime time.Time) string {
+	t.Helper()
+	path := filepath.Join(dir, sessionID+".jsonl")
+	raw := fmt.Sprintf("{\"type\":\"user\",\"cwd\":%q,\"sessionId\":%q,\"gitBranch\":\"main\",\"message\":{\"role\":\"user\",\"content\":%q}}\n", cwd, sessionID, text)
+	if err := os.WriteFile(path, []byte(raw), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(path, mtime, mtime); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}

--- a/cli/internal/ports/inbound/ports.go
+++ b/cli/internal/ports/inbound/ports.go
@@ -86,10 +86,11 @@ type TagRef interface {
 
 // StashInput is the input DTO for StashSession.Stash.
 type StashInput struct {
-	Cwd      string
-	Provider domain.ProviderKind // if empty, claude
-	Message  string              // empty means Git-style "WIP on <branch>"
-	Author   domain.TeamIdentity
+	Cwd         string
+	Provider    domain.ProviderKind // if empty, claude
+	SessionPath string              // exact wrapper-owned session; empty uses provider discovery
+	Message     string              // empty means Git-style "WIP on <branch>"
+	Author      domain.TeamIdentity
 }
 
 // StashOutput is the result of a stash operation.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -215,9 +215,16 @@ message and short SHA link automatically.
 cxt save [-m <message>] [--provider <claude|codex>]
 ```
 
-Creates a manual snapshot for one provider; the default is `claude`. It does
-not consume `cxt add` staging and does not schedule the commit path's detached
-remote pending synchronization.
+Creates a manual snapshot for one provider. An explicit `--provider` wins. If
+it is omitted, cxt follows the provider owned by the live `cxt claude` or
+`cxt codex` wrapper; in a plain shell it chooses the most recently updated
+capture-eligible session in this worktree. Stale inherited wrapper markers are
+ignored. A managed wrapper also binds the command to its exact native session,
+so a newer same-provider session in another terminal cannot be captured by
+accident.
+
+The command does not consume `cxt add` staging and does not schedule the commit
+path's detached remote pending synchronization.
 
 Use `cxt commit` when the capture represents a code commit. Use `cxt save` for
 an explicit standalone checkpoint.
@@ -408,7 +415,7 @@ Tags are synchronized on the next push.
 
 ```text
 cxt stash
-cxt stash push [-m <message>]
+cxt stash push [-m <message>] [--provider <claude|codex>]
 cxt stash list
 cxt stash pop
 ```
@@ -416,6 +423,10 @@ cxt stash pop
 Stores active context separately and restores the branch-head context. `pop`
 restores and removes the newest context stash. Managed Git hooks mirror
 ordinary `git stash` and `git stash pop` operations.
+
+`stash push` uses the same provider selection rule as `cxt save`: explicit
+`--provider`, then a verified live wrapper, then the newest capture-eligible
+session.
 
 ## Team settings and secret masks
 


### PR DESCRIPTION
## Summary

- auto-select the verified live wrapper provider for `cxt save` and `cxt stash push`
- bind managed commands to the wrapper-owned native session ID, so a newer sibling terminal cannot be captured by mtime
- export resume session identity to wrapper descendants and retain terminal-affinity compatibility for pre-upgrade wrappers
- fail closed when a managed wrapper session cannot be identified instead of guessing
- add explicit `stash push --provider` support and exact-session capture tests

## Root cause

`cxt save` defaulted to Claude, while both save and stash eventually used provider-wide latest-mtime discovery. In a Codex wrapper this captured an old Claude session; with multiple same-provider terminals it could capture the wrong sibling even after provider selection was fixed.

## Verification

- CLI full test, vet, and race suites
- focused concurrency/session-selection tests repeated 20x
- backend default and postgres-tag test/build/vet
- web audit (0 vulnerabilities), i18n, typecheck, build
- public tree/history secret preflight and deploy static preflight
- basic E2E and sync E2E
- installed-path dogfood: implicit save produced snapshot `c0d62412fc` with exact current Codex session `20cae0ad-a855-4349-8780-d0c30904c7d1`; fsck Orphans 0 / Missing 0

Closes #100