### PR TITLE
Fix graft-reachable branch context history

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,11 +89,12 @@ jobs:
           node-version: "22"
           cache: npm
           cache-dependency-path: frontend/web/package-lock.json
-      - name: install · i18n check · typecheck · build
+      - name: install · unit test · i18n check · typecheck · build
         working-directory: frontend/web
         run: |
           npm ci
           npm audit --audit-level=high
+          npm test
           npm run check:i18n
           npm run check:vercel
           npx tsc --noEmit -p ../tsconfig.json

--- a/Makefile
+++ b/Makefile
@@ -30,9 +30,10 @@ install: ## Install cxt + cxtd using go install (GOPATH/bin)
 	cd backend && $(GO) install ./cmd/cxtd
 
 .PHONY: test
-test: ## Run unit tests for both Go modules
+test: ## Run unit tests for the CLI, backend, and web UI
 	cd cli && $(GO) test ./...
 	cd backend && $(GO) test ./...
+	cd frontend/web && npm test
 
 .PHONY: test-postgres
 test-postgres: ## Compile with the postgres tag and run the PG smoke test when configured

--- a/frontend/web/package.json
+++ b/frontend/web/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc --noEmit && vite build",
+    "test": "node scripts/run-unit-tests.mjs",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
     "check:i18n": "node scripts/check-i18n.mjs",

--- a/frontend/web/scripts/run-unit-tests.mjs
+++ b/frontend/web/scripts/run-unit-tests.mjs
@@ -1,0 +1,40 @@
+import { readdir } from 'node:fs/promises';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import path from 'node:path';
+import { build } from 'esbuild';
+
+const projectRoot = fileURLToPath(new URL('..', import.meta.url));
+const testsRoot = path.join(projectRoot, 'tests');
+
+async function collectTests(dir) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const target = path.join(dir, entry.name);
+    if (entry.isDirectory()) files.push(...(await collectTests(target)));
+    else if (entry.name.endsWith('.test.ts')) files.push(target);
+  }
+  return files;
+}
+
+const tests = (await collectTests(testsRoot)).sort();
+if (tests.length === 0) throw new Error(`no frontend unit tests found under ${testsRoot}`);
+
+for (const test of tests) {
+  const result = await build({
+    absWorkingDir: projectRoot,
+    entryPoints: [test],
+    bundle: true,
+    format: 'esm',
+    logLevel: 'silent',
+    platform: 'node',
+    target: 'node20',
+    write: false,
+  });
+  const source = result.outputFiles[0]?.text;
+  if (!source) throw new Error(`esbuild produced no output for ${test}`);
+  const encoded = Buffer.from(`${source}\n//# sourceURL=${pathToFileURL(test).href}`).toString('base64');
+  await import(`data:text/javascript;base64,${encoded}`);
+}
+
+console.log(`frontend unit tests: ${tests.length} passed`);

--- a/frontend/web/src/components/ContextView.tsx
+++ b/frontend/web/src/components/ContextView.tsx
@@ -5,7 +5,7 @@ import { useEffect, useMemo, useState } from 'react';
 import type { Repo, Workspace, CIREvent, Snapshot, Pending } from '../types';
 import { useDoc, useMemory, useMe, useFork, useSnapDiff, useSearch, usePendings, useUnsyncs, useRepoView, useReflog } from '../hooks';
 import { navigate, wsPath } from '../route';
-import { holdCounts, sharedReachable } from '../onhold';
+import { holdCounts, reachableSnapshotIds, sharedReachable } from '../onhold';
 import { usePaged, PageControl } from './Pagination';
 import { mainlineOf, sessionBoundaries, compactionBoundaries } from '../graph';
 import { atLeast, canWriteAsset, type Role } from '../roles';
@@ -106,22 +106,14 @@ export function ContextView({ repo, ws, role }: { repo: Repo; ws: ContextWorkspa
     setBranch(pickDefaultBranch(branches, repo.default_branch));
   }, [repo.id, repo.default_branch, branches]);
 
-  // Branch log = git log <branch> meaning: commits reachable from head to parent chain only (label filter is not included — orphan snapshots created by force/reset are only shown in the graph).
+  // Branch log = git log <branch>: every snapshot reachable through natural or
+  // graft-overlay parents. First-parent/mainline styling remains a separate
+  // concern below; snapshots unreachable from the selected ref stay graph-only.
   const snapshots = useMemo(() => {
     const head = refs.find((r) => r.kind === 'branch' && r.name === branch)?.target;
     if (!head) return [];
-    const byId = new Map(allSnapshots.map((s) => [s.id, s]));
-    const seen = new Set<string>();
-    const queue = [head];
-    while (queue.length > 0) {
-      const id = queue.shift() as string;
-      if (seen.has(id)) continue;
-      const s = byId.get(id);
-      if (!s) continue;
-      seen.add(id);
-      for (const p of s.parents ?? []) queue.push(p);
-    }
-    return allSnapshots.filter((s) => seen.has(s.id));
+    const reachable = reachableSnapshotIds([head], allSnapshots);
+    return allSnapshots.filter((s) => reachable.has(s.id));
   }, [refs, branch, allSnapshots]);
   // Selected branch's main lineage (head's first-parent direct ancestor) — distinguishes merge branches (⎘).
   const mainline = useMemo(() => {

--- a/frontend/web/src/onhold.ts
+++ b/frontend/web/src/onhold.ts
@@ -2,25 +2,33 @@
 // The badge number and the number of rows shown in the tab must match, so a single definition is used.
 import type { Ref, Snapshot, Pending, Unsync } from './types';
 
+/** Snapshot IDs reachable from explicit roots under cxthub's immutable graph
+ *  rule. Natural parents and graft overlay parents are equally valid for
+ *  membership; first-parent presentation is handled separately by graph.ts. */
+export function reachableSnapshotIds(targets: Iterable<string>, snapshots: Snapshot[]): Set<string> {
+  const byId = new Map(snapshots.map((s) => [s.id, s]));
+  const seen = new Set<string>();
+  const stack = [...targets];
+  while (stack.length > 0) {
+    const id = stack.pop() as string;
+    if (!id || seen.has(id)) continue;
+    const s = byId.get(id);
+    if (!s) continue;
+    seen.add(id);
+    for (const p of s.parents ?? []) stack.push(p);
+    for (const g of s.graft_parents ?? []) stack.push(g);
+  }
+  return seen;
+}
+
 /** Shared timeline = a set of snapshots reachable from parent chains in server branch/session refs.
  *  Reachability is the same as on the server: parents ∪ graft_parents — after a graft (diverged append),
  *  the old head chain can only be reached via overlay edges. If not taken, the committed session
  *  will reappear as an uncommitted one, and the graph will show orphaned history before the merge. */
 export function sharedReachable(refs: Ref[], snapshots: Snapshot[]): Set<string> {
-  const byId = new Map(snapshots.map((s) => [s.id, s]));
-  const seen = new Set<string>();
   // session ref preserves residual sessions from partial merges but not git branch membership.
-  const queue = refs.filter((r) => r.kind === 'branch' || r.kind === 'session').map((r) => r.target);
-  while (queue.length > 0) {
-    const id = queue.pop() as string;
-    if (!id || seen.has(id)) continue;
-    const s = byId.get(id);
-    if (!s) continue;
-    seen.add(id);
-    for (const p of s.parents ?? []) queue.push(p);
-    for (const g of s.graft_parents ?? []) queue.push(g);
-  }
-  return seen;
+  const roots = refs.filter((r) => r.kind === 'branch' || r.kind === 'session').map((r) => r.target);
+  return reachableSnapshotIds(roots, snapshots);
 }
 
 /** Push wait cluster — a bunch of unpushed commits linked by chains (parent edges).

--- a/frontend/web/tests/reachability.test.ts
+++ b/frontend/web/tests/reachability.test.ts
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict';
+import { mainlineOf } from '../src/graph.ts';
+import { reachableSnapshotIds, sharedReachable } from '../src/onhold.ts';
+import type { Ref, Snapshot } from '../src/types.ts';
+
+function snapshot(id: string, parents: string[] = [], graftParents: string[] = []): Snapshot {
+  return {
+    id,
+    repo_id: 'repo',
+    branch: 'main',
+    parents,
+    graft_parents: graftParents,
+    doc_hash: id,
+    provider: 'codex',
+    fidelity: 'full',
+    message: id,
+    created_at: '2026-08-28T00:00:00Z',
+  };
+}
+
+const snapshots = [
+  snapshot('unreachable'),
+  snapshot('root'),
+  snapshot('graft-root', [], ['merge']), // cycle must terminate
+  snapshot('natural', ['root']),
+  snapshot('merge', ['natural'], ['graft-root', 'graft-root']),
+  snapshot('head', ['merge']),
+];
+
+assert.deepEqual(
+  [...reachableSnapshotIds(['head'], snapshots)].sort(),
+  ['graft-root', 'head', 'merge', 'natural', 'root'],
+  'branch reachability must include natural and graft parents exactly once',
+);
+assert.deepEqual(
+  [...reachableSnapshotIds(['missing'], snapshots)],
+  [],
+  'missing targets must not manufacture reachable snapshots',
+);
+assert.deepEqual(
+  [...mainlineOf('head', snapshots)],
+  ['head', 'merge', 'natural', 'root'],
+  'first-parent styling must continue to exclude graft side histories',
+);
+
+const refs: Ref[] = [
+  { kind: 'branch', name: 'main', repo_id: 'repo', target: 'head' },
+  { kind: 'session', name: 'remaining', repo_id: 'repo', target: 'graft-root' },
+  { kind: 'tag', name: 'unshared', repo_id: 'repo', target: 'unreachable' },
+];
+assert.equal(sharedReachable(refs, snapshots).has('unreachable'), false, 'tags are not shared timeline roots');

--- a/scripts/deploy-preflight.sh
+++ b/scripts/deploy-preflight.sh
@@ -94,11 +94,12 @@ PY
 
   (
     cd frontend/web
+    npm test
     npm run check:i18n
     npm run check:vercel
     npm run typecheck
   )
-  pass "Web i18n, Vercel, and type checks"
+  pass "Web unit, i18n, Vercel, and type checks"
 
   python3 - "$ROOT/schemas/db/migrations" <<'PY'
 import pathlib, re, sys


### PR DESCRIPTION
Closes #110.

## What changed

- make selected branch context lists walk both natural and graft-overlay parents
- retain first-parent-only `mainlineOf` styling and join semantics
- share one reachability traversal with pending/shared-timeline classification
- add the first executable frontend pure-logic test runner
- require frontend unit tests in CI, `make test`, and deploy preflight

## Reproduction / result

Dogfood `main` before the fix:

- natural-parent-only list: 32 snapshots
- branch-reachable graph: 303 snapshots
- silently omitted from the context list: 271 snapshots

The production helper now returns all 303 branch-reachable snapshots while leaving unreachable objects graph-only.

## Verification

- `npm test`
- `npm audit --audit-level=high`
- web i18n / Vercel / typecheck / production build
- CLI full tests + vet
- backend full FS/Postgres-tag tests + vet
- public tree preflight
- deploy static preflight
- full binary E2E
- sync E2E
- live `.cxt` branch-list count (`303`)
