### PR TITLE
Collapse recursive compaction memory

### DIFF
--- a/cli/internal/adapters/memory/distiller.go
+++ b/cli/internal/adapters/memory/distiller.go
@@ -41,14 +41,16 @@ func (d *RuleDistiller) Distill(_ context.Context, cir domain.CIRDocument, nativ
 	for i, ev := range cir.Events {
 		switch ev.Kind {
 		case domain.EventMessage:
-			if ev.CompactSummary && len(ev.Blocks) > 0 && ev.Blocks[0].Text != "" &&
+			if ev.CompactSummary && len(ev.Blocks) > 0 && ev.Blocks[0].Text != "" {
 				// cxt-synthesized seed digests carry the CompactSummary marking but
 				// are bounded copies of inherited memory, not the agent's cumulative
 				// compression — promoting one here would source memorize from
 				// boilerplate and mislabel it as agent-written (#38).
-				!containsSyntheticSeedText(ev.Blocks[0].Text) {
-				compactSummary = ev.Blocks[0].Text // last wins: newest cumulative summary
-				compactSummaryAt = i
+				candidate := domain.LatestProviderCompactionGeneration(ev.Blocks[0].Text)
+				if !containsSyntheticSeedText(candidate) {
+					compactSummary = candidate // last wins: newest cumulative summary
+					compactSummaryAt = i
+				}
 			}
 			if ev.Role == "user" {
 				userMsgs++

--- a/cli/internal/adapters/memory/distiller_test.go
+++ b/cli/internal/adapters/memory/distiller_test.go
@@ -80,11 +80,41 @@ func TestDistillRejectsAgentSummaryContainingNestedSeed(t *testing.T) {
 	}
 }
 
+func TestDistillAcceptsCleanLatestGenerationAfterSyntheticOlderGeneration(t *testing.T) {
+	old := `This session is being continued from a previous conversation.
+
+Summary:
+[cxt] This session was resumed from a branch context seed. 200 events were omitted.
+old inherited summary`
+	latest := `This session is being continued from a previous conversation.
+
+Summary:
+1. Primary Request and Intent:
+   Current provider request.
+2. Key Technical Concepts:
+   - Current provider fact remains.
+7. Pending Tasks:
+   - Current provider task remains.`
+	d := distillWithSummary(t, old+"\n\n"+latest)
+	if strings.Contains(d.Summary, "old inherited summary") || !strings.Contains(d.Summary, "Current provider request") {
+		t.Fatalf("clean latest provider generation was not selected:\n%s", d.Summary)
+	}
+	if !d.TasksAuthoritative || len(d.OpenTasks) != 1 || d.OpenTasks[0] != "Current provider task remains." {
+		t.Fatalf("latest provider structure = authority:%v tasks:%v", d.TasksAuthoritative, d.OpenTasks)
+	}
+}
+
 // TestDistillExtractsStructuredFacts fixes distillation extraction:
 // KeyFacts ← "Key Technical Concepts" top-level bullet (last occurrence, emphasis markers removed),
 // OpenTasks ← "Pending Tasks" bullet. Tool name is not mixed with KeyFacts.
 func TestDistillExtractsStructuredFacts(t *testing.T) {
 	d := distillWithSummary(t, structuredSummary)
+	if count := strings.Count(d.Summary, "This session is being continued from a previous conversation."); count != 1 {
+		t.Fatalf("cumulative provider summary generations = %d, want 1:\n%s", count, d.Summary)
+	}
+	if strings.Contains(d.Summary, "stale fact from older generation") || strings.Contains(d.Summary, "stale task") {
+		t.Fatalf("older cumulative provider generation survived:\n%s", d.Summary)
+	}
 
 	if len(d.KeyFacts) != 2 {
 		t.Fatalf("KeyFacts = %d items %v (want 2 — latest generation top-level bullet only)", len(d.KeyFacts), d.KeyFacts)

--- a/cli/internal/app/memory_lineage_test.go
+++ b/cli/internal/app/memory_lineage_test.go
@@ -1033,3 +1033,53 @@ func TestBoundCarriedDigestSanitizesFragmentStructuredState(t *testing.T) {
 		t.Fatalf("carry projection mutated stored digest: %#v", prior.Fragments[0])
 	}
 }
+
+func TestBoundCarriedDigestCollapsesMeasuredCumulativeProviderSummary(t *testing.T) {
+	source := domain.ContentHash("sha256:" + strings.Repeat("e", 64))
+	old := providerContinuationForTest + `
+
+Summary:
+1. Primary Request and Intent:
+   Historical context.
+7. Pending Tasks:
+   - Completed legacy task.`
+	latest := providerContinuationForTest + `
+
+Summary:
+1. Primary Request and Intent:
+   Current context.
+7. Pending Tasks:
+   - Another unattested legacy task.
+8. Current Work:
+   Latest result remains.`
+	digest := domain.MemoryDigest{Fragments: []domain.MemoryFragment{{
+		SourceSnapshot: source,
+		Summary:        strings.Repeat(old+"\n\n", 8) + latest,
+		OpenTasks:      []string{"Another unattested legacy task."},
+	}}}
+	digest = domain.MergeDigests(domain.MemoryDigest{}, digest)
+
+	got := boundCarriedDigest(digest)
+	if strings.Count(got.Summary, providerContinuationForTest) != 1 {
+		t.Fatalf("carried cumulative generations survived:\n%s", got.Summary)
+	}
+	for _, removed := range []string{"Completed legacy task", "Another unattested legacy task"} {
+		if strings.Contains(got.Summary, removed) || containsExact(got.OpenTasks, removed+".") {
+			t.Fatalf("unattested task survived %q:\n%+v", removed, got)
+		}
+	}
+	if !strings.Contains(got.Summary, "Latest result remains.") {
+		t.Fatalf("latest provider result was lost:\n%s", got.Summary)
+	}
+}
+
+const providerContinuationForTest = "This session is being continued from a previous conversation."
+
+func containsExact(items []string, want string) bool {
+	for _, item := range items {
+		if item == want {
+			return true
+		}
+	}
+	return false
+}

--- a/cli/internal/domain/memory_prompt.go
+++ b/cli/internal/domain/memory_prompt.go
@@ -17,6 +17,7 @@ func PromptStructuredProjection(d MemoryDigest) MemoryDigest {
 		if d.TasksAuthoritative {
 			out.OpenTasks = promptWorthyMemoryTasks(d.OpenTasks, memoryItemSet(out.KeyFacts))
 		} else {
+			out.Summary = withoutStructuredTaskNarrative(out.Summary)
 			out.OpenTasks = nil
 		}
 		return out
@@ -24,9 +25,19 @@ func PromptStructuredProjection(d MemoryDigest) MemoryDigest {
 
 	out.Fragments = make([]MemoryFragment, len(d.Fragments))
 	out.TasksAuthoritative = false
+	latestTaskAuthority := -1
+	for i, source := range d.Fragments {
+		if source.TasksAuthoritative {
+			latestTaskAuthority = i
+		}
+	}
 	factSet := make(map[string]struct{})
 	for i, source := range d.Fragments {
 		fragment := source
+		fragment.Summary = LatestProviderCompactionGeneration(source.Summary)
+		if i != latestTaskAuthority {
+			fragment.Summary = withoutStructuredTaskNarrative(fragment.Summary)
+		}
 		fragment.KeyFacts = PromptWorthyMemoryFacts(source.KeyFacts)
 		fragment.OpenTasks = nil
 		out.Fragments[i] = fragment
@@ -40,8 +51,144 @@ func PromptStructuredProjection(d MemoryDigest) MemoryDigest {
 			out.Fragments[i].OpenTasks = promptWorthyMemoryTasks(source.OpenTasks, factSet)
 		}
 	}
+	dropByteContainedProviderSummaries(out.Fragments)
 	renderMemoryFragments(&out)
 	return out
+}
+
+const providerContinuationPrefix = "This session is being continued from a previous conversation"
+
+// LatestProviderCompactionGeneration removes older cumulative generations
+// that some providers embed verbatim inside the next compaction summary. The
+// raw CIR remains immutable; this canonical form is used only for distilled or
+// provider-visible memory. A single occurrence is left byte-for-byte intact so
+// ordinary prose that merely uses the heading cannot be truncated.
+func LatestProviderCompactionGeneration(summary string) string {
+	last, occurrences := -1, 0
+	for offset := 0; offset < len(summary); {
+		end := strings.IndexByte(summary[offset:], '\n')
+		if end < 0 {
+			end = len(summary)
+		} else {
+			end += offset
+		}
+		line := strings.TrimSpace(summary[offset:end])
+		if isProviderContinuationHeader(line) {
+			last = offset
+			occurrences++
+		}
+		if end == len(summary) {
+			break
+		}
+		offset = end + 1
+	}
+	if occurrences < 2 || last < 0 {
+		return summary
+	}
+	return strings.TrimSpace(summary[last:])
+}
+
+func isProviderContinuationHeader(line string) bool {
+	if !strings.HasPrefix(line, providerContinuationPrefix) {
+		return false
+	}
+	rest := strings.TrimPrefix(line, providerContinuationPrefix)
+	switch rest {
+	case ".",
+		" that ran out of context.",
+		" that ran out of context. The summary below covers the earlier portion of the conversation.":
+		return true
+	default:
+		return false
+	}
+}
+
+func withoutStructuredTaskNarrative(summary string) string {
+	if summary == "" {
+		return ""
+	}
+	lines := strings.SplitAfter(summary, "\n")
+	out := make([]string, 0, len(lines))
+	skipping := false
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		title, numbered := numberedMemorySectionTitle(line)
+		if numbered {
+			if isTaskSectionTitle(title) {
+				skipping = true
+				continue
+			}
+			if skipping {
+				skipping = false
+			}
+		} else if skipping && (trimmed == extractiveFallbackDeltaMarker ||
+			trimmed == extractiveFallbackHeader || isProviderContinuationHeader(trimmed)) {
+			skipping = false
+		}
+		if !skipping {
+			out = append(out, line)
+		}
+	}
+	return strings.TrimSpace(strings.Join(out, ""))
+}
+
+func numberedMemorySectionTitle(line string) (string, bool) {
+	line = strings.TrimRight(line, "\r\n")
+	trimmedLeft := strings.TrimLeft(line, " ")
+	if len(line)-len(trimmedLeft) > 3 {
+		return "", false
+	}
+	line = strings.TrimSpace(trimmedLeft)
+	if line == "" || line[0] < '1' || line[0] > '9' {
+		return "", false
+	}
+	i := 1
+	for i < len(line) && line[i] >= '0' && line[i] <= '9' {
+		i++
+	}
+	if i+1 >= len(line) || line[i] != '.' || line[i+1] != ' ' {
+		return "", false
+	}
+	title := strings.ToLower(strings.Trim(strings.TrimSpace(line[i+2:]), "*#: "))
+	return title, true
+}
+
+func isTaskSectionTitle(title string) bool {
+	return title == "pending tasks" || title == "open tasks" ||
+		strings.HasPrefix(title, "pending tasks ") || strings.HasPrefix(title, "open tasks ")
+}
+
+// dropByteContainedProviderSummaries removes only canonical provider
+// continuation summaries whose complete bytes are represented by another
+// fragment. Unique sibling summaries remain independent; equal copies prefer
+// the later fragment for deterministic recency.
+func dropByteContainedProviderSummaries(fragments []MemoryFragment) {
+	for i := range fragments {
+		candidate := strings.TrimSpace(fragments[i].Summary)
+		if candidate == "" || !isCanonicalProviderContinuation(candidate) {
+			continue
+		}
+		for j := range fragments {
+			if i == j {
+				continue
+			}
+			other := strings.TrimSpace(fragments[j].Summary)
+			if len(other) < len(candidate) || !isCanonicalProviderContinuation(other) {
+				continue
+			}
+			if strings.Contains(other, candidate) && (len(other) > len(candidate) || j > i) {
+				fragments[i].Summary = ""
+				break
+			}
+		}
+	}
+}
+
+func isCanonicalProviderContinuation(summary string) bool {
+	if end := strings.IndexByte(summary, '\n'); end >= 0 {
+		summary = summary[:end]
+	}
+	return isProviderContinuationHeader(strings.TrimSpace(summary))
 }
 
 // PromptWorthyMemoryFacts is the shared filter for structured project facts

--- a/cli/internal/domain/memory_prompt_test.go
+++ b/cli/internal/domain/memory_prompt_test.go
@@ -1,0 +1,192 @@
+package domain
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+const providerContinuation = "This session is being continued from a previous conversation."
+
+func TestLatestProviderCompactionGenerationKeepsOnlyNewestCumulativeBlock(t *testing.T) {
+	old := providerContinuation + `
+
+Summary:
+1. Primary Request and Intent:
+   Old request.
+7. Pending Tasks:
+   - Stale task.`
+	latest := "This session is being continued from a previous conversation that ran out of context. The summary below covers the earlier portion of the conversation." + `
+
+Summary:
+1. Primary Request and Intent:
+   Current request.
+7. Pending Tasks:
+   - Current task.
+8. Current Work:
+   Current implementation state.`
+	cumulative := "[... earlier summary omitted ...]\n" + old + "\n\n" + old + "\n\n" + latest
+
+	got := LatestProviderCompactionGeneration(cumulative)
+	if got != latest {
+		t.Fatalf("latest generation mismatch:\n%s", got)
+	}
+	if strings.Contains(got, "Stale task") || strings.Count(got, "This session is being continued") != 1 {
+		t.Fatalf("cumulative generations survived:\n%s", got)
+	}
+
+	single := "Provider prose mentioning the continuation format.\n" + providerContinuation
+	if got := LatestProviderCompactionGeneration(single); got != single {
+		t.Fatalf("single provider block changed: got %q want %q", got, single)
+	}
+}
+
+func TestPromptStructuredProjectionKeepsOnlyLatestAuthoritativeTaskNarrative(t *testing.T) {
+	ids := []ContentHash{
+		ContentHash("sha256:" + strings.Repeat("a", 64)),
+		ContentHash("sha256:" + strings.Repeat("b", 64)),
+		ContentHash("sha256:" + strings.Repeat("c", 64)),
+	}
+	oldSummary := providerContinuation + `
+
+Summary:
+1. Primary Request and Intent:
+   Keep old project history.
+7. Pending Tasks:
+   - Superseded detailed task.
+8. Current Work:
+   Old implementation result remains useful.`
+	unattestedSummary := providerContinuation + `
+
+Summary:
+1. Primary Request and Intent:
+   Keep fallback project history.
+7. Pending Tasks:
+   - Extractive fallback must not become a command.
+8. Current Work:
+   Fallback implementation result remains useful.`
+	currentSummary := providerContinuation + `
+
+Summary:
+1. Primary Request and Intent:
+   Keep current project history.
+7. Pending Tasks:
+   - Current detailed task remains.
+8. Current Work:
+   Current implementation result remains useful.`
+	digest := MemoryDigest{Fragments: []MemoryFragment{
+		{SourceSnapshot: ids[0], Summary: oldSummary, OpenTasks: []string{"Superseded detailed task."}, TasksAuthoritative: true},
+		{SourceSnapshot: ids[1], Summary: unattestedSummary, OpenTasks: []string{"Extractive fallback must not become a command."}},
+		{SourceSnapshot: ids[2], Summary: currentSummary, OpenTasks: []string{"Current detailed task remains."}, TasksAuthoritative: true},
+	}}
+	digest = MergeDigests(MemoryDigest{}, digest)
+	original := cloneMemoryDigestForTest(digest)
+
+	got := PromptStructuredProjection(digest)
+	for _, removed := range []string{"Superseded detailed task", "Extractive fallback must not become a command"} {
+		if strings.Contains(got.Summary, removed) || containsString(got.OpenTasks, removed+".") {
+			t.Fatalf("superseded/unattested task survived %q:\n%+v", removed, got)
+		}
+	}
+	for _, kept := range []string{
+		"Old implementation result remains useful.",
+		"Fallback implementation result remains useful.",
+		"Current detailed task remains.",
+		"Current implementation result remains useful.",
+	} {
+		if !strings.Contains(got.Summary, kept) && !containsString(got.OpenTasks, kept) {
+			t.Fatalf("prompt projection lost %q:\n%+v", kept, got)
+		}
+	}
+	if !reflect.DeepEqual(got.OpenTasks, []string{"Current detailed task remains."}) {
+		t.Fatalf("current task projection = %v", got.OpenTasks)
+	}
+	if !reflect.DeepEqual(digest, original) {
+		t.Fatal("narrative projection mutated immutable digest")
+	}
+}
+
+func TestPromptStructuredProjectionDropsOnlyByteContainedProviderBaseline(t *testing.T) {
+	leftID := ContentHash("sha256:" + strings.Repeat("d", 64))
+	rightID := ContentHash("sha256:" + strings.Repeat("e", 64))
+	base := providerContinuation + `
+
+Summary:
+1. Primary Request and Intent:
+   Shared baseline remains exactly represented.`
+	expanded := base + `
+8. Current Work:
+   Newer exact extension remains.`
+	digest := MemoryDigest{Fragments: []MemoryFragment{
+		{SourceSnapshot: leftID, Summary: base},
+		{SourceSnapshot: rightID, Summary: expanded},
+	}}
+	digest = MergeDigests(MemoryDigest{}, digest)
+
+	got := PromptStructuredProjection(digest)
+	if strings.Count(got.Summary, providerContinuation) != 1 ||
+		strings.Count(got.Summary, "Shared baseline remains exactly represented.") != 1 ||
+		!strings.Contains(got.Summary, "Newer exact extension remains.") {
+		t.Fatalf("contained provider baseline was not losslessly collapsed:\n%s", got.Summary)
+	}
+
+	unique := MemoryDigest{Fragments: []MemoryFragment{
+		{SourceSnapshot: leftID, Summary: providerContinuation + "\n\nSummary:\n1. Left-only decision."},
+		{SourceSnapshot: rightID, Summary: providerContinuation + "\n\nSummary:\n1. Right-only decision."},
+	}}
+	unique = MergeDigests(MemoryDigest{}, unique)
+	projected := PromptStructuredProjection(unique)
+	for _, want := range []string{"Left-only decision.", "Right-only decision."} {
+		if !strings.Contains(projected.Summary, want) {
+			t.Fatalf("unique sibling summary lost %q:\n%s", want, projected.Summary)
+		}
+	}
+}
+
+func TestPromptStructuredProjectionKeepsConversationDeltaAfterStrippedTaskSection(t *testing.T) {
+	base := providerContinuation + `
+
+Summary:
+1. Primary Request and Intent:
+   Project baseline remains.
+7. Pending Tasks:
+   - Unattested task is removed.`
+	summary := AppendExtractiveConversationDelta(base, RenderExtractiveFallbackSummary(
+		[]string{"Recent user decision remains."},
+		[]string{"Recent assistant result remains."},
+	))
+	digest := MemoryDigest{Summary: summary}
+
+	got := PromptStructuredProjection(digest)
+	if strings.Contains(got.Summary, "Unattested task is removed") {
+		t.Fatalf("unattested task narrative survived:\n%s", got.Summary)
+	}
+	for _, want := range []string{
+		"Project baseline remains.", "Recent user decision remains.", "Recent assistant result remains.",
+	} {
+		if !strings.Contains(got.Summary, want) {
+			t.Fatalf("task stripping lost %q:\n%s", want, got.Summary)
+		}
+	}
+}
+
+func TestPromptStructuredProjectionDoesNotTruncateOpaqueLegacyNarrative(t *testing.T) {
+	left := providerContinuation + `
+
+Summary:
+1. Primary Request and Intent:
+   Unique left lineage narrative.`
+	right := providerContinuation + `
+
+Summary:
+1. Primary Request and Intent:
+   Unique right lineage narrative.`
+	legacy := MemoryDigest{Summary: left + "\n\n" + right}
+
+	got := PromptStructuredProjection(legacy)
+	for _, want := range []string{"Unique left lineage narrative.", "Unique right lineage narrative."} {
+		if !strings.Contains(got.Summary, want) {
+			t.Fatalf("opaque legacy projection lost %q:\n%s", want, got.Summary)
+		}
+	}
+}

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -370,6 +370,17 @@ new cxt seed text preserves authoritative task lists and explicit empty task
 tombstones during memoryless recovery; unmarked historical seed sections are
 never promoted to authority retroactively.
 
+Provider compaction summaries can themselves be cumulative and contain prior
+continuation generations verbatim. Fresh distillation keeps only the latest
+recognized generation, while inherited provenance fragments receive the same
+non-mutating prompt projection. Detailed `Pending Tasks` narrative is retained
+only for the latest authoritative task fragment; older or unattested task
+sections remain recoverable from their immutable memory/CIR objects but do not
+enter active context. Distinct sibling summaries are kept, and containment
+deduplication applies only when one canonical provider summary contains the
+other byte-for-byte. Opaque legacy digests without fragment provenance are not
+generation-truncated.
+
 ## Synchronization
 
 ### `cxt push`


### PR DESCRIPTION
Closes #106.

## Root cause

Provider compaction summaries can contain prior continuation generations verbatim. The distiller stored the cumulative text byte-for-byte, fragment rendering deduplicated only whole summaries, and the 256 KiB carry cap retained a repeated tail. Dogfood measured 248,492 carried bytes and 12 copies of already-completed task text after structured fields were cleaned.

## Fix

- canonicalize fresh provider compaction to its latest recognized continuation generation
- accept a clean latest generation even when an older dropped generation contains a synthetic cxt seed
- apply the projection non-destructively to inherited provenance fragments
- retain detailed task narrative only for the latest authoritative task fragment
- preserve extractive conversation deltas after stripped task sections
- remove only byte-contained canonical provider summaries; retain unique siblings
- never generation-truncate opaque legacy digests without fragment provenance

## Dogfood projection

Against the real polluted memory, the new binary returned a 10,530-byte MCP view with zero copies of the two stale UI tasks and no Pending/Open task heading. The source memory object remained unchanged.

## Verification

- measured cumulative fixture and authority/containment regressions, 20 repetitions
- CLI full test, vet, race
- backend default and postgres-tag test/vet
- web audit, i18n, Vercel, typecheck, build
- core frontend frozen-lock typecheck
- basic E2E and sync E2E
- public tree and deploy static preflights