### PR TITLE
fix(cli): brief locally promoted contexts

### DIFF
--- a/cli/internal/adapters/capture/briefing.go
+++ b/cli/internal/adapters/capture/briefing.go
@@ -194,8 +194,9 @@ func writeBriefingText(cwd, text string) error {
 }
 
 // ReadPullBriefingCursor returns the last remote branch tip durably queued for
-// this terminal/wrapper. Corrupt, cross-branch, and invalid-hash files fail
-// closed and are ignored by the caller, which falls back to the local ref.
+// this terminal/wrapper, or the known local baseline reserved immediately
+// before a ref-moving promotion. Corrupt, cross-branch, and invalid-hash files
+// fail closed and are ignored by the caller, which falls back to the local ref.
 func ReadPullBriefingCursor(cwd, branch string) (domain.ContentHash, bool) {
 	if domain.ValidateBranchName(branch) != nil {
 		return "", false
@@ -211,10 +212,12 @@ func ReadPullBriefingCursor(cwd, branch string) (domain.ContentHash, bool) {
 	return cursor.Target, true
 }
 
-// CompareAndSwapPullBriefingCursor advances only after the corresponding queue
-// entry is durable (ordering enforced by the caller). The filesystem lock and
-// expected pointer prevent concurrent post-merge hooks from moving C back to B.
-// A lost race leaves the queue intact and safely re-evaluates on the next pull.
+// CompareAndSwapPullBriefingCursor normally advances only after the
+// corresponding queue entry is durable. It may also initialize an absent
+// cursor to a pre-promotion local baseline, which excludes only history already
+// known to this terminal. The filesystem lock and expected pointer prevent
+// concurrent post-merge hooks from moving C back to B. A lost race leaves the
+// queue intact and safely re-evaluates on the next pull.
 func CompareAndSwapPullBriefingCursor(cwd, branch string, expected, target domain.ContentHash) error {
 	if !cxtEnabled(cwd) {
 		return nil

--- a/cli/internal/adapters/delivery/cli/githook.go
+++ b/cli/internal/adapters/delivery/cli/githook.go
@@ -849,7 +849,7 @@ func runGitHook(ctx context.Context, c *Container, cwd string, rest []string) er
 }
 
 // handleIncomingContexts processes team contexts incoming through code merge/merge/pull/pull --rebase:
-// fetch(only objects) → remote hint → briefing creation → context promotion of merge commit.
+// fetch(only objects) → preserve local baseline → promote merge context → queue the final remote delta.
 // Called from post-merge (merge pull) and post-rewrite (rebase pull — pull.rebase=true team default path).
 // If origin is not registered, do nothing silently.
 func handleIncomingContexts(ctx context.Context, c *Container, cwd string) {
@@ -868,22 +868,82 @@ func handleIncomingContexts(ctx context.Context, c *Container, cwd string) {
 	for _, b := range out.RemoteAhead {
 		hookWarn("New context on remote %q — history move is 'cxt pull', session injection is 'cxt load'", b)
 	}
-	// If team member context arrived on the current branch, create a one-shot
-	// identifier notice. Raw conversations and collaborator-authored labels do
-	// not enter the live model prompt; they remain available in the web view.
 	branch := gitOut(cwd, "rev-parse", "--abbrev-ref", "HEAD")
+	localBaseline, baselineOK := localBranchTarget(ctx, c, branch)
+	remoteWasAhead := false
 	for _, b := range out.RemoteAhead {
 		if b == branch && branch != "" && branch != "HEAD" {
-			writePullBriefing(ctx, c, cwd, branch)
+			remoteWasAhead = true
 			break
 		}
 	}
+	if branch == "" || branch == "HEAD" {
+		return
+	}
+	if !baselineOK {
+		hookWarn("incoming context promotion deferred: local %q baseline is unavailable", branch)
+		return
+	}
+	if err := preservePullBriefingBaseline(cwd, branch, localBaseline); err != nil {
+		hookWarn("incoming context promotion deferred: local %q baseline was not saved: %v", branch, err)
+		return
+	}
+	cursorTarget, cursorOK := capture.ReadPullBriefingCursor(cwd, branch)
+	cursorNeedsReconcile := cursorOK && cursorTarget != localBaseline
 	// PR merge context promotion: First resolve host-side squash/rebase/merge
 	// commits back to their source branches. Then retain the generic [git sha]
 	// path for non-GitHub and direct merge histories.
 	shas := incomingCommitSHAs(cwd)
-	appendMergedPRContexts(ctx, c.PRMerges, c.Sync, cwd, branch, gitOut(cwd, "config", "--get", "remote.origin.url"), shas)
-	appendMergedContexts(ctx, c, cwd, branch, shas)
+	prReflected := appendMergedPRContexts(ctx, c.PRMerges, c.Sync, cwd, branch, gitOut(cwd, "config", "--get", "remote.origin.url"), shas)
+	mergeReflected := appendMergedContexts(ctx, c, cwd, branch, shas)
+
+	// Resolve the final remote only after local/hosted promotion. AppendBranch
+	// may already have moved the local ref to that target, so comparing against
+	// the post-promotion local ref would erase the very range being announced.
+	// Keep the pre-promotion local tip as the fallback baseline; the durable
+	// briefing cursor still wins when it is reachable from the final remote.
+	if remoteWasAhead || prReflected || mergeReflected || cursorNeedsReconcile {
+		writePullBriefingFromBaseline(ctx, c, cwd, branch, localBaseline)
+	}
+}
+
+// preservePullBriefingBaseline makes promotion retry-safe. Moving the local
+// ref and then failing to queue its briefing must not make the next hook treat
+// the promoted target as already delivered. An existing cursor is newer
+// delivery state and is never replaced; an absent cursor can safely start at
+// the local tip because that history was already known before this hook.
+func preservePullBriefingBaseline(cwd, branch string, baseline domain.ContentHash) error {
+	if baseline == "" {
+		return nil
+	}
+	if _, ok := capture.ReadPullBriefingCursor(cwd, branch); ok {
+		return nil
+	}
+	if err := capture.CompareAndSwapPullBriefingCursor(cwd, branch, "", baseline); err != nil {
+		if errors.Is(err, domain.ErrSyncConflict) {
+			if _, ok := capture.ReadPullBriefingCursor(cwd, branch); ok {
+				return nil
+			}
+		}
+		return err
+	}
+	return nil
+}
+
+func localBranchTarget(ctx context.Context, c *Container, branch string) (domain.ContentHash, bool) {
+	if c == nil || c.List == nil || branch == "" || branch == "HEAD" {
+		return "", false
+	}
+	all, err := c.List.List(ctx, inbound.ListInput{})
+	if err != nil {
+		return "", false
+	}
+	for _, ref := range all.Refs {
+		if ref.Kind == domain.RefBranch && ref.Name == branch {
+			return ref.Target, true
+		}
+	}
+	return "", true
 }
 
 func incomingCommitSHAs(cwd string) []string {
@@ -915,17 +975,18 @@ func appendMergedPRContexts(
 	syncer mergedPRContextSync,
 	cwd, branch, gitRemoteURL string,
 	shas []string,
-) {
+) bool {
 	if resolver == nil || syncer == nil || branch == "" || branch == "HEAD" || gitRemoteURL == "" || len(shas) == 0 {
-		return
+		return false
 	}
 	pulls, err := resolver.ResolveMergedPullRequests(ctx, gitRemoteURL, branch, shas)
 	if err != nil {
 		hookWarn("GitHub PR context lookup failed (git continues): %v", err)
-		return
+		return false
 	}
 
 	appended := 0
+	reflected := false
 	for _, pull := range pulls {
 		if pull.BaseBranch != branch || pull.HeadBranch == "" || pull.HeadBranch == branch {
 			continue
@@ -942,16 +1003,19 @@ func appendMergedPRContexts(
 		}
 		if aerr := syncer.AppendBranch(ctx, inbound.SyncInput{Cwd: cwd}, branch, ref.Target); aerr != nil {
 			if strings.Contains(aerr.Error(), "non_fast_forward") {
+				reflected = true
 				continue // hosted webhook or another client already promoted it
 			}
 			hookWarn("PR #%d context promotion failed (%s → %s): %v", pull.Number, pull.HeadBranch, branch, aerr)
 			continue
 		}
 		appended++
+		reflected = true
 	}
 	if appended > 0 {
 		fmt.Printf("cxt: promoted %d merged PR context(s) to %q timeline (appended)\n", appended, branch)
 	}
+	return reflected
 }
 
 // appendMergedContexts appends git merge/pull commits and chained context snapshots to the same-named cxt branch.
@@ -960,13 +1024,13 @@ func appendMergedPRContexts(
 // — this hook fills that gap. Append is a lossless operation (overlay) that is idempotent and conflict-free (server CAS,
 // non-ff targets rejected → skip). Provider PR resolution above supplies the
 // squash/rebase path whose original commit links are absent from the base Git history.
-func appendMergedContexts(ctx context.Context, c *Container, cwd, branch string, shas []string) {
+func appendMergedContexts(ctx context.Context, c *Container, cwd, branch string, shas []string) bool {
 	if branch == "" || branch == "HEAD" || len(shas) == 0 {
-		return
+		return false
 	}
 	list, err := c.List.List(ctx, inbound.ListInput{})
 	if err != nil {
-		return
+		return false
 	}
 	rewrites := loadRewrites(cwd)
 	// [git <sha>] link → snapshot. Multiple snapshots for the same commit are the latest (same as refSync).
@@ -1002,7 +1066,7 @@ func appendMergedContexts(ctx context.Context, c *Container, cwd, branch string,
 		}
 	}
 	if len(cands) == 0 {
-		return
+		return false
 	}
 	// Remove candidates already reachable from the server branch + ancestors of other candidates (minimize requests).
 	reach := map[domain.ContentHash]bool{}
@@ -1023,9 +1087,17 @@ func appendMergedContexts(ctx context.Context, c *Container, cwd, branch string,
 	if ref, rerr := c.Sync.ResolveRemoteBranch(ctx, inbound.SyncInput{Cwd: cwd}, branch); rerr == nil && ref.Target != "" {
 		walk(ref.Target)
 	}
+	remoteReach := make(map[domain.ContentHash]bool, len(reach))
+	for id := range reach {
+		remoteReach[id] = true
+	}
+	reflected := false
 	var kept []domain.Snapshot
 	for i := len(cands) - 1; i >= 0; i-- { // newest candidates first — absorb ancestor candidates as cover
 		if reach[cands[i].ID] {
+			if remoteReach[cands[i].ID] {
+				reflected = true
+			}
 			continue
 		}
 		kept = append([]domain.Snapshot{cands[i]}, kept...)
@@ -1035,16 +1107,19 @@ func appendMergedContexts(ctx context.Context, c *Container, cwd, branch string,
 	for _, sn := range kept { // from oldest — tip = latest merge
 		if aerr := c.Sync.AppendBranch(ctx, inbound.SyncInput{Cwd: cwd}, branch, sn.ID); aerr != nil {
 			if strings.Contains(aerr.Error(), "non_fast_forward") {
+				reflected = true
 				continue // skip if another team member has already promoted (idempotent no-op)
 			}
 			hookWarn("merge context promotion failed(%s): %v", shortHash(sn.ID), aerr)
 			continue
 		}
 		appended++
+		reflected = true
 	}
 	if appended > 0 {
 		fmt.Printf("cxt: promoted %d merge contexts to %q timeline (appended)\n", appended, branch)
 	}
+	return reflected
 }
 
 // --- History Rewrite Mapping (.cxt/rewrites.json) ---
@@ -1248,12 +1323,19 @@ func queuePullBriefing(cwd, branch string, delta []domain.Snapshot) error {
 	return capture.WritePullBriefing(cwd, branch, ids)
 }
 
-// writePullBriefing records validated identifiers for team member snapshots
-// received via git pull in a terminal-scoped sidecar and advances a separate
-// durable remote cursor. The active/local context ref remains untouched. The
-// next prompt consumes the notice once; collaborator-authored labels and raw
+// writePullBriefingFromBaseline records validated identifiers for team member
+// snapshots received via git pull or merge promotion in a terminal-scoped
+// sidecar and advances a separate durable remote cursor. localBaseline must be
+// captured before promotion because AppendBranch can converge the local ref to
+// the final remote target. The active context ref remains untouched. The next
+// prompt consumes the notice once; collaborator-authored labels and raw
 // conversations are never copied into additionalContext.
-func writePullBriefing(ctx context.Context, c *Container, cwd, branch string) {
+func writePullBriefingFromBaseline(
+	ctx context.Context,
+	c *Container,
+	cwd, branch string,
+	localBaseline domain.ContentHash,
+) {
 	if err := capture.WithPullBriefingTransaction(cwd, branch, func() error {
 		ref, err := c.Sync.ResolveRemoteBranch(ctx, inbound.SyncInput{Cwd: cwd}, branch)
 		if err != nil || ref.Target == "" {
@@ -1263,15 +1345,8 @@ func writePullBriefing(ctx context.Context, c *Container, cwd, branch string) {
 		if err != nil {
 			return err
 		}
-		var localTarget domain.ContentHash
-		for _, r := range all.Refs {
-			if r.Kind == domain.RefBranch && r.Name == branch {
-				localTarget = r.Target
-				break
-			}
-		}
 		cursorTarget, _ := capture.ReadPullBriefingCursor(cwd, branch)
-		delta, complete := pullBriefingDelta(all.Snapshots, ref.Target, localTarget, cursorTarget)
+		delta, complete := pullBriefingDelta(all.Snapshots, ref.Target, localBaseline, cursorTarget)
 		if !complete {
 			return nil // fetched graph is incomplete — do not skip an unobserved range
 		}

--- a/cli/internal/adapters/delivery/cli/githook_briefing_test.go
+++ b/cli/internal/adapters/delivery/cli/githook_briefing_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -9,6 +10,8 @@ import (
 
 	"github.com/wnsdy95/cxthub/cli/internal/adapters/capture"
 	"github.com/wnsdy95/cxthub/cli/internal/domain"
+	"github.com/wnsdy95/cxthub/cli/internal/ports/inbound"
+	"github.com/wnsdy95/cxthub/cli/internal/ports/outbound"
 )
 
 func briefingHash(label string) domain.ContentHash {
@@ -134,5 +137,289 @@ func TestQueuePullBriefingExcludesCollaboratorControlledPromptText(t *testing.T)
 		if !strings.Contains(got, want) {
 			t.Fatalf("model-visible briefing missing %q:\n%s", want, got)
 		}
+	}
+}
+
+type fixedBriefingList struct {
+	out inbound.ListOutput
+}
+
+func (f fixedBriefingList) List(context.Context, inbound.ListInput) (inbound.ListOutput, error) {
+	return f.out, nil
+}
+
+type fixedBriefingSync struct {
+	remote    domain.Ref
+	appendErr error
+}
+
+func (f fixedBriefingSync) Push(context.Context, inbound.SyncInput) (inbound.SyncOutput, error) {
+	return inbound.SyncOutput{}, nil
+}
+
+func (f fixedBriefingSync) Pull(context.Context, inbound.SyncInput) (inbound.SyncOutput, error) {
+	return inbound.SyncOutput{}, nil
+}
+
+func (f fixedBriefingSync) Connect(context.Context, inbound.SyncInput) (inbound.ConnectOutput, error) {
+	return inbound.ConnectOutput{}, nil
+}
+
+func (f fixedBriefingSync) SyncPendings(context.Context, inbound.SyncInput, []string) (int, error) {
+	return 0, nil
+}
+
+func (f fixedBriefingSync) ResolveRemoteBranch(context.Context, inbound.SyncInput, string) (domain.Ref, error) {
+	return f.remote, nil
+}
+
+func (f fixedBriefingSync) AppendBranch(context.Context, inbound.SyncInput, string, domain.ContentHash) error {
+	return f.appendErr
+}
+
+type promotionBriefingState struct {
+	baseline                   domain.ContentHash
+	promoted                   domain.ContentHash
+	local                      domain.ContentHash
+	remote                     domain.ContentHash
+	listErr                    error
+	failMainResolveAfterAppend bool
+	mainResolveFailed          bool
+	pullFetchOnly              bool
+	appends                    int
+}
+
+func (s *promotionBriefingState) List(context.Context, inbound.ListInput) (inbound.ListOutput, error) {
+	if s.listErr != nil {
+		return inbound.ListOutput{}, s.listErr
+	}
+	return inbound.ListOutput{
+		Snapshots: []domain.Snapshot{
+			{ID: s.baseline, Message: "local baseline"},
+			{ID: s.promoted, GraftParents: []domain.ContentHash{s.baseline}, Message: "promoted PR context"},
+		},
+		Refs: []domain.Ref{{Kind: domain.RefBranch, Name: "main", Target: s.local}},
+	}, nil
+}
+
+func (s *promotionBriefingState) Push(context.Context, inbound.SyncInput) (inbound.SyncOutput, error) {
+	return inbound.SyncOutput{}, nil
+}
+
+func (s *promotionBriefingState) Pull(_ context.Context, in inbound.SyncInput) (inbound.SyncOutput, error) {
+	s.pullFetchOnly = in.FetchOnly
+	// This is the production-without-webhook case: the base remote is not ahead
+	// until the local post-merge resolver promotes the source context below.
+	return inbound.SyncOutput{}, nil
+}
+
+func (s *promotionBriefingState) Connect(context.Context, inbound.SyncInput) (inbound.ConnectOutput, error) {
+	return inbound.ConnectOutput{}, nil
+}
+
+func (s *promotionBriefingState) SyncPendings(context.Context, inbound.SyncInput, []string) (int, error) {
+	return 0, nil
+}
+
+func (s *promotionBriefingState) ResolveRemoteBranch(
+	_ context.Context,
+	_ inbound.SyncInput,
+	branch string,
+) (domain.Ref, error) {
+	switch branch {
+	case "main":
+		if s.failMainResolveAfterAppend && s.appends > 0 && !s.mainResolveFailed {
+			s.mainResolveFailed = true
+			return domain.Ref{}, fmt.Errorf("temporary final remote lookup failure")
+		}
+		return domain.Ref{Kind: domain.RefBranch, Name: branch, Target: s.remote}, nil
+	case "feature/topic":
+		return domain.Ref{Kind: domain.RefBranch, Name: branch, Target: s.promoted}, nil
+	default:
+		return domain.Ref{}, domain.ErrNotFound
+	}
+}
+
+func (s *promotionBriefingState) AppendBranch(
+	_ context.Context,
+	_ inbound.SyncInput,
+	branch string,
+	target domain.ContentHash,
+) error {
+	if branch != "main" || target != s.promoted {
+		return fmt.Errorf("unexpected append %s -> %s", branch, target)
+	}
+	if s.remote == target {
+		return fmt.Errorf("non_fast_forward: target already reflected")
+	}
+	s.appends++
+	s.remote = target
+	s.local = target
+	return nil
+}
+
+func newPostMergeBriefingRepo(t *testing.T) string {
+	t.Helper()
+	repo := t.TempDir()
+	runGitForTest(t, repo, "init", "-b", "main")
+	runGitForTest(t, repo, "config", "core.hooksPath", t.TempDir())
+	runGitForTest(t, repo, "config", "user.name", "Test")
+	runGitForTest(t, repo, "config", "user.email", "test@example.com")
+	runGitForTest(t, repo, "remote", "add", "origin", "https://github.com/acme/project.git")
+	runGitForTest(t, repo, "commit", "--allow-empty", "-m", "base")
+	baselineCommit := gitOut(repo, "rev-parse", "HEAD")
+	runGitForTest(t, repo, "commit", "--allow-empty", "-m", "merged PR")
+	runGitForTest(t, repo, "update-ref", "ORIG_HEAD", baselineCommit)
+	if err := os.MkdirAll(filepath.Join(repo, ".cxt"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CXT_REMOTE", "https://cxthub.test/acme/project")
+	return repo
+}
+
+func TestHandleIncomingContextsBriefsLocallyPromotedPRRange(t *testing.T) {
+	repo := newPostMergeBriefingRepo(t)
+	t.Setenv("TERM_SESSION_ID", "local-promotion-briefing-test")
+
+	baseline := briefingHash("handle-promotion-baseline")
+	promoted := briefingHash("handle-promotion-target")
+	state := &promotionBriefingState{
+		baseline: baseline,
+		promoted: promoted,
+		local:    baseline,
+		remote:   baseline,
+	}
+	resolver := &fakePRMergeResolver{pulls: []outbound.MergedPullRequest{{
+		Number: 31, BaseBranch: "main", HeadBranch: "feature/topic",
+	}}}
+	c := &Container{List: state, Sync: state, PRMerges: resolver}
+
+	handleIncomingContexts(context.Background(), c, repo)
+	if !state.pullFetchOnly || state.appends != 1 || state.local != promoted || state.remote != promoted {
+		t.Fatalf("promotion state = %+v", state)
+	}
+	briefing, ok := capture.ConsumeBriefing(repo)
+	if !ok || !strings.Contains(briefing, string(promoted)) || strings.Contains(briefing, string(baseline)) {
+		t.Fatalf("locally promoted briefing = %q, want only promoted target", briefing)
+	}
+}
+
+func TestHandleIncomingContextsDefersPromotionWithoutBaseline(t *testing.T) {
+	repo := newPostMergeBriefingRepo(t)
+
+	baseline := briefingHash("unavailable-baseline")
+	promoted := briefingHash("deferred-promotion")
+	state := &promotionBriefingState{
+		baseline: baseline,
+		promoted: promoted,
+		local:    baseline,
+		remote:   baseline,
+		listErr:  fmt.Errorf("local store unavailable"),
+	}
+	resolver := &fakePRMergeResolver{pulls: []outbound.MergedPullRequest{{
+		Number: 32, BaseBranch: "main", HeadBranch: "feature/topic",
+	}}}
+
+	handleIncomingContexts(context.Background(), &Container{List: state, Sync: state, PRMerges: resolver}, repo)
+	if !state.pullFetchOnly || state.appends != 0 || state.local != baseline || state.remote != baseline {
+		t.Fatalf("promotion was not deferred: %+v", state)
+	}
+}
+
+func TestHandleIncomingContextsRetriesBriefingAfterPostPromotionFailure(t *testing.T) {
+	repo := newPostMergeBriefingRepo(t)
+	t.Setenv("TERM_SESSION_ID", "promotion-briefing-retry-test")
+
+	baseline := briefingHash("retry-baseline")
+	promoted := briefingHash("retry-promoted")
+	state := &promotionBriefingState{
+		baseline:                   baseline,
+		promoted:                   promoted,
+		local:                      baseline,
+		remote:                     baseline,
+		failMainResolveAfterAppend: true,
+	}
+	resolver := &fakePRMergeResolver{pulls: []outbound.MergedPullRequest{{
+		Number: 33, BaseBranch: "main", HeadBranch: "feature/topic",
+	}}}
+	c := &Container{List: state, Sync: state, PRMerges: resolver}
+
+	handleIncomingContexts(context.Background(), c, repo)
+	if _, ok := capture.ConsumeBriefing(repo); ok {
+		t.Fatal("briefing unexpectedly survived the injected final-remote failure")
+	}
+	if cursor, ok := capture.ReadPullBriefingCursor(repo, "main"); !ok || cursor != baseline {
+		t.Fatalf("retry baseline cursor = %s, %v; want %s", cursor, ok, baseline)
+	}
+
+	// A later Git operation can replace ORIG_HEAD before the retry. The durable
+	// baseline cursor must recover delivery without resolving the PR again.
+	runGitForTest(t, repo, "update-ref", "-d", "ORIG_HEAD")
+	handleIncomingContexts(context.Background(), c, repo)
+	briefing, ok := capture.ConsumeBriefing(repo)
+	if !ok || !strings.Contains(briefing, string(promoted)) || strings.Contains(briefing, string(baseline)) {
+		t.Fatalf("retried briefing = %q, want only promoted target", briefing)
+	}
+	if cursor, ok := capture.ReadPullBriefingCursor(repo, "main"); !ok || cursor != promoted {
+		t.Fatalf("retried cursor = %s, %v; want %s", cursor, ok, promoted)
+	}
+}
+
+func TestAppendMergedContextsDoesNotTreatCoveredFailedCandidateAsReflected(t *testing.T) {
+	base := briefingHash("generic-promotion-base")
+	older := briefingHash("generic-promotion-older")
+	newer := briefingHash("generic-promotion-newer")
+	c := &Container{
+		List: fixedBriefingList{out: inbound.ListOutput{Snapshots: []domain.Snapshot{
+			{ID: newer, Parents: []domain.ContentHash{older}, Message: "newer [git bbbb]"},
+			{ID: older, Parents: []domain.ContentHash{base}, Message: "older [git aaaa]"},
+			{ID: base, Message: "base"},
+		}}},
+		Sync: fixedBriefingSync{
+			remote:    domain.Ref{Kind: domain.RefBranch, Name: "main", Target: base},
+			appendErr: fmt.Errorf("remote unavailable"),
+		},
+	}
+
+	if reflected := appendMergedContexts(
+		context.Background(), c, t.TempDir(), "main", []string{"aaaa1111", "bbbb2222"},
+	); reflected {
+		t.Fatal("failed newest candidate was masked by its covered ancestor")
+	}
+}
+
+func TestWritePullBriefingUsesPrePromotionBaselineAfterLocalRefMoves(t *testing.T) {
+	cwd := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cwd, ".cxt"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("TERM_SESSION_ID", "post-promotion-briefing-test")
+	baseline := briefingHash("promotion-baseline")
+	promoted := briefingHash("promotion-target")
+	c := &Container{
+		List: fixedBriefingList{out: inbound.ListOutput{
+			Snapshots: []domain.Snapshot{
+				{ID: baseline, Message: "local baseline"},
+				{ID: promoted, GraftParents: []domain.ContentHash{baseline}, Message: "promoted PR context"},
+			},
+			// AppendBranch has already converged the local ref to the final remote
+			// target. Looking this up now would produce an empty delta.
+			Refs: []domain.Ref{{Kind: domain.RefBranch, Name: "main", Target: promoted}},
+		}},
+		Sync: fixedBriefingSync{remote: domain.Ref{Kind: domain.RefBranch, Name: "main", Target: promoted}},
+	}
+
+	writePullBriefingFromBaseline(context.Background(), c, cwd, "main", baseline)
+	briefing, ok := capture.ConsumeBriefing(cwd)
+	if !ok || !strings.Contains(briefing, string(promoted)) || strings.Contains(briefing, string(baseline)) {
+		t.Fatalf("post-promotion briefing = %q, want only promoted target", briefing)
+	}
+	if cursor, ok := capture.ReadPullBriefingCursor(cwd, "main"); !ok || cursor != promoted {
+		t.Fatalf("briefing cursor = %s, %v; want promoted target", cursor, ok)
+	}
+
+	writePullBriefingFromBaseline(context.Background(), c, cwd, "main", baseline)
+	if repeated, ok := capture.ConsumeBriefing(cwd); ok {
+		t.Fatalf("promoted range was briefed twice: %q", repeated)
 	}
 }

--- a/cli/internal/adapters/delivery/cli/githook_pr_test.go
+++ b/cli/internal/adapters/delivery/cli/githook_pr_test.go
@@ -93,7 +93,7 @@ func TestAppendMergedPRContextsPromotesInResolverOrder(t *testing.T) {
 	}
 
 	shas := []string{"aaa", "bbb", "ccc", "ddd", "eee"}
-	appendMergedPRContexts(
+	reflected := appendMergedPRContexts(
 		context.Background(),
 		resolver,
 		syncer,
@@ -102,6 +102,9 @@ func TestAppendMergedPRContextsPromotesInResolverOrder(t *testing.T) {
 		"git@github.com:acme/project.git",
 		shas,
 	)
+	if !reflected {
+		t.Fatal("successful/already-promoted PR contexts were not reported as reflected")
+	}
 
 	if resolver.remote != "git@github.com:acme/project.git" || resolver.base != "main" {
 		t.Fatalf("resolver inputs = (%q, %q), want Git remote and main", resolver.remote, resolver.base)
@@ -129,7 +132,7 @@ func TestAppendMergedPRContextsResolverFailureIsFailOpen(t *testing.T) {
 
 	resolver := &fakePRMergeResolver{err: errors.New("rate limited")}
 	syncer := &fakeMergedPRSync{}
-	appendMergedPRContexts(
+	reflected := appendMergedPRContexts(
 		context.Background(),
 		resolver,
 		syncer,
@@ -138,8 +141,36 @@ func TestAppendMergedPRContextsResolverFailureIsFailOpen(t *testing.T) {
 		"https://github.com/acme/project",
 		[]string{"aaa"},
 	)
+	if reflected {
+		t.Fatal("resolver failure was reported as reflected")
+	}
 	if len(syncer.appends) != 0 {
 		t.Fatalf("append calls = %#v, want none after resolver failure", syncer.appends)
+	}
+}
+
+func TestAppendMergedPRContextsPromotionFailureIsNotReflected(t *testing.T) {
+	t.Parallel()
+
+	target := domain.ContentHash("sha256:failed")
+	resolver := &fakePRMergeResolver{pulls: []outbound.MergedPullRequest{{
+		Number: 21, BaseBranch: "main", HeadBranch: "feature/fails", MergeCommitSHA: "aaa",
+	}}}
+	syncer := &fakeMergedPRSync{
+		refs:       map[string]domain.Ref{"feature/fails": {Target: target}},
+		appendErrs: map[domain.ContentHash]error{target: errors.New("remote unavailable")},
+	}
+
+	if reflected := appendMergedPRContexts(
+		context.Background(),
+		resolver,
+		syncer,
+		"/repo",
+		"main",
+		"https://github.com/acme/project",
+		[]string{"aaa"},
+	); reflected {
+		t.Fatal("failed PR promotion was reported as reflected")
 	}
 }
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -487,13 +487,18 @@ post-rewrite
 
 Existing user hooks are chained and restored on uninstall.
 
-After `git pull` or merge, the post-merge hook fetches new team context without
-moving the active local context ref. The next prompt receives one terminal-
-scoped notice containing only the validated incoming snapshot IDs. Teammate-
-authored commit labels, author fields, and conversation text are not copied
-into the model's `additionalContext`; inspect those untrusted details in the
-web context view. The notice is consumed once, expires after 24 hours, keeps
-the newest 12 visible snapshots, and remains capped at 4 KiB.
+After `git pull` or merge, the post-merge hook first fetches new team context
+without moving the active local context ref. A merged branch context is then
+losslessly appended to the base timeline; the local context ref converges only
+when that preserves its history. This does not replace, slice, or copy another
+conversation into the running agent session. The next prompt instead receives
+one terminal-scoped notice containing only the validated incoming snapshot
+IDs. Its range is calculated from a durable pre-promotion baseline, so a local
+PR promotion cannot hide its own delta and a failed delivery remains retryable.
+Teammate-authored commit labels, author fields, and conversation text are not
+copied into the model's `additionalContext`; inspect those untrusted details in
+the web context view. The notice is consumed once, expires after 24 hours,
+keeps the newest 12 visible snapshots, and remains capped at 4 KiB.
 
 ## Configuration
 


### PR DESCRIPTION
Closes #102

Summary
- capture the local branch tip before PR/generic merge context promotion
- calculate the one-shot identifier briefing from the final remote DAG after promotion
- seed a durable pre-promotion cursor so a post-promotion delivery failure remains retryable even after ORIG_HEAD changes
- defer remote promotion when the local baseline cannot be read or persisted
- distinguish already-reflected candidates from candidates merely covered by a failed newer append
- document that git pull never slices or imports teammate conversations into the active agent window

Regression coverage
- local PR fallback with no initial remote-ahead signal
- local ref already converged before briefing selection
- baseline read failure
- final remote lookup failure followed by metadata-independent retry
- resolver/promotion failures and already-reflected paths
- grouped generic merge candidate failure

Validation
- CLI test, vet, and race suites
- backend default and postgres-tag suites plus vet
- web audit, i18n, typecheck, and production build
- frontend core frozen-lockfile typecheck
- basic and sync real-binary E2E
- public tree and deploy static preflights