### PR TITLE
Fix stale memory fields entering future prompts

### DIFF
--- a/cli/internal/adapters/delivery/mcp/server.go
+++ b/cli/internal/adapters/delivery/mcp/server.go
@@ -315,6 +315,7 @@ func (s *Server) toolMemory(ctx context.Context, cwd string, repo domain.Repo, r
 	if !ok {
 		return "No memory digest for this sequence (cxt memorize or automatic commit memorize required)", nil
 	}
+	d = domain.PromptStructuredProjection(d)
 	var b strings.Builder
 	fmt.Fprintf(&b, "memory digest (Snapshot %s based)\n\n%s\n", shortHash(d.SnapshotID), truncateRunes(d.Summary, 8000))
 	if len(d.KeyFacts) > 0 {

--- a/cli/internal/adapters/delivery/mcp/server_test.go
+++ b/cli/internal/adapters/delivery/mcp/server_test.go
@@ -141,3 +141,30 @@ func TestMCPProtocolRoundTrip(t *testing.T) {
 		t.Fatalf("search disconnected notice abnormal: %s", lines[5])
 	}
 }
+
+func TestMemoryToolOmitsUnattestedStructuredArchiveState(t *testing.T) {
+	srv := testServer()
+	st := srv.store.(fakeStore)
+	st.mems[h("m")] = domain.MemoryDigest{
+		SnapshotID: h("a"),
+		Summary:    "provider summary remains",
+		KeyFacts:   []string{"apply_patch", "The MCP projection keeps this project fact."},
+		OpenTasks:  []string{"Completed fallback task must stay archived."},
+	}
+	srv.store = st
+
+	got, err := srv.toolMemory(context.Background(), "", domain.Repo{ID: "repo-1", DefaultBranch: "main"}, "main")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range []string{"apply_patch", "Completed fallback task"} {
+		if strings.Contains(got, forbidden) {
+			t.Fatalf("MCP memory rendered unattested state %q:\n%s", forbidden, got)
+		}
+	}
+	for _, want := range []string{"provider summary remains", "The MCP projection keeps this project fact."} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("MCP memory lost %q:\n%s", want, got)
+		}
+	}
+}

--- a/cli/internal/adapters/memory/managed_sink_test.go
+++ b/cli/internal/adapters/memory/managed_sink_test.go
@@ -106,6 +106,25 @@ func TestRenderMemoryMarkdownOmitsLegacyNativeProvenanceFacts(t *testing.T) {
 	}
 }
 
+func TestRenderMemoryMarkdownOmitsUnattestedTasksAndToolFacts(t *testing.T) {
+	digest := domain.MemoryDigest{
+		Summary:   "provider summary remains",
+		KeyFacts:  []string{"apply_patch", "The managed memory keeps this project fact."},
+		OpenTasks: []string{"Completed fallback task must stay archived."},
+	}
+	got := renderMemoryMarkdown(digest)
+	for _, forbidden := range []string{"apply_patch", "Completed fallback task"} {
+		if strings.Contains(got, forbidden) {
+			t.Fatalf("managed memory rendered unattested state %q:\n%s", forbidden, got)
+		}
+	}
+	for _, want := range []string{"provider summary remains", "The managed memory keeps this project fact."} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("managed memory lost %q:\n%s", want, got)
+		}
+	}
+}
+
 func TestMemorySinkRejectsMalformedMarkersWithoutWrite(t *testing.T) {
 	for _, body := range []string{
 		"user\n" + testManagedMemoryBegin + "\nunterminated\n",
@@ -128,16 +147,17 @@ func TestMemorySinkRejectsMalformedMarkersWithoutWrite(t *testing.T) {
 
 func TestRenderedManagedMemoryIsBoundedAndKeepsNewestState(t *testing.T) {
 	digest := domain.MemoryDigest{
-		SnapshotID: domain.HashContent([]byte("managed-memory-snapshot")),
-		Summary:    "OLDEST-SUMMARY\n" + strings.Repeat("é", 80<<10) + "\nNEWEST-SUMMARY",
-		KeyFacts:   []string{strings.Repeat("old-fact ", 12<<10), "NEWEST-FACT"},
-		OpenTasks:  []string{strings.Repeat("old-task ", 12<<10), "NEWEST-TASK"},
+		SnapshotID:         domain.HashContent([]byte("managed-memory-snapshot")),
+		Summary:            "OLDEST-SUMMARY\n" + strings.Repeat("é", 80<<10) + "\nNEWEST-SUMMARY",
+		KeyFacts:           []string{strings.Repeat("old fact ", 12<<10), "NEWEST FACT remains"},
+		OpenTasks:          []string{strings.Repeat("old task ", 12<<10), "NEWEST TASK remains"},
+		TasksAuthoritative: true,
 	}
 	got := renderMemoryMarkdown(digest)
 	if len(got) > 64<<10 || !utf8.ValidString(got) {
 		t.Fatalf("managed memory bytes=%d valid=%v", len(got), utf8.ValidString(got))
 	}
-	for _, want := range []string{"NEWEST-SUMMARY", "NEWEST-FACT", "NEWEST-TASK", string(digest.SnapshotID)} {
+	for _, want := range []string{"NEWEST-SUMMARY", "NEWEST FACT remains", "NEWEST TASK remains", string(digest.SnapshotID)} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("bounded managed memory lost %q", want)
 		}

--- a/cli/internal/adapters/memory/render.go
+++ b/cli/internal/adapters/memory/render.go
@@ -19,6 +19,7 @@ const (
 // provider-facing projection is bounded so it cannot consume the next session's
 // context window before the user says anything.
 func renderMemoryMarkdown(d domain.MemoryDigest) string {
+	d = domain.PromptStructuredProjection(d)
 	header := managedMemoryBegin + "\n# cxt memory\n\n"
 	footer := ""
 	if d.SnapshotID != "" && domain.ValidateContentHash(d.SnapshotID) == nil {
@@ -32,13 +33,7 @@ func renderMemoryMarkdown(d domain.MemoryDigest) string {
 
 	// Structured state receives fixed reservations before narrative. Lists are
 	// selected newest-first but rendered in their original order.
-	providerFacts := make([]string, 0, len(d.KeyFacts))
-	for _, fact := range d.KeyFacts {
-		if !domain.IsNativeMemoryProvenanceFact(fact) {
-			providerFacts = append(providerFacts, fact)
-		}
-	}
-	facts := renderMemoryListTail("Key facts", providerFacts, available/6)
+	facts := renderMemoryListTail("Key facts", d.KeyFacts, available/6)
 	tasks := renderMemoryListTail("Open tasks", d.OpenTasks, available/4)
 	remaining := available - len(facts) - len(tasks)
 	summary := ""

--- a/cli/internal/app/branch_seed.go
+++ b/cli/internal/app/branch_seed.go
@@ -397,6 +397,11 @@ func isSyntheticReplayMessage(ev domain.Event) bool {
 // outgrows the digest budget. Bullets are reserved first and summaries keep
 // their newest tail; exact byte accounting guarantees the result fits maxBytes.
 func renderSeedText(from, to string, mainMem *domain.MemoryDigest, branchMem domain.MemoryDigest, maxBytes int) string {
+	branchMem = domain.PromptStructuredProjection(branchMem)
+	if mainMem != nil {
+		projected := domain.PromptStructuredProjection(*mainMem)
+		mainMem = &projected
+	}
 	header := fmt.Sprintf("[cxt seed] Branch-switch context: %s → %s\n", from, to) +
 		"This session is the seed of a new branch — continue from the summaries and the verbatim recent context below.\n"
 	trailer := "\n## Recent context (verbatim)\nThe events below are the actual conversation right before the switch.\n"

--- a/cli/internal/app/branch_seed_inheritance_test.go
+++ b/cli/internal/app/branch_seed_inheritance_test.go
@@ -39,6 +39,10 @@ func putBranchSeedSnapshot(
 	if memory != nil {
 		digest := *memory
 		digest.SnapshotID = docHash
+		// Production memorize normalizes fresh structured state into persisted
+		// fragments before PutMemory; keep this fixture on the same wire path so
+		// task authority survives JSON storage.
+		digest = domain.MergeDigests(domain.MemoryDigest{}, digest)
 		memoryHash, err = store.PutMemory(ctx, digest)
 		if err != nil {
 			t.Fatalf("put memory: %v", err)
@@ -274,10 +278,11 @@ func TestBranchSeedFromMainIncludesStoredMemoryAndFullSession(t *testing.T) {
 		seedMessage("assistant", "main session latest answer", 3),
 	)
 	head := putBranchSeedSnapshot(t, ctx, store, repo.ID, "main", headEvents, []domain.ContentHash{parent}, &domain.MemoryDigest{
-		Summary:   "MAIN COMPACT MEMORY: preserve architecture and current decisions.",
-		KeyFacts:  []string{"main compact fact"},
-		OpenTasks: []string{"main compact task"},
-		Provider:  domain.ProviderCodex,
+		Summary:            "MAIN COMPACT MEMORY: preserve architecture and current decisions.",
+		KeyFacts:           []string{"main compact fact"},
+		OpenTasks:          []string{"main compact task"},
+		TasksAuthoritative: true,
+		Provider:           domain.ProviderCodex,
 	})
 	putBranchSeedRef(t, ctx, store, repo.ID, "main", head)
 
@@ -708,14 +713,16 @@ func TestBranchSeedMainMemoryAndConversationStayWithinBudget(t *testing.T) {
 // the main summary outgrew the digest budget.
 func TestRenderSeedTextKeepsBulletsAndNewestSummaryTail(t *testing.T) {
 	mainMem := &domain.MemoryDigest{
-		Summary:   "OLDEST-GENERATION-HEAD\n" + strings.Repeat("m", 4*seedDigestBudgetBytes) + "\nNEWEST-MAIN-TAIL",
-		KeyFacts:  []string{"main fact alpha beta"},
-		OpenTasks: []string{"main task gamma delta"},
+		Summary:            "OLDEST-GENERATION-HEAD\n" + strings.Repeat("m", 4*seedDigestBudgetBytes) + "\nNEWEST-MAIN-TAIL",
+		KeyFacts:           []string{"main fact alpha beta"},
+		OpenTasks:          []string{"main task gamma delta"},
+		TasksAuthoritative: true,
 	}
 	branchMem := domain.MemoryDigest{
-		Summary:   "OLD-BRANCH-HEAD\n" + strings.Repeat("b", 2*seedDigestBudgetBytes) + "\nNEWEST-BRANCH-TAIL",
-		KeyFacts:  []string{"branch fact epsilon zeta"},
-		OpenTasks: []string{"branch task eta theta"},
+		Summary:            "OLD-BRANCH-HEAD\n" + strings.Repeat("b", 2*seedDigestBudgetBytes) + "\nNEWEST-BRANCH-TAIL",
+		KeyFacts:           []string{"branch fact epsilon zeta"},
+		OpenTasks:          []string{"branch task eta theta"},
+		TasksAuthoritative: true,
 	}
 	out := renderSeedText("main", "fix/x", mainMem, branchMem, seedDigestBudgetBytes)
 	if len(out) > seedDigestBudgetBytes {
@@ -740,6 +747,25 @@ func TestRenderSeedTextKeepsBulletsAndNewestSummaryTail(t *testing.T) {
 		if strings.Contains(out, unwanted) {
 			t.Fatalf("seed text kept stale summary head %q instead of the newest tail", unwanted)
 		}
+	}
+}
+
+func TestRenderSeedTextOmitsUnattestedTasksFromBothLayers(t *testing.T) {
+	mainMem := &domain.MemoryDigest{
+		Summary:   "main provider state",
+		OpenTasks: []string{"Stale main fallback task."},
+	}
+	branchMem := domain.MemoryDigest{
+		Summary:            "branch provider state",
+		OpenTasks:          []string{"Current branch task remains."},
+		TasksAuthoritative: true,
+	}
+	out := renderSeedText("main", "fix/x", mainMem, branchMem, seedDigestBudgetBytes)
+	if strings.Contains(out, "Stale main fallback task") {
+		t.Fatalf("branch seed injected unattested main task:\n%s", out)
+	}
+	if !strings.Contains(out, "Current branch task remains") {
+		t.Fatalf("branch seed lost authoritative task:\n%s", out)
 	}
 }
 

--- a/cli/internal/app/load_session.go
+++ b/cli/internal/app/load_session.go
@@ -569,12 +569,23 @@ func renderPortableReplayDigest(digest domain.MemoryDigest, budget int) string {
 }
 
 func renderSeedDigestWithHeader(digest domain.MemoryDigest, header string, budget int) string {
+	digest = domain.PromptStructuredProjection(digest)
 	if len(header) >= budget {
 		return truncateUTF8Prefix(header, budget)
 	}
 
 	facts := renderSeedBulletSection("Key facts:", seedWorthyFacts(digest.KeyFacts), budget/6)
-	tasks := renderSeedBulletSection("Open tasks:", digest.OpenTasks, budget/4)
+	taskHeading := seedLegacyTasksHeading
+	if digest.TasksAuthoritative {
+		taskHeading = seedAuthoritativeTasksHeading
+	}
+	tasks := renderSeedBulletSection(taskHeading, digest.OpenTasks, budget/4)
+	if digest.TasksAuthoritative && tasks == "" && budget/4 > len(taskHeading) {
+		// Preserve an explicit all-tasks-completed tombstone if this prompt is
+		// later the sole recoverable cxt seed. Unmarked legacy headings are never
+		// upgraded to authority.
+		tasks = taskHeading + "\n"
+	}
 	remaining := budget - len(header) - len(facts) - len(tasks)
 
 	summaryBlock := ""
@@ -713,6 +724,11 @@ func replaceSyntheticSeedSummary(events []domain.Event, seed domain.Event, inser
 
 // `seedSummaryPrefix` is the identifier prefix for seed compression summary events — a marker to find and replace (remove) the previous generation summary in the tail when the next seed is generated. It is removed from materialized copies, while the saved doc remains unchanged.
 const seedSummaryPrefix = "[cxt] This session was resumed from a branch context seed."
+
+const (
+	seedLegacyTasksHeading        = "Open tasks:"
+	seedAuthoritativeTasksHeading = "Open tasks: <!-- cxt:tasks-authoritative-v1 -->"
+)
 
 // prependTrimDigest inserts a CompactSummary event for the omitted history before the recent raw tail.
 // This preserves decisions, constraints, and open tasks within the seed budget. The compact marker drives
@@ -918,7 +934,7 @@ func withoutSyntheticSeedStructuredSections(text string) string {
 		case "Key facts:":
 			section = sectionFacts
 			continue
-		case "Open tasks:":
+		case seedLegacyTasksHeading, seedAuthoritativeTasksHeading:
 			section = sectionTasks
 			continue
 		}
@@ -951,8 +967,13 @@ func syntheticSeedStructuredProjection(text string) (facts, tasks []string, task
 			facts = nil // latest rendered section wins
 			section = sectionFacts
 			continue
-		case "Open tasks:":
-			tasks = nil // an empty latest section is authoritative
+		case seedLegacyTasksHeading:
+			tasks = nil // latest legacy section wins, but remains unattested
+			tasksAuthoritative = false
+			section = sectionTasks
+			continue
+		case seedAuthoritativeTasksHeading:
+			tasks = nil // an empty marked section is an explicit tombstone
 			tasksAuthoritative = true
 			section = sectionTasks
 			continue
@@ -982,15 +1003,7 @@ func syntheticSeedStructuredProjection(text string) (facts, tasks []string, task
 // extracts sentence-form facts from compressed summaries, but legacy stored digests may contain tool-name lists and ingestion markers (empirically observed: "apply_patch", "unknown:Agent", "native memory: …") —
 // excluding whitespace-free single tokens and marker prefixes, only sentence-form facts pass.
 func seedWorthyFacts(facts []string) []string {
-	var out []string
-	for _, f := range facts {
-		t := strings.TrimSpace(f)
-		if t == "" || !strings.Contains(t, " ") || domain.IsNativeMemoryProvenanceFact(t) {
-			continue
-		}
-		out = append(out, t)
-	}
-	return out
+	return domain.PromptWorthyMemoryFacts(facts)
 }
 
 // loadMemory performs memory-form restoration: native-first ingestion → distillation → provider memory file injection.

--- a/cli/internal/app/memorize.go
+++ b/cli/internal/app/memorize.go
@@ -802,6 +802,10 @@ const memoryCarryListBudgetBytes = 64 << 10
 // >256KiB native memory or newly generated summary would be lossy on its first
 // storage and there would be no full ancestor object to recover it from.
 func boundCarriedDigest(d domain.MemoryDigest) domain.MemoryDigest {
+	// A carried digest becomes future provider context. Keep immutable archive
+	// objects untouched, but do not copy legacy tool facts or unattested task
+	// unions into another active generation.
+	d = domain.PromptStructuredProjection(d)
 	// Legacy memories can contain recursively materialized cxt seed summaries.
 	// They remain immutable on their ancestor snapshots, but must not be copied
 	// into the active projection again. Structured facts/tasks are retained and

--- a/cli/internal/app/memory_lineage_test.go
+++ b/cli/internal/app/memory_lineage_test.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"errors"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -901,9 +902,10 @@ func TestBoundCarriedDigestKeepsNewestTail(t *testing.T) {
 	}
 
 	big := domain.MemoryDigest{
-		Summary:   "OLDEST-GENERATION-HEAD\n" + strings.Repeat("m", 2*memoryCarryBudgetBytes) + "\nNEWEST-GENERATION-TAIL",
-		KeyFacts:  []string{"fact stays"},
-		OpenTasks: []string{"task stays"},
+		Summary:            "OLDEST-GENERATION-HEAD\n" + strings.Repeat("m", 2*memoryCarryBudgetBytes) + "\nNEWEST-GENERATION-TAIL",
+		KeyFacts:           []string{"fact stays"},
+		OpenTasks:          []string{"task stays"},
+		TasksAuthoritative: true,
 	}
 	got := boundCarriedDigest(big)
 	if len(got.Summary) > memoryCarryBudgetBytes {
@@ -952,10 +954,11 @@ func TestBoundCarriedDigestDropsNestedSeedNarrativeButKeepsStructure(t *testing.
 		KeyFacts:   []string{"The immutable parent rule remains in force."},
 		OpenTasks:  []string{"Verify the clean projection."},
 		Fragments: []domain.MemoryFragment{{
-			SourceSnapshot: source,
-			Summary:        "project history\n" + seedSummaryPrefix + " 99 events omitted\nrecursive history",
-			KeyFacts:       []string{"The immutable parent rule remains in force."},
-			OpenTasks:      []string{"Verify the clean projection."},
+			SourceSnapshot:     source,
+			Summary:            "project history\n" + seedSummaryPrefix + " 99 events omitted\nrecursive history",
+			KeyFacts:           []string{"The immutable parent rule remains in force."},
+			OpenTasks:          []string{"Verify the clean projection."},
+			TasksAuthoritative: true,
 		}},
 	}
 	carried := boundCarriedDigest(prior)
@@ -984,14 +987,49 @@ func TestBoundedCarryDoesNotTruncateFreshDigest(t *testing.T) {
 
 func TestBoundCarriedDigestBoundsStructuredListsFromNewestTail(t *testing.T) {
 	d := domain.MemoryDigest{
-		KeyFacts:  []string{"old-fact", strings.Repeat("f", memoryCarryListBudgetBytes), "new-fact"},
-		OpenTasks: []string{"old-task", strings.Repeat("t", memoryCarryListBudgetBytes), "new-task"},
+		KeyFacts:           []string{"old fact remains", strings.Repeat("oversized fact ", memoryCarryListBudgetBytes), "new fact remains"},
+		OpenTasks:          []string{"old task remains", strings.Repeat("oversized task ", memoryCarryListBudgetBytes), "new task remains"},
+		TasksAuthoritative: true,
 	}
 	got := boundCarriedDigest(d)
-	if len(got.KeyFacts) != 1 || got.KeyFacts[0] != "new-fact" {
+	if len(got.KeyFacts) != 1 || got.KeyFacts[0] != "new fact remains" {
 		t.Fatalf("facts carry = %v, want newest tail", got.KeyFacts)
 	}
-	if len(got.OpenTasks) != 1 || got.OpenTasks[0] != "new-task" {
+	if len(got.OpenTasks) != 1 || got.OpenTasks[0] != "new task remains" {
 		t.Fatalf("tasks carry = %v, want newest tail", got.OpenTasks)
+	}
+}
+
+func TestBoundCarriedDigestSanitizesFragmentStructuredState(t *testing.T) {
+	ancestorID := domain.ContentHash("sha256:" + strings.Repeat("c", 64))
+	currentID := domain.ContentHash("sha256:" + strings.Repeat("d", 64))
+	prior := domain.MemoryDigest{Fragments: []domain.MemoryFragment{
+		{
+			SourceSnapshot: ancestorID,
+			Summary:        "archived ancestor summary",
+			KeyFacts:       []string{"apply_patch", "The immutable parent contract remains active."},
+			OpenTasks:      []string{"Already completed fallback task."},
+		},
+		{
+			SourceSnapshot:     currentID,
+			Summary:            "current provider baseline",
+			OpenTasks:          []string{"Verify the authoritative carry projection."},
+			TasksAuthoritative: true,
+		},
+	}}
+	prior = domain.MergeDigests(domain.MemoryDigest{}, prior)
+
+	got := boundCarriedDigest(prior)
+	if !reflect.DeepEqual(got.KeyFacts, []string{"The immutable parent contract remains active."}) {
+		t.Fatalf("carried facts = %v", got.KeyFacts)
+	}
+	if !reflect.DeepEqual(got.OpenTasks, []string{"Verify the authoritative carry projection."}) {
+		t.Fatalf("carried tasks = %v", got.OpenTasks)
+	}
+	if len(got.Fragments[0].OpenTasks) != 0 {
+		t.Fatalf("non-authoritative task survived carry: %#v", got.Fragments[0])
+	}
+	if len(prior.Fragments[0].OpenTasks) != 1 || prior.Fragments[0].KeyFacts[0] != "apply_patch" {
+		t.Fatalf("carry projection mutated stored digest: %#v", prior.Fragments[0])
 	}
 }

--- a/cli/internal/app/seed_digest_test.go
+++ b/cli/internal/app/seed_digest_test.go
@@ -425,7 +425,6 @@ func TestPortableReplaySeedCarriesExistingSyntheticMemoryBeforeReplacement(t *te
 		"PORTABLE PROVIDER BASELINE",
 		"SOLE SURVIVING PROJECT MEMORY",
 		"Preserve the only prior decision.",
-		"Verify replacement without recursion.",
 	} {
 		if got := strings.Count(text, want); got != 1 {
 			t.Fatalf("portable replacement count(%q)=%d, want one:\n%s", want, got, text)
@@ -433,6 +432,9 @@ func TestPortableReplaySeedCarriesExistingSyntheticMemoryBeforeReplacement(t *te
 	}
 	if got := strings.Count(text, seedSummaryPrefix); got != 1 {
 		t.Fatalf("portable replacement retained %d recursive seed markers, want one:\n%s", got, text)
+	}
+	if strings.Contains(text, "Verify replacement without recursion.") {
+		t.Fatalf("unmarked legacy seed task was re-attested:\n%s", text)
 	}
 }
 
@@ -716,14 +718,46 @@ func TestInsertTrimDigestProjectsExistingSeedWithoutStoredMemory(t *testing.T) {
 		"fresh omitted conversation",
 		"[prior cxt context]",
 		"The sole-memory fallback must retain structured decisions.",
-		"Verify the memoryless replay path.",
 	} {
 		if !strings.Contains(seedText, want) {
 			t.Fatalf("memoryless projection lost %q:\n%s", want, seedText)
 		}
 	}
+	if strings.Contains(seedText, "Verify the memoryless replay path.") {
+		t.Fatalf("memoryless recovery re-attested an unmarked legacy task:\n%s", seedText)
+	}
 	if out.Events[0].Locked == nil || out.Events[0].Locked.Blob != "PINNED" {
 		t.Fatalf("memoryless projection changed provider state: %+v", out.Events)
+	}
+}
+
+func TestSyntheticSeedTaskAuthorityRequiresVersionedHeading(t *testing.T) {
+	legacy := "project memory\n\n" + seedLegacyTasksHeading + "\n- Stale legacy task."
+	_, legacyTasks, legacyAuthority := syntheticSeedStructuredProjection(legacy)
+	if legacyAuthority || len(legacyTasks) != 1 {
+		t.Fatalf("legacy parse authority=%v tasks=%v", legacyAuthority, legacyTasks)
+	}
+
+	digest := domain.MemoryDigest{
+		Summary:            "provider memory",
+		OpenTasks:          []string{"Current attested task."},
+		TasksAuthoritative: true,
+	}
+	rendered := renderSeedDigest(digest, 1, 8<<10)
+	if !strings.Contains(rendered, seedAuthoritativeTasksHeading) {
+		t.Fatalf("rendered authoritative seed lacks versioned heading:\n%s", rendered)
+	}
+	_, tasks, authority := syntheticSeedStructuredProjection(rendered)
+	if !authority || len(tasks) != 1 || tasks[0] != "Current attested task." {
+		t.Fatalf("rendered authority round trip=%v tasks=%v", authority, tasks)
+	}
+
+	empty := digest
+	empty.OpenTasks = nil
+	rendered = renderSeedDigest(empty, 1, 8<<10)
+	_, tasks, authority = syntheticSeedStructuredProjection(rendered)
+	if !authority || len(tasks) != 0 {
+		t.Fatalf("empty authoritative tombstone round trip=%v tasks=%v\n%s", authority, tasks, rendered)
 	}
 }
 

--- a/cli/internal/app/seed_trim_test.go
+++ b/cli/internal/app/seed_trim_test.go
@@ -198,7 +198,8 @@ func TestTrimEventsForSeedNeverDropsOversizedLockedCompactionState(t *testing.T)
 func TestRenderSeedDigestIsBoundedAndKeepsRecentState(t *testing.T) {
 	const budget = 8 << 10
 	digest := domain.MemoryDigest{
-		Summary: strings.Repeat("résumé history ", 5000) + "\nLATEST DECISION: continue from the public repository.",
+		Summary:            strings.Repeat("résumé history ", 5000) + "\nLATEST DECISION: continue from the public repository.",
+		TasksAuthoritative: true,
 		KeyFacts: []string{
 			"the restored session must use the target working directory",
 		},
@@ -225,6 +226,31 @@ func TestRenderSeedDigestIsBoundedAndKeepsRecentState(t *testing.T) {
 	}
 	if !strings.Contains(got, "earlier summary omitted") {
 		t.Fatal("large summary was not visibly truncated")
+	}
+}
+
+func TestRenderSeedDigestOmitsUnattestedStructuredArchiveState(t *testing.T) {
+	digest := domain.MemoryDigest{
+		SnapshotID: domain.ContentHash("sha256:" + strings.Repeat("e", 64)),
+		Summary:    "provider summary remains visible",
+		KeyFacts: []string{
+			"apply_patch",
+			"The provider prompt keeps this project fact.",
+		},
+		OpenTasks: []string{
+			"Completed fallback task must not be injected.",
+		},
+	}
+	got := renderSeedDigest(digest, 10, 8<<10)
+	for _, forbidden := range []string{"apply_patch", "Completed fallback task"} {
+		if strings.Contains(got, forbidden) {
+			t.Fatalf("seed rendered unattested archive state %q:\n%s", forbidden, got)
+		}
+	}
+	for _, want := range []string{"provider summary remains visible", "The provider prompt keeps this project fact."} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("seed lost %q:\n%s", want, got)
+		}
 	}
 }
 

--- a/cli/internal/domain/memory_prompt.go
+++ b/cli/internal/domain/memory_prompt.go
@@ -1,0 +1,119 @@
+package domain
+
+import "strings"
+
+// PromptStructuredProjection returns the provider-visible structured state of
+// a memory digest without mutating its immutable archival representation.
+//
+// Summaries remain lossless and provenance fragments remain addressable. Facts
+// are filtered to project knowledge, while tasks are emitted only from a
+// provider-attested structured extraction. Extractive/legacy task lists are
+// retained in storage for inspection but cannot become instructions in a
+// future load, branch seed, managed memory file, or carried generation.
+func PromptStructuredProjection(d MemoryDigest) MemoryDigest {
+	out := d
+	if len(d.Fragments) == 0 {
+		out.KeyFacts = PromptWorthyMemoryFacts(d.KeyFacts)
+		if d.TasksAuthoritative {
+			out.OpenTasks = promptWorthyMemoryTasks(d.OpenTasks, memoryItemSet(out.KeyFacts))
+		} else {
+			out.OpenTasks = nil
+		}
+		return out
+	}
+
+	out.Fragments = make([]MemoryFragment, len(d.Fragments))
+	out.TasksAuthoritative = false
+	factSet := make(map[string]struct{})
+	for i, source := range d.Fragments {
+		fragment := source
+		fragment.KeyFacts = PromptWorthyMemoryFacts(source.KeyFacts)
+		fragment.OpenTasks = nil
+		out.Fragments[i] = fragment
+		for key := range memoryItemSet(fragment.KeyFacts) {
+			factSet[key] = struct{}{}
+		}
+	}
+	for i, source := range d.Fragments {
+		if source.TasksAuthoritative {
+			out.TasksAuthoritative = true
+			out.Fragments[i].OpenTasks = promptWorthyMemoryTasks(source.OpenTasks, factSet)
+		}
+	}
+	renderMemoryFragments(&out)
+	return out
+}
+
+// PromptWorthyMemoryFacts is the shared filter for structured project facts
+// rendered into provider-controlled context. Older distillers stored tool
+// tokens and source-provenance labels alongside facts; those remain in the
+// archive but are not useful project knowledge.
+func PromptWorthyMemoryFacts(facts []string) []string {
+	out := make([]string, 0, len(facts))
+	seen := make(map[string]struct{}, len(facts))
+	for _, fact := range facts {
+		item := strings.TrimSpace(fact)
+		if !promptWorthyMemoryItem(item) {
+			continue
+		}
+		key := strings.ToLower(item)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, item)
+	}
+	return out
+}
+
+func promptWorthyMemoryTasks(tasks []string, facts map[string]struct{}) []string {
+	out := make([]string, 0, len(tasks))
+	seen := make(map[string]struct{}, len(tasks))
+	for _, task := range tasks {
+		item := strings.TrimSpace(task)
+		if !promptWorthyMemoryItem(item) {
+			continue
+		}
+		key := strings.ToLower(item)
+		if _, duplicateFact := facts[key]; duplicateFact {
+			continue
+		}
+		if _, duplicateTask := seen[key]; duplicateTask {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, item)
+	}
+	return out
+}
+
+func memoryItemSet(items []string) map[string]struct{} {
+	out := make(map[string]struct{}, len(items))
+	for _, item := range items {
+		out[strings.ToLower(strings.TrimSpace(item))] = struct{}{}
+	}
+	return out
+}
+
+func promptWorthyMemoryItem(item string) bool {
+	if item == "" || !strings.ContainsAny(item, " \t\n") || IsNativeMemoryProvenanceFact(item) {
+		return false
+	}
+	lower := strings.ToLower(item)
+	for _, prefix := range []string{
+		"[cxt] this session was resumed from a branch context seed.",
+		"[cxt seed] branch-switch context:",
+		"<environment_context",
+		"<turn_aborted",
+		"conversation digest (extractive fallback;",
+		"recent user intent:",
+		"recent assistant outcomes:",
+		"session summary:",
+		"tools [",
+	} {
+		if strings.HasPrefix(lower, prefix) {
+			return false
+		}
+	}
+	return true
+}

--- a/cli/internal/domain/merge_digests_test.go
+++ b/cli/internal/domain/merge_digests_test.go
@@ -192,6 +192,120 @@ func TestWithoutExactSummaryBaselinePreservesDeltasAndUnrelatedFragments(t *test
 	}
 }
 
+func TestPromptStructuredProjectionKeepsOnlyAttestedPromptState(t *testing.T) {
+	ancestorID := ContentHash("sha256:" + strings.Repeat("4", 64))
+	currentID := ContentHash("sha256:" + strings.Repeat("5", 64))
+	latestID := ContentHash("sha256:" + strings.Repeat("6", 64))
+	digest := MemoryDigest{
+		SnapshotID: latestID,
+		Provider:   ProviderCodex,
+		Fragments: []MemoryFragment{
+			{
+				SourceSnapshot: ancestorID,
+				Summary:        "PROVIDER BASELINE",
+				KeyFacts: []string{
+					"Overlay graft parents remain immutable.",
+					"apply_patch",
+					"native memory: claude:MEMORY.md",
+				},
+				OpenTasks: []string{
+					"Completed task from an extractive fallback.",
+					"<environment_context>runtime state</environment_context>",
+				},
+			},
+			{
+				SourceSnapshot: currentID,
+				Summary:        "CURRENT PROVIDER STATE",
+				KeyFacts:       []string{"The prompt projection must preserve valid project facts."},
+				OpenTasks: []string{
+					"Fix the remaining authoritative task.",
+					"Overlay graft parents remain immutable.",
+					"continue",
+					"[cxt] This session was resumed from a branch context seed.",
+				},
+				TasksAuthoritative: true,
+			},
+			{
+				SourceSnapshot: latestID,
+				KeyFacts:       []string{"A later non-authoritative fact is still useful project knowledge."},
+				OpenTasks:      []string{"A later fallback must not revive stale tasks."},
+			},
+		},
+	}
+	digest = MergeDigests(MemoryDigest{}, digest)
+	original := cloneMemoryDigestForTest(digest)
+
+	got := PromptStructuredProjection(digest)
+	if !reflect.DeepEqual(got.KeyFacts, []string{
+		"Overlay graft parents remain immutable.",
+		"The prompt projection must preserve valid project facts.",
+		"A later non-authoritative fact is still useful project knowledge.",
+	}) {
+		t.Fatalf("prompt facts = %#v", got.KeyFacts)
+	}
+	if !reflect.DeepEqual(got.OpenTasks, []string{"Fix the remaining authoritative task."}) {
+		t.Fatalf("prompt tasks = %#v", got.OpenTasks)
+	}
+	if len(got.Fragments) != 3 || len(got.Fragments[0].OpenTasks) != 0 ||
+		!reflect.DeepEqual(got.Fragments[1].OpenTasks, got.OpenTasks) || len(got.Fragments[2].OpenTasks) != 0 {
+		t.Fatalf("projected fragment tasks = %#v", got.Fragments)
+	}
+	for _, want := range []string{"PROVIDER BASELINE", "CURRENT PROVIDER STATE"} {
+		if !strings.Contains(got.Summary, want) {
+			t.Fatalf("prompt projection lost summary %q:\n%s", want, got.Summary)
+		}
+	}
+	if !reflect.DeepEqual(digest, original) {
+		t.Fatal("prompt projection mutated the stored digest")
+	}
+}
+
+func TestPromptStructuredProjectionPreservesAuthoritativeEmptyTaskTombstone(t *testing.T) {
+	ids := []ContentHash{
+		ContentHash("sha256:" + strings.Repeat("7", 64)),
+		ContentHash("sha256:" + strings.Repeat("8", 64)),
+		ContentHash("sha256:" + strings.Repeat("9", 64)),
+	}
+	digest := MemoryDigest{Fragments: []MemoryFragment{
+		{SourceSnapshot: ids[0], OpenTasks: []string{"Previously active task."}, TasksAuthoritative: true},
+		{SourceSnapshot: ids[1], OpenTasks: []string{"Unattested fallback task."}},
+		{SourceSnapshot: ids[2], TasksAuthoritative: true},
+	}}
+	digest = MergeDigests(MemoryDigest{}, digest)
+
+	got := PromptStructuredProjection(digest)
+	if len(got.OpenTasks) != 0 {
+		t.Fatalf("authoritative empty task state revived ancestors: %v", got.OpenTasks)
+	}
+	if len(got.Fragments) != 3 || !got.Fragments[2].TasksAuthoritative {
+		t.Fatalf("authoritative tombstone lost: %#v", got.Fragments)
+	}
+
+	legacy := MemoryDigest{OpenTasks: []string{"Ambiguous legacy task must stay archived."}}
+	if projected := PromptStructuredProjection(legacy); len(projected.OpenTasks) != 0 {
+		t.Fatalf("ambiguous legacy tasks entered prompt: %v", projected.OpenTasks)
+	}
+	authoritative := MemoryDigest{
+		OpenTasks:          []string{"Current attested task remains."},
+		TasksAuthoritative: true,
+	}
+	if projected := PromptStructuredProjection(authoritative); !reflect.DeepEqual(projected.OpenTasks, authoritative.OpenTasks) {
+		t.Fatalf("attested legacy task projection = %v", projected.OpenTasks)
+	}
+}
+
+func cloneMemoryDigestForTest(d MemoryDigest) MemoryDigest {
+	out := d
+	out.KeyFacts = append([]string(nil), d.KeyFacts...)
+	out.OpenTasks = append([]string(nil), d.OpenTasks...)
+	out.Fragments = append([]MemoryFragment(nil), d.Fragments...)
+	for i := range out.Fragments {
+		out.Fragments[i].KeyFacts = append([]string(nil), d.Fragments[i].KeyFacts...)
+		out.Fragments[i].OpenTasks = append([]string(nil), d.Fragments[i].OpenTasks...)
+	}
+	return out
+}
+
 func TestWithoutAutoLoadedSummaryPrefixKeepsNativeTail(t *testing.T) {
 	id := ContentHash("sha256:" + strings.Repeat("4", 64))
 	const (

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -359,6 +359,17 @@ kept as the long-term baseline, and meaningful user/assistant turns after that
 baseline are attached as a deterministic bounded conversation delta. Repeated
 baseline text is rendered once across merged lineage fragments.
 
+Immutable memory objects retain their original structured fields for audit and
+recovery. Before cxt places those fields in a provider prompt, branch seed,
+managed memory file, MCP response, or a carried generation, it creates a
+non-mutating prompt projection. Legacy tool/provenance entries are omitted, and
+an `open_tasks` list is treated as active work only when it came from a
+provider-structured extraction. Extractive or legacy task lists remain in the
+archive but are not reintroduced as instructions. A versioned hidden marker in
+new cxt seed text preserves authoritative task lists and explicit empty task
+tombstones during memoryless recovery; unmarked historical seed sections are
+never promoted to authority retroactively.
+
 ## Synchronization
 
 ### `cxt push`


### PR DESCRIPTION
Closes #104.

## Root cause

Fragment-backed digests reconstruct structured fields from fragments, so filtering only the top-level KeyFacts before merge had no effect. Non-authoritative OpenTasks were unioned forever and every prompt-facing renderer consumed the raw compatibility fields. Legacy synthetic seeds could also re-attest an unmarked task section during memoryless recovery.

## Fix

- add one non-mutating domain projection for provider-visible structured memory
- preserve immutable summaries/fragments while filtering tool/provenance facts
- emit tasks only after provider-structured authority, including empty tombstones
- apply the projection to carry, load/resume seeds, branch seeds, managed memory, and MCP
- version authoritative task headings in new cxt seeds; never promote unmarked legacy headings
- document the archive-versus-prompt contract

## Verification

- focused authority/projection tests, 20 repetitions
- CLI test, vet, race
- backend default and postgres-tag test/vet
- web audit, i18n, Vercel check, typecheck, build
- core frontend frozen-lock typecheck
- basic E2E and sync E2E
- public tree and deploy static preflights