### PR TITLE
Archive deleted context branches without data loss

### DIFF
--- a/backend/internal/adapters/delivery/http/server.go
+++ b/backend/internal/adapters/delivery/http/server.go
@@ -33,6 +33,7 @@ type Backend interface {
 	Commit(ctx context.Context, in inbound.CommitInput) (inbound.CommitOutput, error)
 	Send(ctx context.Context, in inbound.PullSendInput) (inbound.PullSendOutput, error)
 	UpdateRef(ctx context.Context, in inbound.UpdateRefInput) (inbound.UpdateRefOutput, error)
+	UpdateRefs(ctx context.Context, in inbound.UpdateRefsInput) (inbound.UpdateRefsOutput, error)
 	List(ctx context.Context, in inbound.ListSnapshotsInput) ([]domain.Snapshot, error)
 	Diff(ctx context.Context, in inbound.DiffInput) (inbound.DiffOutput, error)
 	Search(ctx context.Context, in inbound.SearchInput) (inbound.SearchOutput, error)
@@ -160,6 +161,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("GET /api/v1/repos/{repoID}/manifest", s.guard(domain.RoleViewer, s.getManifest))
 	mux.HandleFunc("GET /api/v1/repos/{repoID}/branches", s.guard(domain.RoleViewer, s.listRefs))
 	mux.HandleFunc("GET /api/v1/repos/{repoID}/refs", s.guard(domain.RoleViewer, s.listRefs))
+	mux.HandleFunc("POST /api/v1/repos/{repoID}/refs/batch", s.guard(domain.RoleMember, s.putRefs))
 	mux.HandleFunc("GET /api/v1/repos/{repoID}/snapshots", s.guard(domain.RoleViewer, s.listSnapshots))
 	mux.HandleFunc("GET /api/v1/repos/{repoID}/snapshots/{id}", s.guard(domain.RoleViewer, s.getSnapshot))
 	mux.HandleFunc("POST /api/v1/repos/{repoID}/snapshots/{id}/promote", s.guard(domain.RoleMember, s.promoteSnapshot))
@@ -839,6 +841,35 @@ type putRefBody struct {
 	Append bool `json:"append,omitempty"`
 }
 
+type putRefsBody struct {
+	Updates []struct {
+		Ref    domain.Ref `json:"ref"`
+		Force  bool       `json:"force,omitempty"`
+		Append bool       `json:"append,omitempty"`
+	} `json:"updates"`
+}
+
+func (s *Server) putRefs(w http.ResponseWriter, r *http.Request) {
+	var body putRefsBody
+	if !s.decodeLimited(w, r, &body, inbound.MaxRefBatchJSONBody) {
+		return
+	}
+	if len(body.Updates) > inbound.MaxRefBatchUpdates {
+		s.respond(w, nil, fmt.Errorf("%w: at most %d ref updates per batch", domain.ErrValidation, inbound.MaxRefBatchUpdates))
+		return
+	}
+	rid := s.repoID(r)
+	updates := make([]inbound.UpdateRefInput, 0, len(body.Updates))
+	for _, update := range body.Updates {
+		update.Ref.RepoID = rid
+		updates = append(updates, inbound.UpdateRefInput{
+			RepoID: rid, Ref: update.Ref, Force: update.Force, Append: update.Append,
+		})
+	}
+	out, err := s.b.UpdateRefs(r.Context(), inbound.UpdateRefsInput{RepoID: rid, Updates: updates})
+	s.respond(w, out, err)
+}
+
 // undismissPending re-adds dismissed uncommitted sessions to the list (undo dismiss).
 func (s *Server) undismissPending(w http.ResponseWriter, r *http.Request) {
 	if !isJSONBody(r) { // dismiss and same body-less POST CSRF 2nd defense
@@ -1129,7 +1160,7 @@ func (s *Server) decodeLimited(w http.ResponseWriter, r *http.Request, v any, ma
 	if err := json.NewDecoder(r.Body).Decode(v); err != nil {
 		var tooLarge *http.MaxBytesError
 		if errors.As(err, &tooLarge) {
-			s.writeError(w, http.StatusRequestEntityTooLarge, "payload_too_large", "bounded chunk body exceeds transport limit")
+			s.writeError(w, http.StatusRequestEntityTooLarge, "payload_too_large", "request body exceeds transport limit")
 			return false
 		}
 		s.writeError(w, http.StatusBadRequest, "bad_request", err.Error())
@@ -1163,6 +1194,8 @@ func mapError(err error) (code string, status int) {
 		return "non_fast_forward", http.StatusConflict
 	case errors.Is(err, domain.ErrRefConflict):
 		return "ref_conflict", http.StatusConflict
+	case errors.Is(err, domain.ErrBranchArchived):
+		return "branch_archived", http.StatusConflict
 	case errors.Is(err, domain.ErrUnauthorized):
 		return "unauthenticated", http.StatusUnauthorized
 	case errors.Is(err, domain.ErrForbidden):

--- a/backend/internal/adapters/delivery/http/server_test.go
+++ b/backend/internal/adapters/delivery/http/server_test.go
@@ -518,6 +518,40 @@ func TestPushPullRoundtrip(t *testing.T) {
 		t.Fatalf("ref put code %d", code)
 	}
 
+	// 3b) bounded ref batch: lifecycle event precedes its mutable branch
+	// projection, and a later archive removes only that projection.
+	const batchBranchName = "feature/batch-lifecycle"
+	activeEvent, err := domain.NewBranchLifecycleRef(rid, batchBranchName, h, 1, domain.BranchActive)
+	if err != nil {
+		t.Fatal(err)
+	}
+	batchBranch := domain.Ref{Kind: domain.RefBranch, Name: batchBranchName, RepoID: rid, Target: h}
+	var batchOut inbound.UpdateRefsOutput
+	if code := doJSON(t, "POST", base+"/refs/batch", map[string]any{"updates": []map[string]any{
+		{"ref": activeEvent}, {"ref": batchBranch},
+	}}, &batchOut); code != 200 || batchOut.Applied != 2 {
+		t.Fatalf("ref batch create code=%d out=%+v", code, batchOut)
+	}
+	archiveEvent, err := domain.NewBranchLifecycleRef(rid, batchBranchName, h, 2, domain.BranchArchived)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if code := doJSON(t, "POST", base+"/refs/batch", map[string]any{"updates": []map[string]any{{"ref": archiveEvent}}}, &batchOut); code != 200 || batchOut.Applied != 1 {
+		t.Fatalf("ref batch archive code=%d out=%+v", code, batchOut)
+	}
+	var projectedRefs []domain.Ref
+	if code := doJSON(t, "GET", base+"/refs", nil, &projectedRefs); code != 200 {
+		t.Fatalf("list projected refs code %d", code)
+	}
+	foundArchivedBranch, foundArchiveEvent := false, false
+	for _, ref := range projectedRefs {
+		foundArchivedBranch = foundArchivedBranch || (ref.Kind == domain.RefBranch && ref.Name == batchBranchName)
+		foundArchiveEvent = foundArchiveEvent || ref.Name == archiveEvent.Name
+	}
+	if foundArchivedBranch || !foundArchiveEvent {
+		t.Fatalf("batch archive projection refs=%+v", projectedRefs)
+	}
+
 	// 4) negotiate re-request → no longer want (dedup)
 	var neg2 struct {
 		SnapshotWants []domain.ContentHash `json:"snapshot_wants"`

--- a/backend/internal/adapters/store/branch_lifecycle_test.go
+++ b/backend/internal/adapters/store/branch_lifecycle_test.go
@@ -1,0 +1,179 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/wnsdy95/cxthub/backend/internal/domain"
+)
+
+func TestFSStoreBranchLifecycleBlocksStaleResurrection(t *testing.T) {
+	ctx := context.Background()
+	st := NewFSStore(t.TempDir())
+	repo := rlHash('4')
+	target := rlHash('a')
+	branch := domain.Ref{Kind: domain.RefBranch, Name: "feature/archive", RepoID: repo, Target: target}
+	if err := st.CompareAndSwapRef(ctx, repo, branch, ""); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.CompareAndSwapRef(ctx, repo, domain.Ref{Kind: domain.RefHead, Name: domain.HeadRefName, RepoID: repo, Symbolic: branch.Name}, ""); err != nil {
+		t.Fatal(err)
+	}
+	archive, err := domain.NewBranchLifecycleRef(repo, branch.Name, target, 1, domain.BranchArchived)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.ApplyBranchLifecycleRef(ctx, repo, archive); err != nil {
+		t.Fatalf("apply archive: %v", err)
+	}
+	if _, err := st.GetRef(ctx, repo, domain.RefBranch, branch.Name); !errors.Is(err, domain.ErrNotFound) {
+		t.Fatalf("archived branch still active: %v", err)
+	}
+	if head, err := st.GetRef(ctx, repo, domain.RefHead, domain.HeadRefName); err != nil || head.Symbolic != "" || head.Target != target {
+		t.Fatalf("HEAD was not detached at archived target: %+v, %v", head, err)
+	}
+	reflog, err := st.ReadReflog(ctx, repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	archiveLogged, removalLogged := false, false
+	for _, entry := range reflog {
+		archiveLogged = archiveLogged || (entry.Kind == domain.RefTag && entry.Name == archive.Name && entry.New == target)
+		removalLogged = removalLogged || (entry.Kind == domain.RefBranch && entry.Name == branch.Name && entry.Old == target && entry.New == "")
+	}
+	if !archiveLogged || !removalLogged {
+		t.Fatalf("archive reflog missing tag/removal audit: %+v", reflog)
+	}
+	// Simulate a process crash after the immutable archive tag was written but
+	// before the old branch file was removed.
+	if err := writeAtomic(st.refFile(repo, domain.RefBranch, branch.Name), []byte(string(target)+"\n")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.GetRef(ctx, repo, domain.RefBranch, branch.Name); !errors.Is(err, domain.ErrNotFound) {
+		t.Fatalf("crash residue leaked through GetRef: %v", err)
+	}
+	refs, err := st.ListRefs(ctx, repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, ref := range refs {
+		if ref.Kind == domain.RefBranch && ref.Name == branch.Name {
+			t.Fatalf("crash residue leaked into logical refs: %+v", ref)
+		}
+	}
+	if err := st.CompareAndSwapRef(ctx, repo, branch, ""); !errors.Is(err, domain.ErrBranchArchived) {
+		t.Fatalf("stale branch resurrected: %v", err)
+	}
+	if err := os.Remove(st.refFile(repo, domain.RefBranch, branch.Name)); err != nil {
+		t.Fatal(err)
+	}
+
+	active, err := domain.NewBranchLifecycleRef(repo, branch.Name, target, 2, domain.BranchActive)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.ApplyBranchLifecycleRef(ctx, repo, active); err != nil {
+		t.Fatalf("apply active: %v", err)
+	}
+	if err := st.CompareAndSwapRef(ctx, repo, branch, ""); err != nil {
+		t.Fatalf("explicit restore rejected: %v", err)
+	}
+}
+
+func TestFSStoreArchivePreservesAdvancedBranchWithCompensatingEvent(t *testing.T) {
+	ctx := context.Background()
+	st := NewFSStore(t.TempDir())
+	repo := rlHash('5')
+	oldTarget, advancedTarget := rlHash('a'), rlHash('b')
+	branch := domain.Ref{Kind: domain.RefBranch, Name: "feature/live", RepoID: repo, Target: advancedTarget}
+	if err := st.CompareAndSwapRef(ctx, repo, branch, ""); err != nil {
+		t.Fatal(err)
+	}
+	archive, err := domain.NewBranchLifecycleRef(repo, branch.Name, oldTarget, 1, domain.BranchArchived)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.ApplyBranchLifecycleRef(ctx, repo, archive); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := st.GetRef(ctx, repo, domain.RefBranch, branch.Name); err != nil || got.Target != advancedTarget {
+		t.Fatalf("advanced branch changed: %+v, %v", got, err)
+	}
+	refs, err := st.ListRefs(ctx, repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	latest, ok, err := domain.LatestBranchLifecycle(refs, branch.Name)
+	if err != nil || !ok || latest.State != domain.BranchActive || latest.Generation != 2 || latest.Target != advancedTarget {
+		t.Fatalf("compensating event = %+v, %v, %v", latest, ok, err)
+	}
+}
+
+func TestFSStoreCASRepairsLifecycleBeforeMovingAdvancedArchiveResidue(t *testing.T) {
+	ctx := context.Background()
+	st := NewFSStore(t.TempDir())
+	repo := rlHash('6')
+	archivedTarget, advancedTarget, nextTarget := rlHash('a'), rlHash('b'), rlHash('c')
+	const branchName = "feature/recovered"
+
+	// Simulate a crash/interleaving in which the immutable archive event and an
+	// already-advanced physical branch exist without the active compensation
+	// normally written by ApplyBranchLifecycleRef.
+	archive, err := domain.NewBranchLifecycleRef(repo, branchName, archivedTarget, 1, domain.BranchArchived)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := writeAtomic(st.refFile(repo, domain.RefTag, archive.Name), []byte(string(archive.Target)+"\n")); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeAtomic(st.refFile(repo, domain.RefBranch, branchName), []byte(string(advancedTarget)+"\n")); err != nil {
+		t.Fatal(err)
+	}
+
+	next := domain.Ref{Kind: domain.RefBranch, Name: branchName, RepoID: repo, Target: nextTarget}
+	if err := st.CompareAndSwapRef(ctx, repo, next, advancedTarget); err != nil {
+		t.Fatalf("move advanced residue: %v", err)
+	}
+	got, err := st.GetRef(ctx, repo, domain.RefBranch, branchName)
+	if err != nil || got.Target != nextTarget {
+		t.Fatalf("moved branch = %+v, %v", got, err)
+	}
+	refs, err := st.listRefsRaw(ctx, repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	latest, ok, err := domain.LatestBranchLifecycle(refs, branchName)
+	if err != nil || !ok || latest.State != domain.BranchActive || latest.Generation != 2 || latest.Target != advancedTarget {
+		t.Fatalf("recovery event = %+v, %v, %v", latest, ok, err)
+	}
+}
+
+func TestFSStoreProjectsSymbolicHEADAfterInterruptedArchive(t *testing.T) {
+	ctx := context.Background()
+	st := NewFSStore(t.TempDir())
+	repo, target := rlHash('7'), rlHash('d')
+	const branchName = "feature/interrupted-head"
+	branch := domain.Ref{Kind: domain.RefBranch, Name: branchName, RepoID: repo, Target: target}
+	if err := st.CompareAndSwapRef(ctx, repo, branch, ""); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.CompareAndSwapRef(ctx, repo, domain.Ref{Kind: domain.RefHead, Name: domain.HeadRefName, RepoID: repo, Symbolic: branchName}, ""); err != nil {
+		t.Fatal(err)
+	}
+	archive, err := domain.NewBranchLifecycleRef(repo, branchName, target, 1, domain.BranchArchived)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := writeAtomic(st.refFile(repo, domain.RefTag, archive.Name), []byte(string(archive.Target)+"\n")); err != nil {
+		t.Fatal(err)
+	}
+	head, err := st.GetRef(ctx, repo, domain.RefHead, domain.HeadRefName)
+	if err != nil || head.Symbolic != "" || head.Target != target {
+		t.Fatalf("projected HEAD = %+v, %v", head, err)
+	}
+	if _, err := st.GetRef(ctx, repo, domain.RefBranch, branchName); !errors.Is(err, domain.ErrNotFound) {
+		t.Fatalf("interrupted branch projection remains visible: %v", err)
+	}
+}

--- a/backend/internal/adapters/store/fs_store.go
+++ b/backend/internal/adapters/store/fs_store.go
@@ -1827,7 +1827,7 @@ func (s *FSStore) refFile(repoID domain.ContentHash, kind domain.RefKind, name s
 	}
 }
 
-func (s *FSStore) GetRef(_ context.Context, repoID domain.ContentHash, kind domain.RefKind, name string) (domain.Ref, error) {
+func (s *FSStore) getRefRaw(_ context.Context, repoID domain.ContentHash, kind domain.RefKind, name string) (domain.Ref, error) {
 	if err := validateHash(repoID); err != nil {
 		return domain.Ref{}, err
 	}
@@ -1859,12 +1859,33 @@ func (s *FSStore) GetRef(_ context.Context, repoID domain.ContentHash, kind doma
 	return ref, nil
 }
 
-func (s *FSStore) ListRefs(ctx context.Context, repoID domain.ContentHash) ([]domain.Ref, error) {
+func (s *FSStore) GetRef(ctx context.Context, repoID domain.ContentHash, kind domain.RefKind, name string) (domain.Ref, error) {
+	ref, err := s.getRefRaw(ctx, repoID, kind, name)
+	if err != nil || (kind != domain.RefBranch && kind != domain.RefHead) {
+		return ref, err
+	}
+	refs, err := s.listRefsRaw(ctx, repoID)
+	if err != nil {
+		return domain.Ref{}, err
+	}
+	projected, err := domain.ProjectBranchLifecycleRefs(refs)
+	if err != nil {
+		return domain.Ref{}, err
+	}
+	for _, candidate := range projected {
+		if candidate.Kind == kind && candidate.Name == name {
+			return candidate, nil
+		}
+	}
+	return domain.Ref{}, domain.ErrNotFound
+}
+
+func (s *FSStore) listRefsRaw(ctx context.Context, repoID domain.ContentHash) ([]domain.Ref, error) {
 	if err := validateHash(repoID); err != nil {
 		return nil, err
 	}
 	var out []domain.Ref
-	if head, err := s.GetRef(ctx, repoID, domain.RefHead, domain.HeadRefName); err == nil {
+	if head, err := s.getRefRaw(ctx, repoID, domain.RefHead, domain.HeadRefName); err == nil {
 		out = append(out, head)
 	} else if !errors.Is(err, domain.ErrNotFound) {
 		return nil, err
@@ -1888,7 +1909,7 @@ func (s *FSStore) ListRefs(ctx context.Context, repoID domain.ContentHash) ([]do
 			if rerr != nil {
 				return rerr
 			}
-			ref, rerr := s.GetRef(ctx, repoID, kc.kind, filepath.ToSlash(rel))
+			ref, rerr := s.getRefRaw(ctx, repoID, kc.kind, filepath.ToSlash(rel))
 			if rerr != nil {
 				return rerr
 			}
@@ -1900,6 +1921,14 @@ func (s *FSStore) ListRefs(ctx context.Context, repoID domain.ContentHash) ([]do
 		}
 	}
 	return out, nil
+}
+
+func (s *FSStore) ListRefs(ctx context.Context, repoID domain.ContentHash) ([]domain.Ref, error) {
+	refs, err := s.listRefsRaw(ctx, repoID)
+	if err != nil {
+		return nil, err
+	}
+	return domain.ProjectBranchLifecycleRefs(refs)
 }
 
 var fsRefLocks sync.Map
@@ -1939,6 +1968,37 @@ func (s *FSStore) CompareAndSwapRef(ctx context.Context, repoID domain.ContentHa
 	lock := s.refLock(repoID, next.Kind, next.Name)
 	lock.Lock()
 	defer lock.Unlock()
+	if next.Kind == domain.RefBranch {
+		raw, rawErr := s.getRefRaw(ctx, repoID, domain.RefBranch, next.Name)
+		if rawErr != nil && !errors.Is(rawErr, domain.ErrNotFound) {
+			return rawErr
+		}
+		refs, err := s.listRefsRaw(ctx, repoID)
+		if err != nil {
+			return err
+		}
+		latest, ok, err := domain.LatestBranchLifecycle(refs, next.Name)
+		if err != nil {
+			return err
+		}
+		if ok && latest.State == domain.BranchArchived {
+			if errors.Is(rawErr, domain.ErrNotFound) || latest.Target == raw.Target {
+				return domain.ErrBranchArchived
+			}
+			generation, err := domain.NextBranchLifecycleGeneration(refs, next.Name)
+			if err != nil {
+				return err
+			}
+			active, err := domain.NewBranchLifecycleRef(repoID, next.Name, raw.Target, generation, domain.BranchActive)
+			if err != nil {
+				return err
+			}
+			if err := writeAtomic(s.refFile(repoID, domain.RefTag, active.Name), []byte(string(active.Target)+"\n")); err != nil {
+				return err
+			}
+			s.appendReflog(repoID, domain.RefLogEntry{Kind: domain.RefTag, Name: active.Name, New: active.Target, CreatedAt: time.Now().UTC()})
+		}
+	}
 	if next.Kind == domain.RefHead {
 		content := string(next.Target)
 		if next.Symbolic != "" {
@@ -1959,6 +2019,94 @@ func (s *FSStore) CompareAndSwapRef(ctx context.Context, repoID domain.ContentHa
 	}
 	// reflog: appends-only log on ref movement success (safety net for recovered tips). Best-effort.
 	s.appendReflog(repoID, domain.RefLogEntry{Kind: next.Kind, Name: next.Name, Old: curTarget, New: next.Target, CreatedAt: time.Now().UTC()})
+	return nil
+}
+
+func (s *FSStore) detachHeadFromBranchRaw(ctx context.Context, repoID domain.ContentHash, branch string, target domain.ContentHash) error {
+	head, err := s.getRefRaw(ctx, repoID, domain.RefHead, domain.HeadRefName)
+	if errors.Is(err, domain.ErrNotFound) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if strings.TrimPrefix(head.Symbolic, "refs/heads/") != branch {
+		return nil
+	}
+	return writeAtomic(s.refFile(repoID, domain.RefHead, domain.HeadRefName), []byte(string(target)+"\n"))
+}
+
+// ApplyBranchLifecycleRef stores an immutable lifecycle event and updates the
+// active branch projection under the same repo-wide ref lock used by CAS. An
+// archive only removes the exact target it observed. If the branch has already
+// advanced, a deterministic next-generation active event preserves that work.
+func (s *FSStore) ApplyBranchLifecycleRef(ctx context.Context, repoID domain.ContentHash, eventRef domain.Ref) error {
+	eventRef.RepoID = repoID
+	if err := domain.ValidateRef(eventRef); err != nil {
+		return err
+	}
+	event, ok, err := domain.ParseBranchLifecycleRef(eventRef)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return domain.ErrValidation
+	}
+	lock := s.refLock(repoID, domain.RefBranch, event.Branch)
+	lock.Lock()
+	defer lock.Unlock()
+
+	if existing, err := s.getRefRaw(ctx, repoID, domain.RefTag, eventRef.Name); err == nil {
+		if existing.Target != eventRef.Target {
+			return domain.ErrRefConflict
+		}
+	} else if errors.Is(err, domain.ErrNotFound) {
+		if err := writeAtomic(s.refFile(repoID, domain.RefTag, eventRef.Name), []byte(string(eventRef.Target)+"\n")); err != nil {
+			return err
+		}
+		s.appendReflog(repoID, domain.RefLogEntry{Kind: domain.RefTag, Name: eventRef.Name, New: eventRef.Target, CreatedAt: time.Now().UTC()})
+	} else {
+		return err
+	}
+
+	refs, err := s.listRefsRaw(ctx, repoID)
+	if err != nil {
+		return err
+	}
+	latest, found, err := domain.LatestBranchLifecycle(refs, event.Branch)
+	if err != nil || !found || latest.Ref.Name != eventRef.Name || latest.State != domain.BranchArchived {
+		return err
+	}
+	branch, err := s.getRefRaw(ctx, repoID, domain.RefBranch, event.Branch)
+	if errors.Is(err, domain.ErrNotFound) {
+		return s.detachHeadFromBranchRaw(ctx, repoID, event.Branch, latest.Target)
+	}
+	if err != nil {
+		return err
+	}
+	if branch.Target == latest.Target {
+		if err := s.detachHeadFromBranchRaw(ctx, repoID, event.Branch, branch.Target); err != nil {
+			return err
+		}
+		if err := removeFileDurable(s.refFile(repoID, domain.RefBranch, event.Branch)); err != nil {
+			return err
+		}
+		s.appendReflog(repoID, domain.RefLogEntry{Kind: domain.RefBranch, Name: event.Branch, Old: branch.Target, CreatedAt: time.Now().UTC()})
+		return nil
+	}
+
+	generation, err := domain.NextBranchLifecycleGeneration(refs, event.Branch)
+	if err != nil {
+		return err
+	}
+	active, err := domain.NewBranchLifecycleRef(repoID, event.Branch, branch.Target, generation, domain.BranchActive)
+	if err != nil {
+		return err
+	}
+	if err := writeAtomic(s.refFile(repoID, domain.RefTag, active.Name), []byte(string(active.Target)+"\n")); err != nil {
+		return err
+	}
+	s.appendReflog(repoID, domain.RefLogEntry{Kind: domain.RefTag, Name: active.Name, New: active.Target, CreatedAt: time.Now().UTC()})
 	return nil
 }
 

--- a/backend/internal/adapters/store/postgres_smoke_test.go
+++ b/backend/internal/adapters/store/postgres_smoke_test.go
@@ -14,6 +14,50 @@ import (
 	"github.com/wnsdy95/cxthub/backend/internal/domain"
 )
 
+func TestPostgresBranchLifecycleReadProjectionMatchesFS(t *testing.T) {
+	repo := domain.ContentHash("sha256:" + strings.Repeat("1", 64))
+	archivedTarget := domain.ContentHash("sha256:" + strings.Repeat("2", 64))
+	advancedTarget := domain.ContentHash("sha256:" + strings.Repeat("3", 64))
+	archive, err := domain.NewBranchLifecycleRef(repo, "feature/archived", archivedTarget, 1, domain.BranchArchived)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		name       string
+		branch     domain.Ref
+		wantBranch bool
+	}{
+		{name: "exact archived residue hidden", branch: domain.Ref{Kind: domain.RefBranch, Name: "feature/archived", RepoID: repo, Target: archivedTarget}},
+		{name: "advanced branch preserved", branch: domain.Ref{Kind: domain.RefBranch, Name: "feature/archived", RepoID: repo, Target: advancedTarget}, wantBranch: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := projectBranchLifecycleRefs([]domain.Ref{tc.branch, archive})
+			if err != nil {
+				t.Fatal(err)
+			}
+			branchFound := false
+			for _, ref := range got {
+				branchFound = branchFound || ref.Kind == domain.RefBranch
+			}
+			if branchFound != tc.wantBranch {
+				t.Fatalf("projected refs=%+v wantBranch=%v", got, tc.wantBranch)
+			}
+		})
+	}
+	head := domain.Ref{Kind: domain.RefHead, Name: domain.HeadRefName, RepoID: repo, Symbolic: "feature/archived"}
+	projected, err := projectBranchLifecycleRefs([]domain.Ref{
+		head,
+		{Kind: domain.RefBranch, Name: "feature/archived", RepoID: repo, Target: archivedTarget},
+		archive,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(projected) != 2 || projected[0].Kind != domain.RefHead || projected[0].Symbolic != "" || projected[0].Target != archivedTarget {
+		t.Fatalf("projected interrupted HEAD = %+v", projected)
+	}
+}
+
 // TestPGSmoke is a smoke test for actual Postgres — runs only when CXT_TEST_DSN is set.
 // Skipped when unset (local `go test` skips, CI injects service container DSN).
 //
@@ -130,6 +174,99 @@ func TestPGSmoke(t *testing.T) {
 	}
 	if err := st.CompareAndSwapRef(ctx, repoID, domain.Ref{RepoID: repoID, Kind: domain.RefHead, Name: domain.HeadRefName, Symbolic: "main"}, ""); err != nil {
 		t.Fatalf("symbolic HEAD(NULL target): %v", err)
+	}
+	// Branch lifecycle events use the existing immutable-tag wire shape but
+	// apply tag insertion, branch projection deletion, and reflog in one DB
+	// transaction. A stale branch create is rejected until a newer active event.
+	lifecycleBranch := domain.Ref{RepoID: repoID, Kind: domain.RefBranch, Name: "feature/archived", Target: snapID}
+	if err := st.CompareAndSwapRef(ctx, repoID, lifecycleBranch, ""); err != nil {
+		t.Fatalf("lifecycle branch fixture: %v", err)
+	}
+	archiveEvent, err := domain.NewBranchLifecycleRef(repoID, lifecycleBranch.Name, snapID, 1, domain.BranchArchived)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.ApplyBranchLifecycleRef(ctx, repoID, archiveEvent); err != nil {
+		t.Fatalf("archive lifecycle event: %v", err)
+	}
+	if _, err := st.GetRef(ctx, repoID, domain.RefBranch, lifecycleBranch.Name); !errors.Is(err, domain.ErrNotFound) {
+		t.Fatalf("archived branch remains: %v", err)
+	}
+	lifecycleReflog, err := st.ReadReflog(ctx, repoID)
+	if err != nil {
+		t.Fatalf("lifecycle reflog: %v", err)
+	}
+	archiveLogged, removalLogged := false, false
+	for _, entry := range lifecycleReflog {
+		archiveLogged = archiveLogged || (entry.Kind == domain.RefTag && entry.Name == archiveEvent.Name && entry.New == snapID)
+		removalLogged = removalLogged || (entry.Kind == domain.RefBranch && entry.Name == lifecycleBranch.Name && entry.Old == snapID && entry.New == "")
+	}
+	if !archiveLogged || !removalLogged {
+		t.Fatalf("postgres lifecycle reflog missing tag/removal audit: %+v", lifecycleReflog)
+	}
+	if err := st.CompareAndSwapRef(ctx, repoID, lifecycleBranch, ""); !errors.Is(err, domain.ErrBranchArchived) {
+		t.Fatalf("stale lifecycle branch recreated: %v", err)
+	}
+	activeEvent, err := domain.NewBranchLifecycleRef(repoID, lifecycleBranch.Name, snapID, 2, domain.BranchActive)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.ApplyBranchLifecycleRef(ctx, repoID, activeEvent); err != nil {
+		t.Fatalf("active lifecycle event: %v", err)
+	}
+	if err := st.CompareAndSwapRef(ctx, repoID, lifecycleBranch, ""); err != nil {
+		t.Fatalf("explicit lifecycle restore: %v", err)
+	}
+	// Crash recovery parity with the FS adapter: an archive event may become
+	// durable after the physical branch has already advanced. Generic CAS must
+	// first record that advanced target as active instead of permanently
+	// rejecting the branch as archived.
+	makeLifecycleSnapshot := func(branch string) domain.ContentHash {
+		t.Helper()
+		doc := domain.CIRDocument{Envelope: domain.CIREnvelope{CIRVersion: "1", SourceProvider: domain.ProviderClaude, Fidelity: domain.FidelityFull, GitBranch: branch}}
+		body, err := domain.CanonicalBytes(doc)
+		if err != nil {
+			t.Fatal(err)
+		}
+		id := domain.HashContent(body)
+		if _, err := st.PutDoc(ctx, repoID, domain.SessionDoc{Hash: id, CIR: doc}); err != nil {
+			t.Fatalf("recovery doc %s: %v", branch, err)
+		}
+		if err := st.PutSnapshot(ctx, domain.Snapshot{ID: id, RepoID: repoID, Branch: branch, DocHash: id, Provider: domain.ProviderClaude, Fidelity: domain.FidelityFull, Message: "lifecycle recovery"}); err != nil {
+			t.Fatalf("recovery snapshot %s: %v", branch, err)
+		}
+		return id
+	}
+	const recoveryBranchName = "feature/cas-recovery"
+	advancedTarget := makeLifecycleSnapshot("feature/cas-recovery-advanced")
+	nextTarget := makeLifecycleSnapshot("feature/cas-recovery-next")
+	recoveryBranch := domain.Ref{RepoID: repoID, Kind: domain.RefBranch, Name: recoveryBranchName, Target: advancedTarget}
+	if err := st.CompareAndSwapRef(ctx, repoID, recoveryBranch, ""); err != nil {
+		t.Fatalf("recovery branch fixture: %v", err)
+	}
+	recoveryArchive, err := domain.NewBranchLifecycleRef(repoID, recoveryBranchName, snapID, 1, domain.BranchArchived)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Store only the immutable event to model a crash before lifecycle
+	// projection/compensation completed.
+	if err := st.CompareAndSwapRef(ctx, repoID, recoveryArchive, ""); err != nil {
+		t.Fatalf("recovery archive fixture: %v", err)
+	}
+	recoveryBranch.Target = nextTarget
+	if err := st.CompareAndSwapRef(ctx, repoID, recoveryBranch, advancedTarget); err != nil {
+		t.Fatalf("move advanced archive residue: %v", err)
+	}
+	if got, err := st.GetRef(ctx, repoID, domain.RefBranch, recoveryBranchName); err != nil || got.Target != nextTarget {
+		t.Fatalf("recovered branch = %+v, %v", got, err)
+	}
+	lifecycleRefs, err := listBranchLifecycleRefs(ctx, st.pool, repoID, recoveryBranchName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	latestLifecycle, ok, err := domain.LatestBranchLifecycle(lifecycleRefs, recoveryBranchName)
+	if err != nil || !ok || latestLifecycle.State != domain.BranchActive || latestLifecycle.Generation != 2 || latestLifecycle.Target != advancedTarget {
+		t.Fatalf("postgres recovery event = %+v, %v, %v", latestLifecycle, ok, err)
 	}
 	// Set KeyFacts/OpenTasks to nil to take NOT NULL normalization path.
 	digest := domain.MemoryDigest{SnapshotID: snapID, Summary: "m", Provider: domain.ProviderClaude}

--- a/backend/internal/adapters/store/postgres_smoke_test.go
+++ b/backend/internal/adapters/store/postgres_smoke_test.go
@@ -292,7 +292,8 @@ func TestPGSmoke(t *testing.T) {
 	if err != nil {
 		t.Fatalf("snapshot state hash: %v", err)
 	}
-	if len(repoManifest.SnapshotStates) != 1 || repoManifest.SnapshotStates[snapID] != wantState {
+	if len(repoManifest.SnapshotStates) != 3 || repoManifest.SnapshotStates[snapID] != wantState ||
+		repoManifest.SnapshotStates[advancedTarget] == "" || repoManifest.SnapshotStates[nextTarget] == "" {
 		t.Fatalf("manifest snapshot states = %+v, want %s=%s", repoManifest.SnapshotStates, snapID, wantState)
 	}
 	// Two database clients racing from the same causal parent must serialize on

--- a/backend/internal/adapters/store/postgres_store.go
+++ b/backend/internal/adapters/store/postgres_store.go
@@ -610,7 +610,7 @@ func (s *PostgresStore) HasSnapshots(ctx context.Context, repoID domain.ContentH
 
 // --- Ref / manifest ---
 
-func (s *PostgresStore) GetRef(ctx context.Context, repoID domain.ContentHash, kind domain.RefKind, name string) (domain.Ref, error) {
+func (s *PostgresStore) getRefRaw(ctx context.Context, repoID domain.ContentHash, kind domain.RefKind, name string) (domain.Ref, error) {
 	if err := validateHash(repoID); err != nil {
 		return domain.Ref{}, err
 	}
@@ -629,7 +629,7 @@ func (s *PostgresStore) GetRef(ctx context.Context, repoID domain.ContentHash, k
 	return ref, nil
 }
 
-func (s *PostgresStore) ListRefs(ctx context.Context, repoID domain.ContentHash) ([]domain.Ref, error) {
+func (s *PostgresStore) listRefsRaw(ctx context.Context, repoID domain.ContentHash) ([]domain.Ref, error) {
 	if err := validateHash(repoID); err != nil {
 		return nil, err
 	}
@@ -652,6 +652,125 @@ func (s *PostgresStore) ListRefs(ctx context.Context, repoID domain.ContentHash)
 	return out, rows.Err()
 }
 
+func projectBranchLifecycleRefs(refs []domain.Ref) ([]domain.Ref, error) {
+	return domain.ProjectBranchLifecycleRefs(refs)
+}
+
+func (s *PostgresStore) GetRef(ctx context.Context, repoID domain.ContentHash, kind domain.RefKind, name string) (domain.Ref, error) {
+	ref, err := s.getRefRaw(ctx, repoID, kind, name)
+	if err != nil {
+		return ref, err
+	}
+	if kind == domain.RefHead {
+		refs, err := s.listRefsRaw(ctx, repoID)
+		if err != nil {
+			return domain.Ref{}, err
+		}
+		projected, err := domain.ProjectBranchLifecycleRefs(refs)
+		if err != nil {
+			return domain.Ref{}, err
+		}
+		for _, candidate := range projected {
+			if candidate.Kind == kind && candidate.Name == name {
+				return candidate, nil
+			}
+		}
+		return domain.Ref{}, domain.ErrNotFound
+	}
+	if kind != domain.RefBranch {
+		return ref, nil
+	}
+	refs, err := listBranchLifecycleRefs(ctx, s.pool, repoID, name)
+	if err != nil {
+		return domain.Ref{}, err
+	}
+	latest, ok, err := domain.LatestBranchLifecycle(refs, name)
+	if err != nil {
+		return domain.Ref{}, err
+	}
+	if ok && latest.State == domain.BranchArchived && latest.Target == ref.Target {
+		return domain.Ref{}, domain.ErrNotFound
+	}
+	return ref, nil
+}
+
+func (s *PostgresStore) ListRefs(ctx context.Context, repoID domain.ContentHash) ([]domain.Ref, error) {
+	refs, err := s.listRefsRaw(ctx, repoID)
+	if err != nil {
+		return nil, err
+	}
+	return projectBranchLifecycleRefs(refs)
+}
+
+type pgRowsQuerier interface {
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+}
+
+func listBranchLifecycleRefs(ctx context.Context, q pgRowsQuerier, repoID domain.ContentHash, branch string) ([]domain.Ref, error) {
+	rows, err := q.Query(ctx,
+		`SELECT kind, name, repo_id, COALESCE(target,''), symbolic
+		 FROM refs
+		 WHERE repo_id=$1 AND kind='tag' AND name LIKE $2
+		   AND right(name, char_length($3::text)+1)='/' || $3::text`,
+		string(repoID), domain.BranchLifecycleTagPrefix+"%", branch)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var refs []domain.Ref
+	for rows.Next() {
+		var ref domain.Ref
+		if err := rows.Scan(&ref.Kind, &ref.Name, &ref.RepoID, &ref.Target, &ref.Symbolic); err != nil {
+			return nil, err
+		}
+		if _, ok, err := domain.ParseBranchLifecycleRef(ref); err != nil || !ok {
+			if err != nil {
+				return nil, err
+			}
+			return nil, domain.ErrValidation
+		}
+		refs = append(refs, ref)
+	}
+	return refs, rows.Err()
+}
+
+func insertBranchLifecycleRefTx(ctx context.Context, tx pgx.Tx, repoID domain.ContentHash, ref domain.Ref) (bool, error) {
+	ct, err := tx.Exec(ctx,
+		`INSERT INTO refs (repo_id, kind, name, target, symbolic) VALUES ($1,'tag',$2,$3,'')
+		 ON CONFLICT (repo_id, kind, name) DO NOTHING`,
+		string(repoID), ref.Name, string(ref.Target))
+	if err != nil {
+		return false, err
+	}
+	if ct.RowsAffected() > 0 {
+		if _, err := tx.Exec(ctx,
+			`INSERT INTO reflog (repo_id,kind,name,old,new) VALUES ($1,'tag',$2,'',$3)`,
+			string(repoID), ref.Name, string(ref.Target)); err != nil {
+			return false, err
+		}
+		return true, nil
+	}
+	var existing string
+	if err := tx.QueryRow(ctx,
+		`SELECT COALESCE(target,'') FROM refs WHERE repo_id=$1 AND kind='tag' AND name=$2`,
+		string(repoID), ref.Name).Scan(&existing); err != nil {
+		return false, err
+	}
+	if domain.ContentHash(existing) != ref.Target {
+		return false, domain.ErrRefConflict
+	}
+	return false, nil
+}
+
+func detachHeadFromBranchTx(ctx context.Context, tx pgx.Tx, repoID domain.ContentHash, branch string, target domain.ContentHash) error {
+	_, err := tx.Exec(ctx,
+		`UPDATE refs SET target=$3, symbolic='', version=version+1, updated_at=now()
+		 WHERE repo_id=$1 AND kind='head' AND name='HEAD'
+		   AND (symbolic=$2 OR symbolic='refs/heads/' || $2)`,
+		string(repoID), branch, string(target))
+	return err
+}
+
 // CompareAndSwapRef: moves to next only if expected matches current target (optimistic locking, version++).
 func (s *PostgresStore) CompareAndSwapRef(ctx context.Context, repoID domain.ContentHash, next domain.Ref, expected domain.ContentHash) error {
 	next.RepoID = repoID
@@ -672,6 +791,40 @@ func (s *PostgresStore) CompareAndSwapRef(ctx context.Context, repoID domain.Con
 	if next.Kind == domain.RefBranch || next.Kind == domain.RefSession {
 		if err := lockRepoGraph(ctx, tx, repoID); err != nil {
 			return err
+		}
+	}
+	if next.Kind == domain.RefBranch {
+		refs, err := listBranchLifecycleRefs(ctx, tx, repoID, next.Name)
+		if err != nil {
+			return err
+		}
+		latest, ok, err := domain.LatestBranchLifecycle(refs, next.Name)
+		if err != nil {
+			return err
+		}
+		if ok && latest.State == domain.BranchArchived {
+			var branchTarget string
+			err := tx.QueryRow(ctx,
+				`SELECT COALESCE(target,'') FROM refs
+				 WHERE repo_id=$1 AND kind='branch' AND name=$2 FOR UPDATE`,
+				string(repoID), next.Name).Scan(&branchTarget)
+			if errors.Is(err, pgx.ErrNoRows) || (err == nil && domain.ContentHash(branchTarget) == latest.Target) {
+				return domain.ErrBranchArchived
+			}
+			if err != nil {
+				return err
+			}
+			generation, err := domain.NextBranchLifecycleGeneration(refs, next.Name)
+			if err != nil {
+				return err
+			}
+			active, err := domain.NewBranchLifecycleRef(repoID, next.Name, domain.ContentHash(branchTarget), generation, domain.BranchActive)
+			if err != nil {
+				return err
+			}
+			if _, err := insertBranchLifecycleRefTx(ctx, tx, repoID, active); err != nil {
+				return err
+			}
 		}
 	}
 	if expected == "" {
@@ -704,6 +857,87 @@ func (s *PostgresStore) CompareAndSwapRef(ctx context.Context, repoID domain.Con
 			string(repoID), string(next.Kind), next.Name, string(expected), string(next.Target)); err != nil {
 			return err
 		}
+	}
+	return tx.Commit(ctx)
+}
+
+// ApplyBranchLifecycleRef applies the reserved immutable-tag event and its
+// branch projection in one PostgreSQL transaction.
+func (s *PostgresStore) ApplyBranchLifecycleRef(ctx context.Context, repoID domain.ContentHash, eventRef domain.Ref) error {
+	eventRef.RepoID = repoID
+	if err := domain.ValidateRef(eventRef); err != nil {
+		return err
+	}
+	event, ok, err := domain.ParseBranchLifecycleRef(eventRef)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return domain.ErrValidation
+	}
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx)
+	if err := lockRepoGraph(ctx, tx, repoID); err != nil {
+		return err
+	}
+	if _, err := insertBranchLifecycleRefTx(ctx, tx, repoID, eventRef); err != nil {
+		return err
+	}
+	refs, err := listBranchLifecycleRefs(ctx, tx, repoID, event.Branch)
+	if err != nil {
+		return err
+	}
+	latest, found, err := domain.LatestBranchLifecycle(refs, event.Branch)
+	if err != nil {
+		return err
+	}
+	if !found || latest.Ref.Name != eventRef.Name || latest.State != domain.BranchArchived {
+		return tx.Commit(ctx)
+	}
+	var branchTarget string
+	err = tx.QueryRow(ctx,
+		`SELECT COALESCE(target,'') FROM refs
+		 WHERE repo_id=$1 AND kind='branch' AND name=$2 FOR UPDATE`,
+		string(repoID), event.Branch).Scan(&branchTarget)
+	if errors.Is(err, pgx.ErrNoRows) {
+		if err := detachHeadFromBranchTx(ctx, tx, repoID, event.Branch, latest.Target); err != nil {
+			return err
+		}
+		return tx.Commit(ctx)
+	}
+	if err != nil {
+		return err
+	}
+	if domain.ContentHash(branchTarget) == latest.Target {
+		if err := detachHeadFromBranchTx(ctx, tx, repoID, event.Branch, latest.Target); err != nil {
+			return err
+		}
+		if _, err := tx.Exec(ctx,
+			`DELETE FROM refs WHERE repo_id=$1 AND kind='branch' AND name=$2 AND target=$3`,
+			string(repoID), event.Branch, branchTarget); err != nil {
+			return err
+		}
+		if _, err := tx.Exec(ctx,
+			`INSERT INTO reflog (repo_id,kind,name,old,new) VALUES ($1,'branch',$2,$3,'')`,
+			string(repoID), event.Branch, branchTarget); err != nil {
+			return err
+		}
+		return tx.Commit(ctx)
+	}
+
+	generation, err := domain.NextBranchLifecycleGeneration(refs, event.Branch)
+	if err != nil {
+		return err
+	}
+	active, err := domain.NewBranchLifecycleRef(repoID, event.Branch, domain.ContentHash(branchTarget), generation, domain.BranchActive)
+	if err != nil {
+		return err
+	}
+	if _, err := insertBranchLifecycleRefTx(ctx, tx, repoID, active); err != nil {
+		return err
 	}
 	return tx.Commit(ctx)
 }

--- a/backend/internal/app/branch_lifecycle_test.go
+++ b/backend/internal/app/branch_lifecycle_test.go
@@ -1,0 +1,161 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/wnsdy95/cxthub/backend/internal/domain"
+	"github.com/wnsdy95/cxthub/backend/internal/ports/inbound"
+)
+
+func TestUpdateRefAppliesBranchLifecycleAndRejectsStaleBranch(t *testing.T) {
+	svc, st := newFsckSvc(t)
+	ctx := context.Background()
+	repo := hh("branch-lifecycle-service-repo")
+	target := hh("branch-lifecycle-service-target")
+	if err := st.PutSnapshot(ctx, domain.Snapshot{ID: target, RepoID: repo, DocHash: target, Branch: "feature/archive"}); err != nil {
+		t.Fatal(err)
+	}
+	branch := domain.Ref{Kind: domain.RefBranch, Name: "feature/archive", Target: target}
+	if _, err := svc.UpdateRef(ctx, inbound.UpdateRefInput{RepoID: repo, Ref: branch}); err != nil {
+		t.Fatalf("create branch: %v", err)
+	}
+	if err := svc.PutPending(ctx, repo, "archived-session", domain.Pending{Target: target, Branch: branch.Name}); err != nil {
+		t.Fatal(err)
+	}
+	archive, err := domain.NewBranchLifecycleRef(repo, branch.Name, target, 1, domain.BranchArchived)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, err := svc.UpdateRef(ctx, inbound.UpdateRefInput{RepoID: repo, Ref: archive})
+	if err != nil || out.Result != inbound.RefFastForward {
+		t.Fatalf("archive update = %+v, %v", out, err)
+	}
+	if _, err := st.GetRef(ctx, repo, domain.RefBranch, branch.Name); !errors.Is(err, domain.ErrNotFound) {
+		t.Fatalf("branch projection survived archive: %v", err)
+	}
+	if pendings, err := svc.ListPendings(ctx, repo); err != nil || len(pendings) != 0 {
+		t.Fatalf("archive-shared pending remains: %+v, %v", pendings, err)
+	}
+	if _, err := svc.UpdateRef(ctx, inbound.UpdateRefInput{RepoID: repo, Ref: branch}); !errors.Is(err, domain.ErrBranchArchived) {
+		t.Fatalf("stale branch PUT resurrected archive: %v", err)
+	}
+
+	active, err := domain.NewBranchLifecycleRef(repo, branch.Name, target, 2, domain.BranchActive)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := svc.UpdateRef(ctx, inbound.UpdateRefInput{RepoID: repo, Ref: active}); err != nil {
+		t.Fatalf("active event: %v", err)
+	}
+	if _, err := svc.UpdateRef(ctx, inbound.UpdateRefInput{RepoID: repo, Ref: branch}); err != nil {
+		t.Fatalf("branch restore: %v", err)
+	}
+}
+
+func TestUpdateRefRejectsLifecycleForceAndAppend(t *testing.T) {
+	svc, st := newFsckSvc(t)
+	ctx := context.Background()
+	repo := hh("branch-lifecycle-policy-repo")
+	target := hh("branch-lifecycle-policy-target")
+	if err := st.PutSnapshot(ctx, domain.Snapshot{ID: target, RepoID: repo, DocHash: target}); err != nil {
+		t.Fatal(err)
+	}
+	event, err := domain.NewBranchLifecycleRef(repo, "feature/policy", target, 1, domain.BranchArchived)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, in := range []inbound.UpdateRefInput{
+		{RepoID: repo, Ref: event, Force: true},
+		{RepoID: repo, Ref: event, Append: true},
+	} {
+		if _, err := svc.UpdateRef(ctx, in); !errors.Is(err, domain.ErrValidation) {
+			t.Fatalf("mutable lifecycle event accepted: %+v err=%v", in, err)
+		}
+	}
+}
+
+func TestUpdateRefRejectsArchiveOfProtectedDefaultBranch(t *testing.T) {
+	svc, st := newFsckSvc(t)
+	ctx := context.Background()
+	repo := hh("protected-default-lifecycle-repo")
+	target := hh("protected-default-lifecycle-target")
+	if _, err := st.PutRepo(ctx, domain.Repo{ID: repo, DefaultBranch: "main", ProtectDefault: true}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.PutSnapshot(ctx, domain.Snapshot{ID: target, RepoID: repo, DocHash: target, Branch: "main"}); err != nil {
+		t.Fatal(err)
+	}
+	branch := domain.Ref{Kind: domain.RefBranch, Name: "main", Target: target}
+	if _, err := svc.UpdateRef(ctx, inbound.UpdateRefInput{RepoID: repo, Ref: branch}); err != nil {
+		t.Fatal(err)
+	}
+	archive, err := domain.NewBranchLifecycleRef(repo, branch.Name, target, 1, domain.BranchArchived)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := svc.UpdateRef(ctx, inbound.UpdateRefInput{RepoID: repo, Ref: archive}); !errors.Is(err, domain.ErrForbidden) {
+		t.Fatalf("protected default archive error = %v", err)
+	}
+	if got, err := st.GetRef(ctx, repo, domain.RefBranch, branch.Name); err != nil || got.Target != target {
+		t.Fatalf("protected branch changed: %+v, %v", got, err)
+	}
+}
+
+func TestEmptyRefBatchSelfHealsInterruptedPendingReconciliation(t *testing.T) {
+	svc, st := newFsckSvc(t)
+	ctx := context.Background()
+	repo := hh("deferred-lifecycle-reconciliation-repo")
+	target := hh("deferred-lifecycle-reconciliation-target")
+	if err := st.PutSnapshot(ctx, domain.Snapshot{ID: target, RepoID: repo, DocHash: target}); err != nil {
+		t.Fatal(err)
+	}
+	if err := svc.PutPending(ctx, repo, "deferred-session", domain.Pending{Target: target, Branch: "feature/deferred"}); err != nil {
+		t.Fatal(err)
+	}
+	event, err := domain.NewBranchLifecycleRef(repo, "feature/deferred", target, 1, domain.BranchArchived)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Simulate a process interruption after the durable ref write but before
+	// UpdateRef's reconciliation wrapper.
+	if _, err := svc.updateRef(ctx, inbound.UpdateRefInput{RepoID: repo, Ref: event}); err != nil {
+		t.Fatal(err)
+	}
+	if pendings, err := svc.ListPendings(ctx, repo); err != nil || len(pendings) != 1 {
+		t.Fatalf("interrupted update unexpectedly reconciled: %+v, %v", pendings, err)
+	}
+	out, err := svc.UpdateRefs(ctx, inbound.UpdateRefsInput{RepoID: repo})
+	if err != nil || out.Applied != 0 {
+		t.Fatalf("empty recovery batch = %+v, %v", out, err)
+	}
+	if pendings, err := svc.ListPendings(ctx, repo); err != nil || len(pendings) != 0 {
+		t.Fatalf("final replay did not reconcile: %+v, %v", pendings, err)
+	}
+}
+
+func TestBranchLifecycleEventIsASharedTimelineRoot(t *testing.T) {
+	repo := hh("branch-lifecycle-shared-root-repo")
+	target := hh("branch-lifecycle-shared-root-target")
+	event, err := domain.NewBranchLifecycleRef(repo, "feature/archived", target, 1, domain.BranchArchived)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		name string
+		ref  domain.Ref
+		want bool
+	}{
+		{name: "branch", ref: domain.Ref{Kind: domain.RefBranch, Name: "main", Target: target}, want: true},
+		{name: "session", ref: domain.Ref{Kind: domain.RefSession, Name: "main/session", Target: target}, want: true},
+		{name: "lifecycle", ref: event, want: true},
+		{name: "ordinary tag", ref: domain.Ref{Kind: domain.RefTag, Name: "v1", Target: target}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := sharedTimelineRef(tc.ref); got != tc.want {
+				t.Fatalf("sharedTimelineRef(%+v) = %v, want %v", tc.ref, got, tc.want)
+			}
+		})
+	}
+}

--- a/backend/internal/app/service.go
+++ b/backend/internal/app/service.go
@@ -493,10 +493,43 @@ func (s *Service) Commit(ctx context.Context, in inbound.CommitInput) (inbound.C
 // Tags are immutable: Moving to another target is rejected without Force.
 func (s *Service) UpdateRef(ctx context.Context, in inbound.UpdateRefInput) (inbound.UpdateRefOutput, error) {
 	out, err := s.updateRef(ctx, in)
-	if err == nil && in.Ref.Kind == domain.RefBranch {
-		s.reconcileSharedPendingPointers(ctx, in.RepoID)
+	if err == nil {
+		_, lifecycle, _ := domain.ParseBranchLifecycleRef(in.Ref)
+		if in.Ref.Kind == domain.RefBranch || lifecycle {
+			s.reconcileSharedPendingPointers(ctx, in.RepoID)
+		}
 	}
 	return out, err
+}
+
+// UpdateRefs is the request-level ref transaction boundary. Ref projections
+// remain individually CAS-checked, but pending reachability is reconciled once
+// after the complete batch. An empty retry is intentional: it repairs a server
+// crash that occurred after the last ref write but before metadata cleanup.
+func (s *Service) UpdateRefs(ctx context.Context, in inbound.UpdateRefsInput) (out inbound.UpdateRefsOutput, err error) {
+	if err := domain.ValidateContentHash(in.RepoID); err != nil {
+		return out, err
+	}
+	if len(in.Updates) > inbound.MaxRefBatchUpdates {
+		return out, fmt.Errorf("%w: at most %d ref updates per batch", domain.ErrValidation, inbound.MaxRefBatchUpdates)
+	}
+	defer s.reconcileSharedPendingPointers(ctx, in.RepoID)
+	var rejected []string
+	for _, update := range in.Updates {
+		update.RepoID = in.RepoID
+		if _, updateErr := s.updateRef(ctx, update); updateErr != nil {
+			if errors.Is(updateErr, domain.ErrNonFastForward) {
+				rejected = append(rejected, string(update.Ref.Kind)+"/"+update.Ref.Name)
+				continue
+			}
+			return out, updateErr
+		}
+		out.Applied++
+	}
+	if len(rejected) > 0 {
+		return out, fmt.Errorf("%w: %s", domain.ErrNonFastForward, strings.Join(rejected, ", "))
+	}
+	return out, nil
 }
 
 func (s *Service) updateRef(ctx context.Context, in inbound.UpdateRefInput) (inbound.UpdateRefOutput, error) {
@@ -517,6 +550,35 @@ func (s *Service) updateRef(ctx context.Context, in inbound.UpdateRefInput) (inb
 			return inbound.UpdateRefOutput{}, fmt.Errorf("%w: ref target snapshot %s does not exist", domain.ErrIntegrity, in.Ref.Target)
 		}
 		return inbound.UpdateRefOutput{}, err
+	}
+	if event, lifecycle, err := domain.ParseBranchLifecycleRef(in.Ref); err != nil {
+		return inbound.UpdateRefOutput{}, err
+	} else if lifecycle {
+		if in.Force || in.Append {
+			return inbound.UpdateRefOutput{}, fmt.Errorf("%w: branch lifecycle events are immutable", domain.ErrValidation)
+		}
+		if event.State == domain.BranchArchived {
+			if repo, repoErr := s.meta.GetRepo(ctx, in.RepoID); repoErr == nil &&
+				repo.ProtectDefault && event.Branch == repo.DefaultBranch {
+				return inbound.UpdateRefOutput{}, fmt.Errorf("%w: archiving protected branch %q is forbidden", domain.ErrForbidden, event.Branch)
+			} else if repoErr != nil && !errors.Is(repoErr, domain.ErrNotFound) {
+				return inbound.UpdateRefOutput{}, repoErr
+			}
+		}
+		_, currentErr := s.meta.GetRef(ctx, in.RepoID, domain.RefTag, in.Ref.Name)
+		if currentErr != nil && !errors.Is(currentErr, domain.ErrNotFound) {
+			return inbound.UpdateRefOutput{}, currentErr
+		}
+		if err := s.meta.ApplyBranchLifecycleRef(ctx, in.RepoID, in.Ref); err != nil {
+			return inbound.UpdateRefOutput{}, err
+		}
+		result := inbound.RefFastForward
+		if currentErr == nil {
+			result = inbound.RefUpToDate
+		}
+		return inbound.UpdateRefOutput{
+			Ref: in.Ref, RequestedTarget: in.Ref.Target, ServerTarget: in.Ref.Target, Result: result,
+		}, nil
 	}
 	cur, err := s.meta.GetRef(ctx, in.RepoID, in.Ref.Kind, in.Ref.Name)
 	serverTarget := domain.ContentHash("")
@@ -1351,9 +1413,9 @@ func (s *Service) CompareAndDeletePending(ctx context.Context, repoID domain.Con
 
 // reconcileSharedPendingPointers is a best-effort mutable-metadata cleanup
 // after branch/join ref movement. A pending target is resolved only when a
-// branch or server-managed session ref reaches it through natural or graft
-// parents. Compare-and-delete protects a newer capture that arrives during the
-// reachability walk.
+// branch, server-managed session, or immutable branch-lifecycle root reaches
+// it through natural or graft parents. Compare-and-delete protects a newer
+// capture that arrives during the reachability walk.
 func (s *Service) reconcileSharedPendingPointers(ctx context.Context, repoID domain.ContentHash) {
 	pendings, err := s.meta.ListPendings(ctx, repoID)
 	if err != nil || len(pendings) == 0 {
@@ -1365,7 +1427,7 @@ func (s *Service) reconcileSharedPendingPointers(ctx context.Context, repoID dom
 	}
 	roots := make([]domain.ContentHash, 0, len(refs))
 	for _, ref := range refs {
-		if (ref.Kind == domain.RefBranch || ref.Kind == domain.RefSession) && ref.Target != "" {
+		if sharedTimelineRef(ref) {
 			roots = append(roots, ref.Target)
 		}
 	}
@@ -1399,6 +1461,17 @@ func (s *Service) reconcileSharedPendingPointers(ctx context.Context, repoID dom
 		// allowed): immutable history remains and only the mutable pointer leaves.
 		_, _ = s.meta.CompareAndDeletePending(ctx, repoID, p.SessionID, p.Target)
 	}
+}
+
+func sharedTimelineRef(ref domain.Ref) bool {
+	if ref.Target == "" {
+		return false
+	}
+	if ref.Kind == domain.RefBranch || ref.Kind == domain.RefSession {
+		return true
+	}
+	_, lifecycle, err := domain.ParseBranchLifecycleRef(ref)
+	return err == nil && lifecycle
 }
 
 // pendingTargetOf returns the current pending target of the session (empty string if none).
@@ -1894,11 +1967,11 @@ func (s *Service) Join(ctx context.Context, in inbound.JoinInput) (inbound.JoinO
 		return inbound.JoinOutput{}, err
 	}
 	// Writes the same commit set as the UI. Active pending target is never a join target, and hook leafs not reachable from ref are excluded from descendant/tip calculation.
-	// Conversely, past deduplication leaves hook labels, but if reachable from branch/session ref, it's already a shared commit and included.
+	// Conversely, past deduplication leaves hook labels, but if reachable from a branch/session/lifecycle root, it's already a shared commit and included.
 	shared := map[domain.ContentHash]bool{}
 	targetSessionShared := map[domain.ContentHash]bool{}
 	for _, ref := range refs {
-		if (ref.Kind == domain.RefBranch || ref.Kind == domain.RefSession) && ref.Target != "" {
+		if sharedTimelineRef(ref) {
 			for id := range snapshotReachableSet(byID, ref.Target) {
 				shared[id] = true
 				if ref.Kind == domain.RefSession && strings.HasPrefix(ref.Name, domain.SessionRefPrefix(in.TargetBranch)) {

--- a/backend/internal/domain/branch_lifecycle.go
+++ b/backend/internal/domain/branch_lifecycle.go
@@ -1,0 +1,196 @@
+package domain
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// BranchLifecycleTagPrefix is a reserved immutable-tag namespace used as a
+// backward-compatible branch lifecycle event log. Older clients preserve
+// these refs as ordinary tags instead of rejecting an unknown ref kind.
+const BranchLifecycleTagPrefix = "cxt/branch-state/v1/"
+
+type BranchLifecycleState string
+
+const (
+	BranchActive   BranchLifecycleState = "active"
+	BranchArchived BranchLifecycleState = "archived"
+)
+
+type BranchLifecycleEvent struct {
+	Branch     string
+	Generation uint64
+	State      BranchLifecycleState
+	Target     ContentHash
+	Ref        Ref
+}
+
+func parseBranchLifecycleTagName(name string) (BranchLifecycleEvent, bool, error) {
+	if !strings.HasPrefix(name, BranchLifecycleTagPrefix) {
+		return BranchLifecycleEvent{}, false, nil
+	}
+	rest := strings.TrimPrefix(name, BranchLifecycleTagPrefix)
+	parts := strings.SplitN(rest, "/", 4)
+	if len(parts) != 4 || len(parts[0]) != 20 {
+		return BranchLifecycleEvent{}, true, fmt.Errorf("%w: malformed branch lifecycle tag %q", ErrValidation, name)
+	}
+	generation, err := strconv.ParseUint(parts[0], 10, 64)
+	if err != nil || generation == 0 || fmt.Sprintf("%020d", generation) != parts[0] {
+		return BranchLifecycleEvent{}, true, fmt.Errorf("%w: invalid branch lifecycle generation in %q", ErrValidation, name)
+	}
+	state := BranchLifecycleState(parts[1])
+	if state != BranchActive && state != BranchArchived {
+		return BranchLifecycleEvent{}, true, fmt.Errorf("%w: invalid branch lifecycle state in %q", ErrValidation, name)
+	}
+	if len(parts[2]) != 64 || parts[2] != strings.ToLower(parts[2]) {
+		return BranchLifecycleEvent{}, true, fmt.Errorf("%w: invalid branch lifecycle target in %q", ErrValidation, name)
+	}
+	target := ContentHash("sha256:" + parts[2])
+	if err := ValidateContentHash(target); err != nil {
+		return BranchLifecycleEvent{}, true, err
+	}
+	if err := ValidateBranchName(parts[3]); err != nil {
+		return BranchLifecycleEvent{}, true, err
+	}
+	return BranchLifecycleEvent{Branch: parts[3], Generation: generation, State: state, Target: target}, true, nil
+}
+
+func NewBranchLifecycleRef(repoID ContentHash, branch string, target ContentHash, generation uint64, state BranchLifecycleState) (Ref, error) {
+	if err := ValidateContentHash(repoID); err != nil {
+		return Ref{}, err
+	}
+	if err := ValidateBranchName(branch); err != nil {
+		return Ref{}, err
+	}
+	if err := ValidateContentHash(target); err != nil {
+		return Ref{}, err
+	}
+	if generation == 0 || (state != BranchActive && state != BranchArchived) {
+		return Ref{}, fmt.Errorf("%w: invalid branch lifecycle event", ErrValidation)
+	}
+	name := fmt.Sprintf("%s%020d/%s/%s/%s", BranchLifecycleTagPrefix, generation, state, strings.TrimPrefix(string(target), "sha256:"), branch)
+	ref := Ref{Kind: RefTag, Name: name, RepoID: repoID, Target: target}
+	if err := ValidateRef(ref); err != nil {
+		return Ref{}, err
+	}
+	return ref, nil
+}
+
+func ParseBranchLifecycleRef(ref Ref) (BranchLifecycleEvent, bool, error) {
+	if ref.Kind != RefTag {
+		return BranchLifecycleEvent{}, false, nil
+	}
+	event, ok, err := parseBranchLifecycleTagName(ref.Name)
+	if err != nil || !ok {
+		return BranchLifecycleEvent{}, ok, err
+	}
+	if ref.Target != event.Target {
+		return BranchLifecycleEvent{}, true, fmt.Errorf("%w: lifecycle tag target does not match its name", ErrValidation)
+	}
+	event.Ref = ref
+	return event, true, nil
+}
+
+func branchLifecycleLater(left, right BranchLifecycleEvent) bool {
+	if left.Generation != right.Generation {
+		return left.Generation > right.Generation
+	}
+	if left.State != right.State {
+		return left.State == BranchActive
+	}
+	if left.Target != right.Target {
+		return left.Target > right.Target
+	}
+	return left.Ref.Name > right.Ref.Name
+}
+
+func LatestBranchLifecycle(refs []Ref, branch string) (BranchLifecycleEvent, bool, error) {
+	var latest BranchLifecycleEvent
+	found := false
+	for _, ref := range refs {
+		event, ok, err := ParseBranchLifecycleRef(ref)
+		if err != nil {
+			return BranchLifecycleEvent{}, false, err
+		}
+		if !ok || event.Branch != branch {
+			continue
+		}
+		if !found || branchLifecycleLater(event, latest) {
+			latest, found = event, true
+		}
+	}
+	return latest, found, nil
+}
+
+// BranchLifecycleStates projects the append-only event refs into one latest
+// state per branch in a single pass. List/manifest consumers use this instead
+// of rescanning the complete immutable event history for every branch.
+func BranchLifecycleStates(refs []Ref) (map[string]BranchLifecycleEvent, error) {
+	states := make(map[string]BranchLifecycleEvent)
+	for _, ref := range refs {
+		event, ok, err := ParseBranchLifecycleRef(ref)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			continue
+		}
+		if current, found := states[event.Branch]; !found || branchLifecycleLater(event, current) {
+			states[event.Branch] = event
+		}
+	}
+	return states, nil
+}
+
+// ProjectBranchLifecycleRefs derives the externally visible mutable
+// projections from raw refs plus immutable lifecycle events. An archive hides
+// only the exact branch target it observed. If a crash left symbolic HEAD
+// pointing at that hidden branch, HEAD is exposed as detached at the archived
+// snapshot so manifests never contain a dangling symbolic ref.
+func ProjectBranchLifecycleRefs(refs []Ref) ([]Ref, error) {
+	states, err := BranchLifecycleStates(refs)
+	if err != nil {
+		return nil, err
+	}
+	branches := make(map[string]Ref)
+	for _, ref := range refs {
+		if ref.Kind == RefBranch {
+			branches[ref.Name] = ref
+		}
+	}
+	out := make([]Ref, 0, len(refs))
+	for _, ref := range refs {
+		if ref.Kind == RefBranch {
+			latest, ok := states[ref.Name]
+			if ok && latest.State == BranchArchived && latest.Target == ref.Target {
+				continue
+			}
+		}
+		if ref.Kind == RefHead && ref.Symbolic != "" {
+			branch := strings.TrimPrefix(ref.Symbolic, "refs/heads/")
+			latest, ok := states[branch]
+			raw, exists := branches[branch]
+			if ok && latest.State == BranchArchived && (!exists || raw.Target == latest.Target) {
+				ref.Symbolic = ""
+				ref.Target = latest.Target
+			}
+		}
+		out = append(out, ref)
+	}
+	return out, nil
+}
+
+func NextBranchLifecycleGeneration(refs []Ref, branch string) (uint64, error) {
+	latest, ok, err := LatestBranchLifecycle(refs, branch)
+	if err != nil {
+		return 0, err
+	}
+	if !ok {
+		return 1, nil
+	}
+	if latest.Generation == ^uint64(0) {
+		return 0, fmt.Errorf("%w: branch lifecycle generation exhausted", ErrValidation)
+	}
+	return latest.Generation + 1, nil
+}

--- a/backend/internal/domain/branch_lifecycle_test.go
+++ b/backend/internal/domain/branch_lifecycle_test.go
@@ -1,0 +1,71 @@
+package domain
+
+import (
+	"strings"
+	"testing"
+)
+
+func lifecycleHash(ch byte) ContentHash {
+	return ContentHash("sha256:" + strings.Repeat(string(ch), 64))
+}
+
+func TestBranchLifecycleRefRoundTripAndOrdering(t *testing.T) {
+	repo := lifecycleHash('0')
+	target := lifecycleHash('a')
+	archived, err := NewBranchLifecycleRef(repo, "feature/auth", target, 7, BranchArchived)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if archived.Kind != RefTag || !strings.HasPrefix(archived.Name, BranchLifecycleTagPrefix) {
+		t.Fatalf("archive ref = %+v", archived)
+	}
+	event, ok, err := ParseBranchLifecycleRef(archived)
+	if err != nil || !ok {
+		t.Fatalf("parse = %+v, %v, %v", event, ok, err)
+	}
+	if event.Branch != "feature/auth" || event.Target != target || event.Generation != 7 || event.State != BranchArchived {
+		t.Fatalf("round trip = %+v", event)
+	}
+
+	active, err := NewBranchLifecycleRef(repo, "feature/auth", target, 7, BranchActive)
+	if err != nil {
+		t.Fatal(err)
+	}
+	latest, ok, err := LatestBranchLifecycle([]Ref{archived, active}, "feature/auth")
+	if err != nil || !ok || latest.State != BranchActive {
+		t.Fatalf("same-generation preservation = %+v, %v, %v", latest, ok, err)
+	}
+
+	newer, err := NewBranchLifecycleRef(repo, "feature/auth", target, 8, BranchArchived)
+	if err != nil {
+		t.Fatal(err)
+	}
+	latest, ok, err = LatestBranchLifecycle([]Ref{newer, active}, "feature/auth")
+	if err != nil || !ok || latest.State != BranchArchived || latest.Generation != 8 {
+		t.Fatalf("newest generation = %+v, %v, %v", latest, ok, err)
+	}
+	states, err := BranchLifecycleStates([]Ref{newer, active})
+	if err != nil || len(states) != 1 || states["feature/auth"].Ref.Name != newer.Name {
+		t.Fatalf("single-pass states = %+v, %v", states, err)
+	}
+}
+
+func TestBranchLifecycleRefRejectsMalformedReservedTags(t *testing.T) {
+	repo := lifecycleHash('0')
+	target := lifecycleHash('a')
+	malformed := []Ref{
+		{Kind: RefTag, Name: BranchLifecycleTagPrefix + "7/archived/" + strings.TrimPrefix(string(target), "sha256:") + "/main", RepoID: repo, Target: target},
+		{Kind: RefTag, Name: BranchLifecycleTagPrefix + "00000000000000000007/removed/" + strings.TrimPrefix(string(target), "sha256:") + "/main", RepoID: repo, Target: target},
+		{Kind: RefTag, Name: BranchLifecycleTagPrefix + "00000000000000000007/archived/" + strings.Repeat("b", 64) + "/main", RepoID: repo, Target: target},
+	}
+	for _, ref := range malformed {
+		if _, ok, err := ParseBranchLifecycleRef(ref); !ok || err == nil {
+			t.Fatalf("malformed reserved tag accepted: %+v, ok=%v err=%v", ref, ok, err)
+		}
+
+	}
+	ordinary := Ref{Kind: RefTag, Name: "release/v1", RepoID: repo, Target: target}
+	if _, ok, err := ParseBranchLifecycleRef(ordinary); ok || err != nil {
+		t.Fatalf("ordinary tag classified as lifecycle: ok=%v err=%v", ok, err)
+	}
+}

--- a/backend/internal/domain/errors.go
+++ b/backend/internal/domain/errors.go
@@ -16,6 +16,10 @@ var ErrNonFastForward = errors.New("non fast-forward")
 // ErrRefConflict indicates a mismatch in ref CAS expected (concurrent update) (409).
 var ErrRefConflict = errors.New("ref conflict")
 
+// ErrBranchArchived prevents a stale replica from recreating a branch pointer
+// after a newer immutable lifecycle event archived it.
+var ErrBranchArchived = errors.New("branch is archived")
+
 // ErrUnauthorized indicates an invalid or missing token (401).
 var ErrUnauthorized = errors.New("unauthorized")
 

--- a/backend/internal/domain/values.go
+++ b/backend/internal/domain/values.go
@@ -141,6 +141,10 @@ func ValidateRefName(kind RefKind, name string) error {
 		}
 		return nil
 	}
+	if kind == RefTag && strings.HasPrefix(name, BranchLifecycleTagPrefix) {
+		_, _, err := parseBranchLifecycleTagName(name)
+		return err
+	}
 	return ValidateBranchName(name)
 }
 

--- a/backend/internal/ports/inbound/inbound.go
+++ b/backend/internal/ports/inbound/inbound.go
@@ -32,6 +32,12 @@ type UpdateRef interface {
 	UpdateRef(ctx context.Context, in UpdateRefInput) (UpdateRefOutput, error)
 }
 
+// UpdateRefs applies a bounded ref projection batch and reconciles pending
+// reachability exactly once at the request boundary.
+type UpdateRefs interface {
+	UpdateRefs(ctx context.Context, in UpdateRefsInput) (UpdateRefsOutput, error)
+}
+
 // ListSnapshots returns a list of snapshot metadata per branch (sync protocol, ListSnapshots mirror).
 type ListSnapshots interface {
 	List(ctx context.Context, in ListSnapshotsInput) ([]domain.Snapshot, error)
@@ -202,6 +208,20 @@ type UpdateRefInput struct {
 	Append bool
 }
 
+const (
+	MaxRefBatchUpdates  = 4096
+	MaxRefBatchJSONBody = 8 << 20
+)
+
+type UpdateRefsInput struct {
+	RepoID  domain.ContentHash
+	Updates []UpdateRefInput
+}
+
+type UpdateRefsOutput struct {
+	Applied int `json:"applied"`
+}
+
 // RefUpdateResult is the result of ref move determination (sync protocol).
 type RefUpdateResult string
 
@@ -218,12 +238,12 @@ const (
 
 // UpdateRefOutput: verdict + (fork info when diverged) (sync protocol).
 type UpdateRefOutput struct {
-	Result          RefUpdateResult
-	Ref             domain.Ref
-	RequestedTarget domain.ContentHash
-	ServerTarget    domain.ContentHash
-	ForkedRef       *domain.Ref
-	MergeBase       domain.ContentHash
+	Result          RefUpdateResult    `json:"result"`
+	Ref             domain.Ref         `json:"ref"`
+	RequestedTarget domain.ContentHash `json:"requested_target,omitempty"`
+	ServerTarget    domain.ContentHash `json:"server_target,omitempty"`
+	ForkedRef       *domain.Ref        `json:"forked_ref,omitempty"`
+	MergeBase       domain.ContentHash `json:"merge_base,omitempty"`
 }
 
 // ListSnapshotsInput: branch filter (empty for all).

--- a/backend/internal/ports/outbound/outbound.go
+++ b/backend/internal/ports/outbound/outbound.go
@@ -86,6 +86,9 @@ type MetadataStore interface {
 	ListRefs(ctx context.Context, repoID domain.ContentHash) ([]domain.Ref, error)
 	// CompareAndSwapRef: move to next only if expected matches current disk target (optimistic locking).
 	CompareAndSwapRef(ctx context.Context, repoID domain.ContentHash, next domain.Ref, expected domain.ContentHash) error
+	// ApplyBranchLifecycleRef stores one immutable reserved-tag event and
+	// atomically reconciles the active branch projection.
+	ApplyBranchLifecycleRef(ctx context.Context, repoID domain.ContentHash, event domain.Ref) error
 	// ReadReflog: return append-only log of ref movements in latest order (tip recovery safety net, git reflog equivalent).
 	ReadReflog(ctx context.Context, repoID domain.ContentHash) ([]domain.RefLogEntry, error)
 	GetManifest(ctx context.Context, repoID domain.ContentHash) (domain.Manifest, error)

--- a/cli/cmd/cxt/main.go
+++ b/cli/cmd/cxt/main.go
@@ -229,6 +229,7 @@ func buildContainer(cfg config) container {
 	initSvc := app.NewInitRepoService(gitCtx, store)
 	saveSvc := app.NewSaveSessionService(gitCtx, captures, codecs, store)
 	forkSvc := app.NewForkSessionService(store)
+	branchLifecycleSvc := app.NewBranchLifecycleService(gitCtx, store)
 	loadSvc := app.NewLoadSessionService(store, codecs, materializers, memSources, distiller, memSinks)
 	checkoutSvc := app.NewCheckoutSessionService(forkSvc, loadSvc, store)
 	listSvc := app.NewListSessionsService(store)
@@ -249,6 +250,7 @@ func buildContainer(cfg config) container {
 		Init:            initSvc,
 		Save:            saveSvc,
 		Fork:            forkSvc,
+		Branches:        branchLifecycleSvc,
 		Checkout:        checkoutSvc,
 		Load:            loadSvc,
 		List:            listSvc,

--- a/cli/internal/adapters/backendclient/backend_client.go
+++ b/cli/internal/adapters/backendclient/backend_client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -104,6 +105,7 @@ const (
 	maxChunkWireRawBytes = chunkcas.MaxPortableChunkBytes
 	maxChunkWireObjects  = 32
 	maxChunkWireJSONBody = 4 << 20
+	maxRefBatchUpdates   = 4096
 )
 
 type putRefReq struct {
@@ -113,6 +115,16 @@ type putRefReq struct {
 	Force          bool               `json:"force,omitempty"`
 	// Append grafts diverged push to server head (--append).
 	Append bool `json:"append,omitempty"`
+}
+
+type batchRefUpdate struct {
+	Ref    domain.Ref `json:"ref"`
+	Force  bool       `json:"force,omitempty"`
+	Append bool       `json:"append,omitempty"`
+}
+
+type batchRefsReq struct {
+	Updates []batchRefUpdate `json:"updates"`
 }
 
 // ChunkLocal is local chunk store access (pull delta — does not receive existing chunks).
@@ -658,6 +670,22 @@ func (c *BackendClient) RemoteManifest(ctx context.Context, repoID string) (doma
 	return m, nil
 }
 
+func (c *BackendClient) remoteRefs(ctx context.Context, repoID string) ([]domain.Ref, error) {
+	var refs []domain.Ref
+	if err := c.do(ctx, http.MethodGet, c.reposPath(repoID)+"/refs", nil, &refs); err != nil {
+		return nil, err
+	}
+	for _, ref := range refs {
+		if err := domain.ValidateRef(ref); err != nil {
+			return nil, err
+		}
+		if ref.RepoID != "" && ref.RepoID != repoID {
+			return nil, domain.ErrHashMismatch
+		}
+	}
+	return refs, nil
+}
+
 // NegotiatePushObjects performs the hash-only first phase before the
 // application opens any cumulative SessionDoc bodies. It uses the existing
 // sync endpoint, so old servers that support Push already support this
@@ -836,26 +864,148 @@ func (c *BackendClient) Push(ctx context.Context, repoID string, snapshots []dom
 		}
 	}
 
-	// ref movement (branch/session/tag; HEAD is a local concept). Server determines policy by kind.
-	// Non-fast-forward rejections are collected and reported in git style at the end (other refs continue).
-	var rejected []string
-	for _, ref := range refs {
-		if ref.Kind == domain.RefHEAD || ref.Target == "" {
-			continue
+	// Ref movement (branch/session/tag; HEAD is a local concept). Avoid replaying
+	// immutable lifecycle history and unchanged branch pointers on every push.
+	// A ref-list failure means an old or temporarily unavailable peer, so retain
+	// the previous fail-open behavior and send the complete ref set.
+	refsToPush := pushableRefs(refs)
+	if len(refsToPush) > 0 {
+		if remoteRefs, err := c.remoteRefs(ctx, repoID); err == nil {
+			refsToPush = refsMissingOrChanged(refsToPush, remoteRefs)
 		}
+	}
+
+	updates := make([]batchRefUpdate, 0, len(refsToPush))
+	for _, ref := range refsToPush {
+		_, lifecycle, _ := domain.ParseBranchLifecycleRef(ref)
+		updates = append(updates, batchRefUpdate{
+			Ref: ref, Force: force && !lifecycle,
+			Append: appendDiverged && ref.Kind == domain.RefBranch && !lifecycle,
+		})
+	}
+	batchFallback := false
+	batchRejected := false
+	for _, batch := range refUpdateBatches(updates) {
+		err := c.do(ctx, http.MethodPost, c.reposPath(repoID)+"/refs/batch", batchRefsReq{Updates: batch}, nil)
+		switch {
+		case err == nil:
+		case batchRefsUnsupported(err):
+			batchFallback = true
+		case strings.Contains(err.Error(), "non_fast_forward"):
+			batchRejected = true
+		default:
+			return classifyRefPushError(err)
+		}
+		if batchFallback {
+			break
+		}
+	}
+	if !batchFallback {
+		if batchRejected {
+			return fmt.Errorf("%w: ref batch", domain.ErrSyncConflict)
+		}
+		return nil
+	}
+
+	// Compatibility fallback for servers predating the batch endpoint. Server
+	// determines update policy by ref kind. Non-fast-forward rejections are
+	// collected and reported in git style at the end (other refs continue).
+	var rejected []string
+	for _, ref := range refsToPush {
+		_, lifecycle, _ := domain.ParseBranchLifecycleRef(ref)
 		path := c.reposPath(repoID) + "/refs/" + string(ref.Kind) + "/" + escapePathName(ref.Name)
-		if err := c.do(ctx, http.MethodPut, path, putRefReq{Target: ref.Target, ExpectedTarget: "", Symbolic: ref.Symbolic, Force: force, Append: appendDiverged}, nil); err != nil {
+		request := putRefReq{
+			Target: ref.Target, ExpectedTarget: "", Symbolic: ref.Symbolic,
+			Force:  force && !lifecycle,
+			Append: appendDiverged && ref.Kind == domain.RefBranch && !lifecycle,
+		}
+		if err := c.do(ctx, http.MethodPut, path, request, nil); err != nil {
+			classified := classifyRefPushError(err)
 			if strings.Contains(err.Error(), "non_fast_forward") {
 				rejected = append(rejected, string(ref.Kind)+"/"+ref.Name)
 				continue
 			}
-			return err
+			return classified
 		}
 	}
 	if len(rejected) > 0 {
 		return fmt.Errorf("%w: %s", domain.ErrSyncConflict, strings.Join(rejected, ", "))
 	}
 	return nil
+}
+
+func pushableRefs(refs []domain.Ref) []domain.Ref {
+	out := make([]domain.Ref, 0, len(refs))
+	for _, ref := range refs {
+		if ref.Kind != domain.RefHEAD && ref.Target != "" {
+			out = append(out, ref)
+		}
+	}
+	return out
+}
+
+func refsMissingOrChanged(local, remote []domain.Ref) []domain.Ref {
+	type refKey struct {
+		kind domain.RefKind
+		name string
+	}
+	type remoteState struct {
+		ref       domain.Ref
+		ambiguous bool
+	}
+	remoteByKey := make(map[refKey]remoteState, len(remote))
+	for _, ref := range remote {
+		key := refKey{kind: ref.Kind, name: ref.Name}
+		if previous, ok := remoteByKey[key]; ok {
+			if previous.ref.Target != ref.Target || previous.ref.Symbolic != ref.Symbolic {
+				previous.ambiguous = true
+				remoteByKey[key] = previous
+			}
+			continue
+		}
+		remoteByKey[key] = remoteState{ref: ref}
+	}
+
+	out := make([]domain.Ref, 0, len(local))
+	for _, ref := range local {
+		state, ok := remoteByKey[refKey{kind: ref.Kind, name: ref.Name}]
+		if ok && !state.ambiguous && state.ref.Target == ref.Target && state.ref.Symbolic == ref.Symbolic {
+			continue
+		}
+		out = append(out, ref)
+	}
+	return out
+}
+
+func batchRefsUnsupported(err error) bool {
+	var httpErr *HTTPError
+	return errors.As(err, &httpErr) && (httpErr.Status == http.StatusNotFound || httpErr.Status == http.StatusMethodNotAllowed)
+}
+
+func refUpdateBatches(updates []batchRefUpdate) [][]batchRefUpdate {
+	if len(updates) == 0 {
+		return [][]batchRefUpdate{{}}
+	}
+	out := make([][]batchRefUpdate, 0, (len(updates)+maxRefBatchUpdates-1)/maxRefBatchUpdates)
+	for start := 0; start < len(updates); start += maxRefBatchUpdates {
+		end := start + maxRefBatchUpdates
+		if end > len(updates) {
+			end = len(updates)
+		}
+		out = append(out, updates[start:end])
+	}
+	return out
+}
+
+func classifyRefPushError(err error) error {
+	var httpErr *HTTPError
+	if errors.As(err, &httpErr) && httpErr.Code == "branch_archived" {
+		return fmt.Errorf("%w: %s", domain.ErrBranchArchived, httpErr.Message)
+	}
+	if strings.Contains(err.Error(), "non_fast_forward") {
+		return fmt.Errorf("%w: %v", domain.ErrSyncConflict, err)
+	}
+	return err
 }
 
 func containsString(values []string, want string) bool {

--- a/cli/internal/adapters/backendclient/backend_client_test.go
+++ b/cli/internal/adapters/backendclient/backend_client_test.go
@@ -487,6 +487,156 @@ func TestRefOnlyPushSkipsObjectNegotiation(t *testing.T) {
 	}
 }
 
+func TestRefOnlyPushUsesEmptyBatchToReconcileWhenRemoteIsCurrent(t *testing.T) {
+	repoID := domain.HashContent([]byte("ref-delta-push-repo"))
+	target := domain.HashContent([]byte("ref-delta-push-target"))
+	branch := domain.Ref{Kind: domain.RefBranch, Name: "main", RepoID: string(repoID), Target: target}
+	lifecycle, err := domain.NewBranchLifecycleRef(string(repoID), "main", target, 1, domain.BranchActive)
+	if err != nil {
+		t.Fatal(err)
+	}
+	listCalls, batchCalls, refCalls := 0, 0, 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/refs"):
+			listCalls++
+			_ = json.NewEncoder(w).Encode([]domain.Ref{branch, lifecycle})
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/refs/batch"):
+			batchCalls++
+			var body batchRefsReq
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("decode batch: %v", err)
+			}
+			if len(body.Updates) != 0 {
+				t.Errorf("current remote batch updates = %+v", body.Updates)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]int{"applied": 0})
+		case r.Method == http.MethodPut && strings.Contains(r.URL.Path, "/refs/"):
+			refCalls++
+			_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	c := NewBackendClient(func() string { return ts.URL }, func() string { return "" }, domain.TeamIdentity{})
+	if err := c.Push(context.Background(), string(repoID), nil, nil, []domain.Ref{lifecycle, branch}, false, false); err != nil {
+		t.Fatal(err)
+	}
+	if listCalls != 1 || batchCalls != 1 || refCalls != 0 {
+		t.Fatalf("calls list=%d batch=%d refs=%d, want 1/1/0", listCalls, batchCalls, refCalls)
+	}
+}
+
+func TestRefOnlyPushSendsOnlyRefsMissingFromRemote(t *testing.T) {
+	repoID := domain.HashContent([]byte("ref-partial-delta-push-repo"))
+	target := domain.HashContent([]byte("ref-partial-delta-push-target"))
+	branch := domain.Ref{Kind: domain.RefBranch, Name: "main", RepoID: string(repoID), Target: target}
+	lifecycle, err := domain.NewBranchLifecycleRef(string(repoID), "main", target, 2, domain.BranchArchived)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var batch batchRefsReq
+	var putPaths []string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/refs"):
+			_ = json.NewEncoder(w).Encode([]domain.Ref{branch})
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/refs/batch"):
+			if err := json.NewDecoder(r.Body).Decode(&batch); err != nil {
+				t.Errorf("decode batch: %v", err)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]int{"applied": len(batch.Updates)})
+		case r.Method == http.MethodPut && strings.Contains(r.URL.Path, "/refs/"):
+			putPaths = append(putPaths, r.URL.Path)
+			_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	c := NewBackendClient(func() string { return ts.URL }, func() string { return "" }, domain.TeamIdentity{})
+	if err := c.Push(context.Background(), string(repoID), nil, nil, []domain.Ref{branch, lifecycle}, false, false); err != nil {
+		t.Fatal(err)
+	}
+	if len(putPaths) != 0 || len(batch.Updates) != 1 || batch.Updates[0].Ref.Name != lifecycle.Name {
+		t.Fatalf("batch=%+v PUT paths=%v, want only missing lifecycle tag", batch, putPaths)
+	}
+}
+
+func TestRefUpdateBatchesAreBoundedAndKeepEmptyReconciliation(t *testing.T) {
+	updates := make([]batchRefUpdate, maxRefBatchUpdates+1)
+	batches := refUpdateBatches(updates)
+	if len(batches) != 2 || len(batches[0]) != maxRefBatchUpdates || len(batches[1]) != 1 {
+		t.Fatalf("batch sizes = %d/%d/%d", len(batches), len(batches[0]), len(batches[1]))
+	}
+	empty := refUpdateBatches(nil)
+	if len(empty) != 1 || len(empty[0]) != 0 {
+		t.Fatalf("empty reconciliation batches = %+v", empty)
+	}
+}
+
+func TestRefOnlyPushClassifiesArchivedBranchConflict(t *testing.T) {
+	repoID := domain.HashContent([]byte("archived-ref-push-repo"))
+	target := domain.HashContent([]byte("archived-ref-push-target"))
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusConflict)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]string{"code": "branch_archived", "message": "pull lifecycle state before restoring"},
+		})
+	}))
+	defer ts.Close()
+
+	c := NewBackendClient(func() string { return ts.URL }, func() string { return "" }, domain.TeamIdentity{})
+	ref := domain.Ref{Kind: domain.RefBranch, Name: "feature/deleted", RepoID: string(repoID), Target: target}
+	err := c.Push(context.Background(), string(repoID), nil, nil, []domain.Ref{ref}, false, false)
+	if !errors.Is(err, domain.ErrBranchArchived) {
+		t.Fatalf("push error = %v, want branch archived", err)
+	}
+}
+
+func TestAppendPushDoesNotApplyBranchPolicyToLifecycleTags(t *testing.T) {
+	repoID := domain.HashContent([]byte("lifecycle append policy repo"))
+	target := domain.HashContent([]byte("lifecycle append policy target"))
+	lifecycle, err := domain.NewBranchLifecycleRef(string(repoID), "main", target, 1, domain.BranchActive)
+	if err != nil {
+		t.Fatal(err)
+	}
+	branch := domain.Ref{Kind: domain.RefBranch, Name: "main", RepoID: string(repoID), Target: target}
+	requests := map[string]putRefReq{}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut || !strings.Contains(r.URL.Path, "/refs/") {
+			http.NotFound(w, r)
+			return
+		}
+		var body putRefReq
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode %s: %v", r.URL.Path, err)
+		}
+		if strings.Contains(r.URL.Path, "/refs/tag/") {
+			requests["lifecycle"] = body
+		} else if strings.Contains(r.URL.Path, "/refs/branch/") {
+			requests["branch"] = body
+		}
+		_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+	}))
+	defer ts.Close()
+
+	c := NewBackendClient(func() string { return ts.URL }, func() string { return "" }, domain.TeamIdentity{})
+	if err := c.Push(context.Background(), string(repoID), nil, nil, []domain.Ref{lifecycle, branch}, true, true); err != nil {
+		t.Fatal(err)
+	}
+	if got := requests["lifecycle"]; got.Append || got.Force {
+		t.Fatalf("lifecycle request inherited branch policy: %+v", got)
+	}
+	if got := requests["branch"]; !got.Append || !got.Force {
+		t.Fatalf("branch request lost push policy: %+v", got)
+	}
+}
+
 func TestPushRejectsCIRV2BeforeMutatingOldServer(t *testing.T) {
 	repoID := domain.HashContent([]byte("cir-v2-old-server"))
 	cir := domain.CIRDocument{

--- a/cli/internal/adapters/delivery/cli/args.go
+++ b/cli/internal/adapters/delivery/cli/args.go
@@ -36,6 +36,7 @@ var commandArgSpecs = map[string]commandArgSpec{
 	"claude":    {usage: "cxt claude [claude-arguments...]", passthrough: true},
 	"codex":     {usage: "cxt codex [codex-arguments...]", passthrough: true},
 	"remote":    {usage: "cxt remote [-v] | add <name> <url> | remove <name>", flags: commandFlags(nil, []string{"-v"})},
+	"branch":    {usage: "cxt branch archive <name> | restore <name> [--provider claude|codex] [--mode full|reconstructed|memory]", flags: commandFlags([]string{"--provider", "--mode"}, nil)},
 	"repack":    {usage: "cxt repack"},
 	"add":       {usage: "cxt add [claude|codex|.]..."},
 	"commit":    {usage: "cxt commit [-m <message>]", flags: commandFlags([]string{"-m"}, nil)},
@@ -168,6 +169,13 @@ func validateCommandFlags(cmd string, args []string, spec commandArgSpec) error 
 
 	pos := positionals(args)
 	switch cmd {
+	case "branch":
+		if len(pos) != 2 || (pos[0] != "archive" && pos[0] != "restore") {
+			return fmt.Errorf("usage: %s", spec.usage)
+		}
+		if pos[0] == "archive" && (flagVal(args, "--provider") != "" || flagVal(args, "--mode") != "") {
+			return fmt.Errorf("branch: restore-only flag used with archive\nusage: %s", spec.usage)
+		}
 	case "remote":
 		if flagPresent(args, "-v") && len(pos) > 0 {
 			return fmt.Errorf("remote: flag %q is only valid when listing remotes\nusage: %s", "-v", spec.usage)

--- a/cli/internal/adapters/delivery/cli/githook.go
+++ b/cli/internal/adapters/delivery/cli/githook.go
@@ -15,6 +15,7 @@ package cli
 import (
 	"bufio"
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -146,6 +147,197 @@ func spawnPendingSync(cwd string, resolutions []inbound.PendingResolution) {
 	_ = cmd.Start()
 }
 
+func spawnBranchStateSync(cwd string) {
+	if _, ok := remotecfg.Origin(cwd); !ok && os.Getenv("CXT_REMOTE") == "" {
+		return
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		return
+	}
+	cmd := exec.Command(exe, "git-hook", "branch-state-sync")
+	cmd.Dir = cwd
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	_ = cmd.Start()
+}
+
+// spawnBranchDeletionFinalize defers classification until the Git process has
+// left reference-transaction. During both prepared and committed callbacks a
+// rename's destination ref/reflog is not visible yet, so synchronous handling
+// cannot distinguish rename from deletion. Stdout/stderr are inherited so the
+// ordinary `git branch` command still reports the final context action.
+func spawnBranchDeletionFinalize(cwd, branch, oldOID, gitPID string) {
+	exe, err := os.Executable()
+	if err != nil {
+		return
+	}
+	cmd := exec.Command(exe, "git-hook", "branch-deletion-finalize", branch, oldOID, gitPID)
+	cmd.Dir = cwd
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	_ = cmd.Start()
+}
+
+func waitForGitTransaction(gitPID string) {
+	pid, err := strconv.Atoi(gitPID)
+	if err != nil || pid <= 0 {
+		return
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		err := syscall.Kill(pid, 0)
+		if err != nil && !errors.Is(err, syscall.EPERM) {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+type branchRefTransaction struct {
+	name, oldOID, newOID, createdOID string
+	deleted                          bool
+}
+
+func zeroGitOID(value string) bool {
+	return (len(value) == 40 || len(value) == 64) && strings.Trim(value, "0") == ""
+}
+
+func validNonZeroGitOID(value string) bool {
+	if (len(value) != 40 && len(value) != 64) || zeroGitOID(value) {
+		return false
+	}
+	for _, r := range value {
+		if !((r >= '0' && r <= '9') || (r >= 'a' && r <= 'f') || (r >= 'A' && r <= 'F')) {
+			return false
+		}
+	}
+	return true
+}
+
+func parseBranchRefTransaction(line string) branchRefTransaction {
+	fields := strings.Fields(line)
+	if len(fields) != 3 || !strings.HasPrefix(fields[2], "refs/heads/") {
+		return branchRefTransaction{}
+	}
+	out := branchRefTransaction{
+		name: strings.TrimPrefix(fields[2], "refs/heads/"), oldOID: fields[0], newOID: fields[1],
+	}
+	oldZero, newZero := zeroGitOID(out.oldOID), zeroGitOID(out.newOID)
+	switch {
+	case newZero:
+		out.deleted = true
+	case oldZero:
+		out.createdOID = out.newOID
+	}
+	return out
+}
+
+type preparedBranchRefTransaction struct {
+	CreatedAt time.Time `json:"created_at"`
+	Branch    string    `json:"branch"`
+	OldOID    string    `json:"old_oid"`
+}
+
+func branchRefTransactionLedgerPath(branch string) (string, error) {
+	if err := domain.ValidateBranchName(branch); err != nil {
+		return "", err
+	}
+	digest := sha256.Sum256([]byte(branch))
+	return filepath.Join(".cxt", "ref-transactions", fmt.Sprintf("%x.json", digest)), nil
+}
+
+func recordPreparedBranchRefTransaction(cwd string, lines []string) error {
+	for _, line := range lines {
+		txn := parseBranchRefTransaction(line)
+		if !txn.deleted {
+			continue
+		}
+		path, err := branchRefTransactionLedgerPath(txn.name)
+		if err != nil {
+			return err
+		}
+		oldOID := txn.oldOID
+		if !validNonZeroGitOID(oldOID) {
+			// Git's files ref backend can report zero→zero for deletion. During
+			// prepared the old ref is still authoritative and readable.
+			oldOID = gitOut(cwd, "rev-parse", "--verify", "refs/heads/"+txn.name)
+		}
+		if !validNonZeroGitOID(oldOID) {
+			_ = providerfs.RemoveRepoFile(cwd, path)
+			continue
+		}
+		raw, err := json.Marshal(preparedBranchRefTransaction{
+			CreatedAt: time.Now().UTC(), Branch: txn.name, OldOID: oldOID,
+		})
+		if err != nil {
+			return err
+		}
+		if err := providerfs.WriteRepoFileAtomic(cwd, path, raw, 0o600); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func consumePreparedBranchRefTransaction(cwd, branch string) string {
+	path, err := branchRefTransactionLedgerPath(branch)
+	if err != nil {
+		return ""
+	}
+	defer providerfs.RemoveRepoFile(cwd, path) // best-effort cleanup after commit or malformed state
+	raw, err := providerfs.ReadRepoFile(cwd, path)
+	if err != nil {
+		return ""
+	}
+	var prepared preparedBranchRefTransaction
+	if json.Unmarshal(raw, &prepared) != nil || prepared.CreatedAt.IsZero() {
+		return ""
+	}
+	age := time.Since(prepared.CreatedAt)
+	if age < -time.Minute || age > 2*time.Minute || prepared.Branch != branch || !validNonZeroGitOID(prepared.OldOID) {
+		return ""
+	}
+	return prepared.OldOID
+}
+
+func clearPreparedBranchRefTransactions(cwd string, lines []string) {
+	for _, line := range lines {
+		txn := parseBranchRefTransaction(line)
+		if !txn.deleted {
+			continue
+		}
+		if path, err := branchRefTransactionLedgerPath(txn.name); err == nil {
+			_ = providerfs.RemoveRepoFile(cwd, path)
+		}
+	}
+}
+
+// renamedBranchForDeletion recognizes Git's branch rename contract. Git emits
+// only deletion of the old ref to reference-transaction, while the new ref is
+// already present and its reflog contains the authoritative rename record.
+// Requiring both that exact record and the deleted OID avoids treating an
+// unrelated create+delete pair as a rename.
+func renamedBranchForDeletion(cwd, oldBranch, oldOID string) string {
+	if !validNonZeroGitOID(oldOID) {
+		return ""
+	}
+	refs := gitOut(cwd, "for-each-ref", "--format=%(refname:lstrip=2)%09%(objectname)", "refs/heads")
+	for _, line := range strings.Split(refs, "\n") {
+		fields := strings.SplitN(line, "\t", 2)
+		if len(fields) != 2 || fields[1] != oldOID || fields[0] == oldBranch {
+			continue
+		}
+		newBranch := fields[0]
+		want := fmt.Sprintf("Branch: renamed refs/heads/%s to refs/heads/%s", oldBranch, newBranch)
+		got := gitOut(cwd, "reflog", "show", "-1", "--format=%gs", "refs/heads/"+newBranch)
+		if got == want {
+			return newBranch
+		}
+	}
+	return ""
+}
+
 // acquireSyncLock acquires the pending-sync serialization lock (.cxt/sync.lock).
 // Multiple detached helpers spawned on commit/agent stop reduce contention on SyncPendings to recover stale unsyncs (backlog #2 — self-heal with server and flicker removal).
 // Briefly wait and retry to ensure --resolve deletion is not lost, and proceed without lock on deadline exceeded (availability priority — server self-heals by reachability, so safe). O_EXCL + stale argument pattern.
@@ -274,6 +466,9 @@ func contextSwitch(ctx context.Context, c *Container, cwd string) error {
 				b.SeedPath, b.ResumeCmd = out.WrittenPath, out.ResumeCmd
 				b.SeedID = restoredSessionID(out.WrittenPath, out.ResumeCmd)
 				fmt.Printf("cxt: %q context prepared  [fidelity: %s]\n", branch, out.Fidelity)
+				if out.ActivatedBranch {
+					spawnBranchStateSync(cwd)
+				}
 				syncSettingsToSnapshot(ctx, c, cwd, out.Head, "git checkout "+branch)
 			} else {
 				prepareErr = err
@@ -589,6 +784,30 @@ func runGitHook(ctx context.Context, c *Container, cwd string, rest []string) er
 	event, args := rest[0], rest[1:]
 
 	switch event {
+	case "ref-prepare":
+		var lines []string
+		scanner := bufio.NewScanner(os.Stdin)
+		for scanner.Scan() {
+			lines = append(lines, scanner.Text())
+		}
+		if err := scanner.Err(); err != nil {
+			hookWarn("branch transaction prepare read failed: %v", err)
+			return nil
+		}
+		if err := recordPreparedBranchRefTransaction(cwd, lines); err != nil {
+			hookWarn("branch transaction prepare failed: %v", err)
+		}
+		return nil
+
+	case "ref-abort":
+		var lines []string
+		scanner := bufio.NewScanner(os.Stdin)
+		for scanner.Scan() {
+			lines = append(lines, scanner.Text())
+		}
+		clearPreparedBranchRefTransactions(cwd, lines)
+		return nil
+
 	case "post-commit":
 		// git commit → context snapshot. Passes the message and SHA directly to link code ↔ context.
 		msg := gitOut(cwd, "log", "-1", "--pretty=%s")
@@ -621,6 +840,61 @@ func runGitHook(ctx context.Context, c *Container, cwd string, rest []string) er
 		defer release()
 		if _, err := c.Sync.SyncPendings(ctx, inbound.SyncInput{Cwd: cwd}, resolutions); err != nil {
 			hookWarn("pending sync: %v", err)
+		}
+
+	case "branch-state-sync":
+		if _, ok := remotecfg.Origin(cwd); !ok && os.Getenv("CXT_REMOTE") == "" {
+			return nil
+		}
+		release := acquireSyncLock(cwd)
+		defer release()
+		if _, err := c.Sync.Push(ctx, inbound.SyncInput{Cwd: cwd}); err != nil {
+			hookWarn("branch archive sync: %v", err)
+		}
+
+	case "branch-deletion-finalize":
+		if len(args) < 3 || c.Branches == nil {
+			return nil
+		}
+		name, oldOID, gitPID := args[0], args[1], args[2]
+		if domain.ValidateBranchName(name) != nil {
+			return nil
+		}
+		waitForGitTransaction(gitPID)
+		// A delete+recreate transaction ended with the same Git branch alive.
+		// Its final inventory wins over the intermediate deletion callback.
+		if gitOut(cwd, "show-ref", "--verify", "refs/heads/"+name) != "" {
+			return nil
+		}
+		if !validNonZeroGitOID(oldOID) {
+			// Without the deleted object identity, a committed zeros→zeros event
+			// cannot distinguish a rename from a deletion. Preserve the projection
+			// on uncertainty; a later hook/manual archive can safely retry.
+			hookWarn("context branch %q kept — Git transaction lacked the old object ID needed to distinguish rename from deletion", name)
+			return nil
+		}
+		if renamed := renamedBranchForDeletion(cwd, name, oldOID); renamed != "" {
+			out, err := c.Branches.Rename(ctx, inbound.BranchRenameInput{Cwd: cwd, From: name, To: renamed})
+			switch {
+			case err == nil:
+				fmt.Printf("cxt: git branch %q renamed to %q — context moved at %s (history preserved)\n", name, renamed, shortHash(out.Target))
+				spawnBranchStateSync(cwd)
+			case errors.Is(err, domain.ErrNotFound):
+				// No context pointer existed for the renamed Git branch.
+			default:
+				hookWarn("context branch %q rename to %q failed: %v", name, renamed, err)
+			}
+			return nil
+		}
+		out, err := c.Branches.Archive(ctx, inbound.BranchArchiveInput{Cwd: cwd, Branch: name})
+		switch {
+		case err == nil:
+			fmt.Printf("cxt: git branch %q deleted — context archived at %s (restore: cxt branch restore %s)\n", name, shortHash(out.Target), name)
+			spawnBranchStateSync(cwd)
+		case errors.Is(err, domain.ErrNotFound):
+			// No context pointer existed for this Git branch.
+		default:
+			hookWarn("context branch %q archive failed: %v", name, err)
 		}
 
 	case "post-checkout":
@@ -672,52 +946,48 @@ func runGitHook(ctx context.Context, c *Container, cwd string, rest []string) er
 		// Responds only if the current branch ref moves to the final state (HEAD).
 		// (Git branch creation/fetch etc. changes are filtered out here).
 		branch := gitOut(cwd, "rev-parse", "--abbrev-ref", "HEAD")
-		if branch == "" || branch == "HEAD" {
-			return nil
+		want := ""
+		headFull := ""
+		if branch != "" && branch != "HEAD" {
+			want = "refs/heads/" + branch
+			headFull = gitOut(cwd, "rev-parse", "HEAD")
 		}
-		want := "refs/heads/" + branch
-		headFull := gitOut(cwd, "rev-parse", "HEAD")
 		touched := false
 		type created struct{ name, oid string }
 		var createdRefs []created
-		var deletedRefs []string
-		zeros := strings.Repeat("0", 40)
+		type deleted struct{ name, oid string }
+		var deletedRefs []deleted
 		sc := bufio.NewScanner(os.Stdin)
 		for sc.Scan() {
-			f := strings.Fields(sc.Text())
-			if len(f) != 3 || !strings.HasPrefix(f[2], "refs/heads/") {
+			txn := parseBranchRefTransaction(sc.Text())
+			if txn.name == "" {
 				continue
 			}
-			name := strings.TrimPrefix(f[2], "refs/heads/")
-			if f[0] == zeros && f[1] != zeros {
+			if txn.createdOID != "" {
 				// branch creation (git branch X / checkout -b X) — context branches too.
-				createdRefs = append(createdRefs, created{name: name, oid: f[1]})
+				createdRefs = append(createdRefs, created{name: txn.name, oid: txn.createdOID})
 				continue
 			}
-			if f[0] == zeros && f[1] == zeros {
+			if txn.deleted {
 				// branch deletion (git branch -D / PR merge cleanup). Git reports the committed
-				// phase of the deletion as zeros→zeros (empirically — old oid does not come).
-				// Immutable invariant (P1): context is never deleted or changed — only preservation notice is output.
-				deletedRefs = append(deletedRefs, name)
+				// phase as either zeros→zeros or old→zeros depending on the ref backend.
+				preparedOldOID := consumePreparedBranchRefTransaction(cwd, txn.name)
+				if !validNonZeroGitOID(txn.oldOID) {
+					txn.oldOID = preparedOldOID
+				}
+				deletedRefs = append(deletedRefs, deleted{name: txn.name, oid: txn.oldOID})
 				continue
 			}
-			if f[2] == want && f[1] == headFull {
+			if want != "" && "refs/heads/"+txn.name == want && txn.newOID == headFull {
 				touched = true
 			}
 		}
-		for _, name := range deletedRefs {
-			// Context existence check: branch label snapshot or cxt branch ref (includes fork-only).
-			n := 0
-			if list, lerr := c.List.List(ctx, inbound.ListInput{Branch: name}); lerr == nil {
-				n = len(list.Snapshots)
+		for _, deletedRef := range deletedRefs {
+			gitPID := ""
+			if len(args) > 0 {
+				gitPID = args[0]
 			}
-			refExists := false
-			if _, err := os.Stat(filepath.Join(cwd, ".cxt", "refs", "heads", filepath.FromSlash(name))); err == nil {
-				refExists = true
-			}
-			if n > 0 || refExists {
-				fmt.Printf("cxt: git branch %q deleted — context preserved (restore: cxt checkout %s)\n", name, name)
-			}
+			spawnBranchDeletionFinalize(cwd, deletedRef.name, deletedRef.oid, gitPID)
 		}
 		if !operationInProgress(cwd) {
 			// delayed handling by detached helper: checkout -b/switch -c (transient creation) temporarily

--- a/cli/internal/adapters/delivery/cli/githook_branch_lifecycle_test.go
+++ b/cli/internal/adapters/delivery/cli/githook_branch_lifecycle_test.go
@@ -1,0 +1,125 @@
+package cli
+
+import (
+	"errors"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/wnsdy95/cxthub/cli/internal/domain"
+)
+
+func TestParseBranchRefTransactionSupportsDeletionFormsAndObjectFormats(t *testing.T) {
+	sha1 := strings.Repeat("a", 40)
+	sha256 := strings.Repeat("b", 64)
+	zero40 := strings.Repeat("0", 40)
+	zero64 := strings.Repeat("0", 64)
+
+	for _, tc := range []struct {
+		line        string
+		wantName    string
+		wantCreated string
+		wantDeleted bool
+	}{
+		{line: zero40 + " " + sha1 + " refs/heads/feature/new", wantName: "feature/new", wantCreated: sha1},
+		{line: zero40 + " " + zero40 + " refs/heads/feature/deleted", wantName: "feature/deleted", wantDeleted: true},
+		{line: sha1 + " " + zero40 + " refs/heads/feature/explicit-old", wantName: "feature/explicit-old", wantDeleted: true},
+		{line: zero64 + " " + zero64 + " refs/heads/feature/sha256", wantName: "feature/sha256", wantDeleted: true},
+		{line: zero64 + " " + sha256 + " refs/heads/feature/sha256-new", wantName: "feature/sha256-new", wantCreated: sha256},
+	} {
+		got := parseBranchRefTransaction(tc.line)
+		if got.name != tc.wantName || got.createdOID != tc.wantCreated || got.deleted != tc.wantDeleted {
+			t.Fatalf("parse %q = %+v", tc.line, got)
+		}
+	}
+
+	if got := parseBranchRefTransaction(sha1 + " " + sha1 + " refs/tags/v1"); got.name != "" {
+		t.Fatalf("non-branch ref classified: %+v", got)
+	}
+	for value, want := range map[string]bool{
+		sha1: true, sha256: true, zero40: false, "": false, strings.Repeat("g", 40): false,
+	} {
+		if got := validNonZeroGitOID(value); got != want {
+			t.Fatalf("validNonZeroGitOID(%q) = %v, want %v", value, got, want)
+		}
+	}
+}
+
+func TestPreparedBranchTransactionCarriesOldOIDExactlyOnce(t *testing.T) {
+	repo := t.TempDir()
+	runLifecycleGit(t, repo, "init", "-q")
+	runLifecycleGit(t, repo, "config", "user.name", "cxt test")
+	runLifecycleGit(t, repo, "config", "user.email", "cxt@example.test")
+	runLifecycleGit(t, repo, "commit", "--allow-empty", "-qm", "base")
+	runLifecycleGit(t, repo, "branch", "feature/rename")
+	oldOID := strings.TrimSpace(runLifecycleGit(t, repo, "rev-parse", "refs/heads/feature/rename"))
+	zero := strings.Repeat("0", 40)
+	// Git 2.50's files backend reports zero→zero for branch deletion. The
+	// prepared hook must read the still-live ref instead of trusting stdin.
+	if err := recordPreparedBranchRefTransaction(repo, []string{
+		zero + " " + zero + " refs/heads/feature/rename",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	got := consumePreparedBranchRefTransaction(repo, "feature/rename")
+	if got != oldOID {
+		t.Fatalf("prepared old OID = %q, want %q", got, oldOID)
+	}
+	if again := consumePreparedBranchRefTransaction(repo, "feature/rename"); again != "" {
+		t.Fatalf("prepared ledger was not consumed: %q", again)
+	}
+	if _, err := branchRefTransactionLedgerPath("../escape"); !errors.Is(err, domain.ErrInvalidRef) {
+		t.Fatalf("unsafe transaction ID error = %v", err)
+	}
+	if err := recordPreparedBranchRefTransaction(repo, []string{
+		oldOID + " " + strings.Repeat("b", 40) + " refs/heads/main",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if ordinary := consumePreparedBranchRefTransaction(repo, "main"); ordinary != "" {
+		t.Fatalf("ordinary branch movement created a deletion ledger: %q", ordinary)
+	}
+	if err := recordPreparedBranchRefTransaction(repo, []string{
+		oldOID + " " + zero + " refs/heads/feature/rename",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	clearPreparedBranchRefTransactions(repo, []string{oldOID + " " + zero + " refs/heads/feature/rename"})
+	if aborted := consumePreparedBranchRefTransaction(repo, "feature/rename"); aborted != "" {
+		t.Fatalf("aborted deletion ledger remains: %q", aborted)
+	}
+}
+
+func TestRenamedBranchForDeletionRequiresMatchingRenameReflogAndOID(t *testing.T) {
+	repo := t.TempDir()
+	runLifecycleGit(t, repo, "init", "-q")
+	runLifecycleGit(t, repo, "config", "user.name", "cxt test")
+	runLifecycleGit(t, repo, "config", "user.email", "cxt@example.test")
+	runLifecycleGit(t, repo, "commit", "--allow-empty", "-qm", "base")
+	oid := strings.TrimSpace(runLifecycleGit(t, repo, "rev-parse", "HEAD"))
+	runLifecycleGit(t, repo, "branch", "feature/old")
+	runLifecycleGit(t, repo, "branch", "-m", "feature/old", "feature/new")
+
+	if got := renamedBranchForDeletion(repo, "feature/old", oid); got != "feature/new" {
+		t.Fatalf("rename destination = %q, want feature/new", got)
+	}
+	if got := renamedBranchForDeletion(repo, "feature/old", strings.Repeat("f", len(oid))); got != "" {
+		t.Fatalf("mismatched object classified as rename: %q", got)
+	}
+	runLifecycleGit(t, repo, "branch", "feature/deleted")
+	runLifecycleGit(t, repo, "branch", "-D", "feature/deleted")
+	if got := renamedBranchForDeletion(repo, "feature/deleted", oid); got != "" {
+		t.Fatalf("plain deletion classified as rename: %q", got)
+	}
+}
+
+func runLifecycleGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+	return string(out)
+}

--- a/cli/internal/adapters/delivery/cli/root.go
+++ b/cli/internal/adapters/delivery/cli/root.go
@@ -38,6 +38,7 @@ type Container struct {
 	Init     inbound.InitRepo
 	Save     inbound.SaveSession
 	Fork     inbound.ForkSession
+	Branches inbound.BranchLifecycle
 	Checkout inbound.CheckoutSession
 	Load     inbound.LoadSession
 	List     inbound.ListSessions
@@ -124,6 +125,47 @@ func Run(c *Container, args []string) error {
 	case "remote":
 		return runRemote(ctx, c, cwd, rest)
 
+	case "branch":
+		action := firstPositional(rest)
+		branch := ""
+		pos := positionals(rest)
+		if len(pos) > 1 {
+			branch = pos[1]
+		}
+		switch action {
+		case "archive":
+			if branch == "" {
+				return fmt.Errorf("usage: cxt branch archive <name>")
+			}
+			if gitOut(cwd, "show-ref", "--verify", "refs/heads/"+branch) != "" {
+				return fmt.Errorf("Git branch %q still exists — delete it first, then archive its context", branch)
+			}
+			out, err := c.Branches.Archive(ctx, inbound.BranchArchiveInput{Cwd: cwd, Branch: branch})
+			if err != nil {
+				return err
+			}
+			fmt.Printf("archived context branch %q at %s (history preserved)\n", out.Branch, shortHash(out.Target))
+			spawnBranchStateSync(cwd)
+			return nil
+		case "restore":
+			if branch == "" {
+				return fmt.Errorf("usage: cxt branch restore <name> [--provider claude|codex] [--mode full|reconstructed|memory]")
+			}
+			out, err := c.Checkout.Checkout(ctx, inbound.CheckoutInput{
+				From: branch, TargetProvider: flagVal(rest, "--provider"), Mode: modeOr(cwd, rest), Cwd: cwd,
+			})
+			if err != nil {
+				return err
+			}
+			printRestore(out.Branch, out.Fidelity, out.ResumeCmd, out.WrittenPath)
+			if out.ActivatedBranch {
+				spawnBranchStateSync(cwd)
+			}
+			return nil
+		default:
+			return fmt.Errorf("usage: cxt branch archive|restore <name>")
+		}
+
 	case "repack":
 		// Repack large transcript and memory objects into their storage-only chunk
 		// CAS forms. Content identities and the wire protocol remain unchanged.
@@ -182,6 +224,9 @@ func Run(c *Container, args []string) error {
 			return err
 		}
 		printRestore(out.Branch, out.Fidelity, out.ResumeCmd, out.WrittenPath)
+		if out.ActivatedBranch {
+			spawnBranchStateSync(cwd)
+		}
 		return nil
 
 	case "config":
@@ -621,6 +666,9 @@ func Run(c *Container, args []string) error {
 			return err
 		}
 		printRestore(out.Branch, out.Fidelity, out.ResumeCmd, out.WrittenPath)
+		if out.ActivatedBranch {
+			spawnBranchStateSync(cwd)
+		}
 		return nil
 
 	case "fork":
@@ -960,7 +1008,7 @@ func firstPositional(args []string) string {
 
 var publicCommandNames = []string{
 	"setup", "init", "repo", "claude", "codex", "remote", "repack",
-	"add", "commit", "switch", "config", "login", "logout", "fsck",
+	"branch", "add", "commit", "switch", "config", "login", "logout", "fsck",
 	"reflog", "secrets", "settings", "hooks", "save", "list", "log",
 	"checkout", "fork", "load", "push", "pull", "stash", "memorize",
 	"memory", "tag", "mcp", "hook", "version", "help",
@@ -989,6 +1037,8 @@ usage: cxt <command> [flags]
   remote add origin <url>   connect the server repository URL (the context equivalent of Git origin)
   remote [-v]               list configured remotes
   remote remove <name>      remove a configured remote
+  branch archive <name>     hide a deleted Git branch pointer while preserving all context history
+  branch restore <name>     restore an archived context branch and record a new active generation
   add [claude|codex]        stage providers for the next commit (defaults to both)
   commit [-m msg]           capture the active session (also run automatically by the Git commit hook)
   checkout [<ref>] [-b new] [--provider claude|codex] [--mode full|reconstructed|memory]

--- a/cli/internal/adapters/gitctx/git_context.go
+++ b/cli/internal/adapters/gitctx/git_context.go
@@ -92,5 +92,26 @@ func (a *GitContextAdapter) CurrentBranch(ctx context.Context, cwd string) (stri
 	return b, nil
 }
 
+// LocalBranches returns authoritative local refs/heads names, one per line.
+func (a *GitContextAdapter) LocalBranches(ctx context.Context, cwd string) ([]string, error) {
+	out, err := git(ctx, cwd, "for-each-ref", "--format=%(refname:short)", "refs/heads")
+	if err != nil {
+		return nil, err
+	}
+	if out == "" {
+		return nil, nil
+	}
+	lines := strings.Split(out, "\n")
+	branches := make([]string, 0, len(lines))
+	for _, branch := range lines {
+		branch = strings.TrimSpace(branch)
+		if branch != "" {
+			branches = append(branches, branch)
+		}
+	}
+	return branches, nil
+}
+
 // Ensure GitContextAdapter implements outbound.GitContext.
 var _ outbound.GitContext = (*GitContextAdapter)(nil)
+var _ outbound.GitBranchInventory = (*GitContextAdapter)(nil)

--- a/cli/internal/adapters/gitctx/git_context_test.go
+++ b/cli/internal/adapters/gitctx/git_context_test.go
@@ -1,0 +1,61 @@
+package gitctx
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func runGitContextTestCommand(t *testing.T, cwd string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", cwd}, args...)...)
+	cmd.Env = append(os.Environ(),
+		"GIT_CONFIG_NOSYSTEM=1",
+		"GIT_AUTHOR_NAME=cxt test",
+		"GIT_AUTHOR_EMAIL=cxt@example.invalid",
+		"GIT_COMMITTER_NAME=cxt test",
+		"GIT_COMMITTER_EMAIL=cxt@example.invalid",
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}
+
+func TestLocalBranchesListsAllHeadsWhileDetached(t *testing.T) {
+	repo := t.TempDir()
+	runGitContextTestCommand(t, repo, "init", "-q")
+	runGitContextTestCommand(t, repo, "symbolic-ref", "HEAD", "refs/heads/main")
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("base\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGitContextTestCommand(t, repo, "add", "tracked.txt")
+	runGitContextTestCommand(t, repo, "commit", "-q", "-m", "base")
+	runGitContextTestCommand(t, repo, "branch", "feature/nested")
+	runGitContextTestCommand(t, repo, "branch", "release")
+	runGitContextTestCommand(t, repo, "checkout", "-q", "--detach", "HEAD")
+
+	branches, err := NewGitContextAdapter().LocalBranches(context.Background(), repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := make(map[string]bool, len(branches))
+	for _, branch := range branches {
+		got[branch] = true
+	}
+	for _, want := range []string{"main", "feature/nested", "release"} {
+		if !got[want] {
+			t.Fatalf("LocalBranches() = %v, missing %q", branches, want)
+		}
+	}
+	if len(got) != 3 {
+		t.Fatalf("LocalBranches() = %v, want exactly 3 heads", branches)
+	}
+}
+
+func TestLocalBranchesFailsOutsideGitRepository(t *testing.T) {
+	if _, err := NewGitContextAdapter().LocalBranches(context.Background(), t.TempDir()); err == nil {
+		t.Fatal("LocalBranches() outside a Git repository succeeded")
+	}
+}

--- a/cli/internal/adapters/githooks/githooks.go
+++ b/cli/internal/adapters/githooks/githooks.go
@@ -60,15 +60,29 @@ func script(hookName, cxtBin string) string {
 input=$(cat)
 # Existing user hook chaining (stdin refilling).
 [ -x "$0.pre-cxt" ] && printf '%%s\n' "$input" | "$0.pre-cxt" "$@"
-[ "$1" = "committed" ] || exit 0
 CXT=%s
 [ -x "$CXT" ] || CXT=cxt
 command -v "$CXT" >/dev/null 2>&1 || exit 0
+if [ "$1" = "prepared" ]; then
+  case "$input" in
+  *' 0000000000000000000000000000000000000000 refs/heads/'*|*' 0000000000000000000000000000000000000000000000000000000000000000 refs/heads/'*)
+    printf '%%s\n' "$input" | "$CXT" git-hook ref-prepare || true ;;
+  esac
+  exit 0
+fi
+if [ "$1" = "aborted" ]; then
+  case "$input" in
+  *' 0000000000000000000000000000000000000000 refs/heads/'*|*' 0000000000000000000000000000000000000000000000000000000000000000 refs/heads/'*)
+    printf '%%s\n' "$input" | "$CXT" git-hook ref-abort || true ;;
+  esac
+  exit 0
+fi
+[ "$1" = "committed" ] || exit 0
 case "$input" in
 *refs/stash*) "$CXT" git-hook stash-sync || true ;;
 esac
 case "$input" in
-*refs/heads/*) printf '%%s\n' "$input" | "$CXT" git-hook ref-sync || true ;;
+*refs/heads/*) printf '%%s\n' "$input" | "$CXT" git-hook ref-sync "$PPID" || true ;;
 esac
 exit 0
 `, Marker, shellQuote(cxtBin))

--- a/cli/internal/adapters/githooks/githooks_security_test.go
+++ b/cli/internal/adapters/githooks/githooks_security_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -22,6 +23,29 @@ func TestEnsureGitignoreRefusesSymlinkTarget(t *testing.T) {
 	got, err := os.ReadFile(outside)
 	if err != nil || string(got) != "keep" {
 		t.Fatalf("outside target changed: %q err=%v", got, err)
+	}
+}
+
+func TestReferenceTransactionScriptCarriesPreparedStateByBranch(t *testing.T) {
+	got := script("reference-transaction", "/usr/local/bin/cxt")
+	check := exec.Command("/bin/sh", "-n")
+	check.Stdin = strings.NewReader(got)
+	if out, err := check.CombinedOutput(); err != nil {
+		t.Fatalf("invalid reference-transaction shell: %v\n%s", err, out)
+	}
+	for _, want := range []string{
+		`git-hook ref-prepare`,
+		`git-hook ref-abort`,
+		`git-hook ref-sync "$PPID"`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("reference-transaction hook lacks %q:\n%s", want, got)
+		}
+	}
+	for _, forbidden := range []string{`ref-prepare "$PPID"`, `ref-abort "$PPID"`} {
+		if strings.Contains(got, forbidden) {
+			t.Fatalf("prepared lifecycle is incorrectly keyed by unstable hook PPID %q:\n%s", forbidden, got)
+		}
 	}
 }
 

--- a/cli/internal/adapters/remotecfg/remotecfg.go
+++ b/cli/internal/adapters/remotecfg/remotecfg.go
@@ -433,5 +433,14 @@ func (g *GitContextWithRemote) CurrentBranch(ctx context.Context, cwd string) (s
 	return g.inner.CurrentBranch(ctx, cwd)
 }
 
+func (g *GitContextWithRemote) LocalBranches(ctx context.Context, cwd string) ([]string, error) {
+	inventory, ok := g.inner.(outbound.GitBranchInventory)
+	if !ok {
+		return nil, domain.ErrNotGitRepo
+	}
+	return inventory.LocalBranches(ctx, cwd)
+}
+
 // Ensure interface implementation.
 var _ outbound.GitContext = (*GitContextWithRemote)(nil)
+var _ outbound.GitBranchInventory = (*GitContextWithRemote)(nil)

--- a/cli/internal/adapters/storage/branch_lifecycle_test.go
+++ b/cli/internal/adapters/storage/branch_lifecycle_test.go
@@ -1,0 +1,240 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/wnsdy95/cxthub/cli/internal/domain"
+)
+
+func TestFileStoreBranchLifecycleBlocksStaleResurrectionAndRestoresExplicitly(t *testing.T) {
+	ctx := context.Background()
+	store := NewFileStore(t.TempDir())
+	repoID := string(domain.HashContent([]byte("branch lifecycle repo")))
+	target := domain.HashContent([]byte("branch lifecycle target"))
+	branch := domain.Ref{Kind: domain.RefBranch, Name: "feature/archive", RepoID: repoID, Target: target}
+
+	active, err := store.CreateBranchRef(ctx, branch)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	activeEvent, ok, err := domain.ParseBranchLifecycleRef(active)
+	if err != nil || !ok || activeEvent.State != domain.BranchActive || activeEvent.Generation != 1 {
+		t.Fatalf("active event = %+v, %v, %v", activeEvent, ok, err)
+	}
+	if err := store.PutRef(ctx, domain.Ref{Kind: domain.RefHEAD, Name: domain.HeadRefName, RepoID: repoID, Symbolic: branch.Name}); err != nil {
+		t.Fatal(err)
+	}
+
+	archived, err := store.ArchiveBranchRef(ctx, repoID, branch.Name)
+	if err != nil {
+		t.Fatalf("archive: %v", err)
+	}
+	archiveEvent, ok, err := domain.ParseBranchLifecycleRef(archived)
+	if err != nil || !ok || archiveEvent.State != domain.BranchArchived || archiveEvent.Generation != 2 {
+		t.Fatalf("archive event = %+v, %v, %v", archiveEvent, ok, err)
+	}
+	if _, err := store.GetRef(ctx, repoID, domain.RefBranch, branch.Name); !errors.Is(err, domain.ErrNotFound) {
+		t.Fatalf("archived branch still active: %v", err)
+	}
+	if head, err := store.GetRef(ctx, repoID, domain.RefHEAD, domain.HeadRefName); err != nil || head.Symbolic != "" || head.Target != target {
+		t.Fatalf("HEAD was not detached at archived target: %+v, %v", head, err)
+	}
+	if err := store.PutRef(ctx, branch); !errors.Is(err, domain.ErrBranchArchived) {
+		t.Fatalf("stale PutRef resurrected branch: %v", err)
+	}
+
+	restored, err := store.CreateBranchRef(ctx, branch)
+	if err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+	restoreEvent, ok, err := domain.ParseBranchLifecycleRef(restored)
+	if err != nil || !ok || restoreEvent.State != domain.BranchActive || restoreEvent.Generation != 3 {
+		t.Fatalf("restore event = %+v, %v, %v", restoreEvent, ok, err)
+	}
+	if got, err := store.GetRef(ctx, repoID, domain.RefBranch, branch.Name); err != nil || got.Target != target {
+		t.Fatalf("restored branch = %+v, %v", got, err)
+	}
+}
+
+func TestFileStoreApplyArchivePreservesLiveOrAdvancedLocalBranch(t *testing.T) {
+	ctx := context.Background()
+	repoID := string(domain.HashContent([]byte("branch apply repo")))
+	archivedTarget := domain.HashContent([]byte("archived target"))
+	advancedTarget := domain.HashContent([]byte("advanced target"))
+
+	for _, tc := range []struct {
+		name          string
+		localTarget   domain.ContentHash
+		preserve      bool
+		wantPreserved bool
+	}{
+		{name: "same inactive target is archived", localTarget: archivedTarget},
+		{name: "same live Git branch wins", localTarget: archivedTarget, preserve: true, wantPreserved: true},
+		{name: "advanced local context wins", localTarget: advancedTarget, wantPreserved: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store := NewFileStore(t.TempDir())
+			branch := domain.Ref{Kind: domain.RefBranch, Name: "feature/shared", RepoID: repoID, Target: tc.localTarget}
+			if _, err := store.CreateBranchRef(ctx, branch); err != nil {
+				t.Fatal(err)
+			}
+			archive, err := domain.NewBranchLifecycleRef(repoID, branch.Name, archivedTarget, 2, domain.BranchArchived)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := store.ApplyBranchLifecycleRef(ctx, archive, tc.preserve); err != nil {
+				t.Fatalf("apply: %v", err)
+			}
+			got, getErr := store.GetRef(ctx, repoID, domain.RefBranch, branch.Name)
+			if !tc.wantPreserved {
+				if !errors.Is(getErr, domain.ErrNotFound) {
+					t.Fatalf("branch not archived: %+v, %v", got, getErr)
+				}
+				return
+			}
+			if getErr != nil || got.Target != tc.localTarget {
+				t.Fatalf("live branch changed: %+v, %v", got, getErr)
+			}
+			refs, err := store.ListRefs(ctx, repoID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			latest, ok, err := domain.LatestBranchLifecycle(refs, branch.Name)
+			if err != nil || !ok || latest.State != domain.BranchActive || latest.Generation != 3 || latest.Target != tc.localTarget {
+				t.Fatalf("compensating active event = %+v, %v, %v", latest, ok, err)
+			}
+		})
+	}
+}
+
+func TestFileStorePutRefRepairsLifecycleBeforeMovingAdvancedArchiveResidue(t *testing.T) {
+	ctx := context.Background()
+	store := NewFileStore(t.TempDir())
+	repoID := string(domain.HashContent([]byte("branch lifecycle crash recovery repo")))
+	archivedTarget := domain.HashContent([]byte("archived target"))
+	advancedTarget := domain.HashContent([]byte("advanced target"))
+	nextTarget := domain.HashContent([]byte("next target"))
+	const branchName = "feature/recovered"
+
+	// Simulate a crash/interleaving in which an archive event became durable,
+	// while the physical branch had already advanced and no compensating active
+	// event was written yet.
+	archive, err := domain.NewBranchLifecycleRef(repoID, branchName, archivedTarget, 1, domain.BranchArchived)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.putRefRaw(archive); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.putRefRaw(domain.Ref{Kind: domain.RefBranch, Name: branchName, RepoID: repoID, Target: advancedTarget}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := store.PutRef(ctx, domain.Ref{Kind: domain.RefBranch, Name: branchName, RepoID: repoID, Target: nextTarget}); err != nil {
+		t.Fatalf("move advanced residue: %v", err)
+	}
+	got, err := store.GetRef(ctx, repoID, domain.RefBranch, branchName)
+	if err != nil || got.Target != nextTarget {
+		t.Fatalf("moved branch = %+v, %v", got, err)
+	}
+	refs, err := store.listRefsRaw(ctx, repoID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	latest, ok, err := domain.LatestBranchLifecycle(refs, branchName)
+	if err != nil || !ok || latest.State != domain.BranchActive || latest.Generation != 2 || latest.Target != advancedTarget {
+		t.Fatalf("recovery event = %+v, %v, %v", latest, ok, err)
+	}
+}
+
+func TestFileStoreProjectsSymbolicHEADAfterInterruptedArchive(t *testing.T) {
+	ctx := context.Background()
+	store := NewFileStore(t.TempDir())
+	repoID := string(domain.HashContent([]byte("interrupted archive head repo")))
+	target := domain.HashContent([]byte("interrupted archive head target"))
+	const branchName = "feature/interrupted-head"
+	if _, err := store.CreateBranchRef(ctx, domain.Ref{Kind: domain.RefBranch, Name: branchName, RepoID: repoID, Target: target}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.PutRef(ctx, domain.Ref{Kind: domain.RefHEAD, Name: domain.HeadRefName, RepoID: repoID, Symbolic: branchName}); err != nil {
+		t.Fatal(err)
+	}
+	archive, err := domain.NewBranchLifecycleRef(repoID, branchName, target, 2, domain.BranchArchived)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Crash point: immutable archive is durable, but HEAD detach and branch
+	// file removal have not run yet.
+	if err := store.putRefRaw(archive); err != nil {
+		t.Fatal(err)
+	}
+	head, err := store.GetRef(ctx, repoID, domain.RefHEAD, domain.HeadRefName)
+	if err != nil || head.Symbolic != "" || head.Target != target {
+		t.Fatalf("projected HEAD = %+v, %v", head, err)
+	}
+	if _, err := store.GetRef(ctx, repoID, domain.RefBranch, branchName); !errors.Is(err, domain.ErrNotFound) {
+		t.Fatalf("interrupted branch projection remains visible: %v", err)
+	}
+}
+
+func TestFileStoreReconcilesInterruptedBranchLifecycleBeforePush(t *testing.T) {
+	ctx := context.Background()
+	repoID := string(domain.HashContent([]byte("reconcile interrupted lifecycle repo")))
+	archivedTarget := domain.HashContent([]byte("reconcile archived target"))
+	advancedTarget := domain.HashContent([]byte("reconcile advanced target"))
+
+	t.Run("advanced branch gets durable active compensation", func(t *testing.T) {
+		store := NewFileStore(t.TempDir())
+		archive, err := domain.NewBranchLifecycleRef(repoID, "feature/advanced", archivedTarget, 1, domain.BranchArchived)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := store.putRefRaw(archive); err != nil {
+			t.Fatal(err)
+		}
+		if err := store.putRefRaw(domain.Ref{Kind: domain.RefBranch, Name: "feature/advanced", RepoID: repoID, Target: advancedTarget}); err != nil {
+			t.Fatal(err)
+		}
+		if err := store.ReconcileBranchLifecycleRefs(ctx, repoID); err != nil {
+			t.Fatal(err)
+		}
+		refs, err := store.listRefsRaw(ctx, repoID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		latest, ok, err := domain.LatestBranchLifecycle(refs, "feature/advanced")
+		if err != nil || !ok || latest.State != domain.BranchActive || latest.Generation != 2 || latest.Target != advancedTarget {
+			t.Fatalf("reconciled lifecycle = %+v, %v, %v", latest, ok, err)
+		}
+	})
+
+	t.Run("equal stale branch is removed and symbolic HEAD detached", func(t *testing.T) {
+		store := NewFileStore(t.TempDir())
+		const branch = "feature/equal"
+		archive, err := domain.NewBranchLifecycleRef(repoID, branch, archivedTarget, 1, domain.BranchArchived)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := store.putRefRaw(archive); err != nil {
+			t.Fatal(err)
+		}
+		if err := store.putRefRaw(domain.Ref{Kind: domain.RefBranch, Name: branch, RepoID: repoID, Target: archivedTarget}); err != nil {
+			t.Fatal(err)
+		}
+		if err := store.putRefRaw(domain.Ref{Kind: domain.RefHEAD, Name: domain.HeadRefName, RepoID: repoID, Symbolic: branch}); err != nil {
+			t.Fatal(err)
+		}
+		if err := store.ReconcileBranchLifecycleRefs(ctx, repoID); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := store.getRefRaw(ctx, repoID, domain.RefBranch, branch); !errors.Is(err, domain.ErrNotFound) {
+			t.Fatalf("stale raw branch remains: %v", err)
+		}
+		head, err := store.getRefRaw(ctx, repoID, domain.RefHEAD, domain.HeadRefName)
+		if err != nil || head.Symbolic != "" || head.Target != archivedTarget {
+			t.Fatalf("reconciled HEAD = %+v, %v", head, err)
+		}
+	})
+}

--- a/cli/internal/adapters/storage/file_store.go
+++ b/cli/internal/adapters/storage/file_store.go
@@ -346,6 +346,13 @@ func (s *FileStore) withPendingMutationLock(ctx context.Context, sessionID strin
 	return s.withMutationLock(ctx, "pending", hex.EncodeToString(sum[:]), fn)
 }
 
+// withRefMutationLock serializes all ref projections for this local repo.
+// Branch lifecycle transitions touch one branch plus an immutable tag, so a
+// per-ref lock would still permit a torn archive/create operation.
+func (s *FileStore) withRefMutationLock(ctx context.Context, fn func() error) error {
+	return s.withMutationLock(ctx, "refs", "repo", fn)
+}
+
 func (s *FileStore) withMutationLock(ctx context.Context, namespace, key string, fn func() error) error {
 	locksDir := filepath.Join(s.storeDir(), "locks", namespace)
 	if err := validateCxtDir(locksDir); err != nil {
@@ -644,11 +651,52 @@ func (s *FileStore) ListSnapshots(_ context.Context, _ string, branch string) ([
 	return out, nil
 }
 
-// PutRef upserts a mutable pointer (HEAD/branch/session/tag).
-func (s *FileStore) PutRef(_ context.Context, ref domain.Ref) error {
+// PutRef upserts an existing mutable pointer (HEAD/branch/session/tag). A
+// branch whose latest lifecycle event is archived cannot be recreated through
+// this generic path; CreateBranchRef must record a newer active event first.
+func (s *FileStore) PutRef(ctx context.Context, ref domain.Ref) error {
 	if err := domain.ValidateRef(ref); err != nil {
 		return err
 	}
+	return s.withRefMutationLock(ctx, func() error {
+		if ref.Kind == domain.RefBranch {
+			raw, rawErr := s.getRefRaw(ctx, ref.RepoID, ref.Kind, ref.Name)
+			if rawErr != nil && !errors.Is(rawErr, domain.ErrNotFound) {
+				return rawErr
+			}
+			refs, err := s.listRefsRaw(ctx, ref.RepoID)
+			if err != nil {
+				return err
+			}
+			latest, ok, err := domain.LatestBranchLifecycle(refs, ref.Name)
+			if err != nil {
+				return err
+			}
+			if ok && latest.State == domain.BranchArchived {
+				if errors.Is(rawErr, domain.ErrNotFound) || latest.Target == raw.Target {
+					return domain.ErrBranchArchived
+				}
+				generation, err := domain.NextBranchLifecycleGeneration(refs, ref.Name)
+				if err != nil {
+					return err
+				}
+				active, err := domain.NewBranchLifecycleRef(ref.RepoID, ref.Name, raw.Target, generation, domain.BranchActive)
+				if err != nil {
+					return err
+				}
+				// The raw branch already escaped the archived target. Persist that
+				// evidence before moving it so a crash cannot make later readers
+				// reinterpret the branch as deleted.
+				if err := s.putRefRaw(active); err != nil {
+					return err
+				}
+			}
+		}
+		return s.putRefRaw(ref)
+	})
+}
+
+func (s *FileStore) putRefRaw(ref domain.Ref) error {
 	switch ref.Kind {
 	case domain.RefHEAD:
 		content := string(ref.Target)
@@ -671,8 +719,9 @@ func (s *FileStore) refPath(kind, name string) string {
 	return filepath.Join(s.storeDir(), "refs", kind, filepath.FromSlash(name))
 }
 
-// GetRef retrieves a ref by (repoID, kind, name). Returns domain.ErrNotFound if not found.
-func (s *FileStore) GetRef(_ context.Context, repoID string, kind domain.RefKind, name string) (domain.Ref, error) {
+// getRefRaw reads the physical projection without interpreting lifecycle
+// events. Callers performing a transition already hold the repo ref lock.
+func (s *FileStore) getRefRaw(_ context.Context, repoID string, kind domain.RefKind, name string) (domain.Ref, error) {
 	if err := domain.ValidateRefName(kind, name); err != nil {
 		return domain.Ref{}, err
 	}
@@ -720,10 +769,33 @@ func (s *FileStore) GetRef(_ context.Context, repoID string, kind domain.RefKind
 	}
 }
 
-// ListRefs lists all refs (HEAD + branches + session lines + tags) of a repo.
-func (s *FileStore) ListRefs(ctx context.Context, repoID string) ([]domain.Ref, error) {
+// GetRef retrieves the logical ref projection. An archived branch is absent
+// even if a crash left its old physical file behind after the immutable event
+// was durably written.
+func (s *FileStore) GetRef(ctx context.Context, repoID string, kind domain.RefKind, name string) (domain.Ref, error) {
+	ref, err := s.getRefRaw(ctx, repoID, kind, name)
+	if err != nil || (kind != domain.RefBranch && kind != domain.RefHEAD) {
+		return ref, err
+	}
+	refs, err := s.listRefsRaw(ctx, repoID)
+	if err != nil {
+		return domain.Ref{}, err
+	}
+	projected, err := domain.ProjectBranchLifecycleRefs(refs)
+	if err != nil {
+		return domain.Ref{}, err
+	}
+	for _, candidate := range projected {
+		if candidate.Kind == kind && candidate.Name == name {
+			return candidate, nil
+		}
+	}
+	return domain.Ref{}, domain.ErrNotFound
+}
+
+func (s *FileStore) listRefsRaw(ctx context.Context, repoID string) ([]domain.Ref, error) {
 	var out []domain.Ref
-	if head, err := s.GetRef(ctx, repoID, domain.RefHEAD, "HEAD"); err == nil {
+	if head, err := s.getRefRaw(ctx, repoID, domain.RefHEAD, "HEAD"); err == nil {
 		out = append(out, head)
 	} else if !errors.Is(err, domain.ErrNotFound) {
 		return nil, err
@@ -750,7 +822,7 @@ func (s *FileStore) ListRefs(ctx context.Context, repoID string) ([]domain.Ref, 
 			if rerr != nil {
 				return rerr
 			}
-			ref, rerr := s.GetRef(ctx, repoID, kc.kind, filepath.ToSlash(rel))
+			ref, rerr := s.getRefRaw(ctx, repoID, kc.kind, filepath.ToSlash(rel))
 			if rerr != nil {
 				return rerr
 			}
@@ -762,6 +834,243 @@ func (s *FileStore) ListRefs(ctx context.Context, repoID string) ([]domain.Ref, 
 		}
 	}
 	return out, nil
+}
+
+// ListRefs lists the logical HEAD + active branches + sessions + immutable
+// tags. Lifecycle tags remain in the manifest so other replicas can converge.
+func (s *FileStore) ListRefs(ctx context.Context, repoID string) ([]domain.Ref, error) {
+	refs, err := s.listRefsRaw(ctx, repoID)
+	if err != nil {
+		return nil, err
+	}
+	return domain.ProjectBranchLifecycleRefs(refs)
+}
+
+// CreateBranchRef creates (or explicitly restores) a branch and records a
+// newer active lifecycle event in the same cross-process critical section.
+func (s *FileStore) CreateBranchRef(ctx context.Context, ref domain.Ref) (domain.Ref, error) {
+	if err := domain.ValidateRef(ref); err != nil {
+		return domain.Ref{}, err
+	}
+	if ref.Kind != domain.RefBranch {
+		return domain.Ref{}, domain.ErrInvalidRef
+	}
+	var event domain.Ref
+	err := s.withRefMutationLock(ctx, func() error {
+		raw, err := s.getRefRaw(ctx, ref.RepoID, domain.RefBranch, ref.Name)
+		if err == nil {
+			refs, lerr := s.listRefsRaw(ctx, ref.RepoID)
+			if lerr != nil {
+				return lerr
+			}
+			latest, ok, lerr := domain.LatestBranchLifecycle(refs, ref.Name)
+			if lerr != nil {
+				return lerr
+			}
+			if !ok || latest.State != domain.BranchArchived || latest.Target != raw.Target {
+				return domain.ErrBranchExists
+			}
+		} else if !errors.Is(err, domain.ErrNotFound) {
+			return err
+		}
+		refs, err := s.listRefsRaw(ctx, ref.RepoID)
+		if err != nil {
+			return err
+		}
+		generation, err := domain.NextBranchLifecycleGeneration(refs, ref.Name)
+		if err != nil {
+			return err
+		}
+		event, err = domain.NewBranchLifecycleRef(ref.RepoID, ref.Name, ref.Target, generation, domain.BranchActive)
+		if err != nil {
+			return err
+		}
+		if err := s.putRefRaw(event); err != nil {
+			return err
+		}
+		return s.putRefRaw(ref)
+	})
+	return event, err
+}
+
+func (s *FileStore) detachHeadFromBranch(ctx context.Context, repoID, branch string, target domain.ContentHash) error {
+	head, err := s.getRefRaw(ctx, repoID, domain.RefHEAD, domain.HeadRefName)
+	if errors.Is(err, domain.ErrNotFound) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if strings.TrimPrefix(head.Symbolic, "refs/heads/") != branch {
+		return nil
+	}
+	return s.putRefRaw(domain.Ref{
+		Kind: domain.RefHEAD, Name: domain.HeadRefName, RepoID: repoID, Target: target,
+	})
+}
+
+// ArchiveBranchRef records the current branch target as an immutable event
+// before removing its active projection. Repeating an already-completed
+// archive is idempotent.
+func (s *FileStore) ArchiveBranchRef(ctx context.Context, repoID, branch string) (domain.Ref, error) {
+	if err := domain.ValidateBranchName(branch); err != nil {
+		return domain.Ref{}, err
+	}
+	var event domain.Ref
+	err := s.withRefMutationLock(ctx, func() error {
+		refs, err := s.listRefsRaw(ctx, repoID)
+		if err != nil {
+			return err
+		}
+		latest, hasLatest, err := domain.LatestBranchLifecycle(refs, branch)
+		if err != nil {
+			return err
+		}
+		raw, err := s.getRefRaw(ctx, repoID, domain.RefBranch, branch)
+		if errors.Is(err, domain.ErrNotFound) {
+			if hasLatest && latest.State == domain.BranchArchived {
+				event = latest.Ref
+				return s.detachHeadFromBranch(ctx, repoID, branch, latest.Target)
+			}
+			return domain.ErrNotFound
+		}
+		if err != nil {
+			return err
+		}
+		if hasLatest && latest.State == domain.BranchArchived && latest.Target == raw.Target {
+			event = latest.Ref
+			if err := s.detachHeadFromBranch(ctx, repoID, branch, raw.Target); err != nil {
+				return err
+			}
+			return removeCxtFile(s.refPath("heads", branch))
+		}
+		generation, err := domain.NextBranchLifecycleGeneration(refs, branch)
+		if err != nil {
+			return err
+		}
+		event, err = domain.NewBranchLifecycleRef(repoID, branch, raw.Target, generation, domain.BranchArchived)
+		if err != nil {
+			return err
+		}
+		if err := s.putRefRaw(event); err != nil {
+			return err
+		}
+		if err := s.detachHeadFromBranch(ctx, repoID, branch, raw.Target); err != nil {
+			return err
+		}
+		return removeCxtFile(s.refPath("heads", branch))
+	})
+	return event, err
+}
+
+// ApplyBranchLifecycleRef replicates one immutable lifecycle event. If a local
+// Git branch is known to be live, or its context has already advanced past the
+// archived target, a compensating active event preserves that work.
+func (s *FileStore) ApplyBranchLifecycleRef(ctx context.Context, eventRef domain.Ref, preserve bool) error {
+	event, ok, err := domain.ParseBranchLifecycleRef(eventRef)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return domain.ErrInvalidRef
+	}
+	return s.withRefMutationLock(ctx, func() error {
+		if existing, err := s.getRefRaw(ctx, eventRef.RepoID, domain.RefTag, eventRef.Name); err == nil {
+			if existing.Target != eventRef.Target {
+				return domain.ErrHashMismatch
+			}
+		} else if errors.Is(err, domain.ErrNotFound) {
+			if err := s.putRefRaw(eventRef); err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
+
+		refs, err := s.listRefsRaw(ctx, eventRef.RepoID)
+		if err != nil {
+			return err
+		}
+		latest, found, err := domain.LatestBranchLifecycle(refs, event.Branch)
+		if err != nil || !found || latest.Ref.Name != eventRef.Name || latest.State != domain.BranchArchived {
+			return err
+		}
+		branch, err := s.getRefRaw(ctx, eventRef.RepoID, domain.RefBranch, event.Branch)
+		if errors.Is(err, domain.ErrNotFound) {
+			return s.detachHeadFromBranch(ctx, eventRef.RepoID, event.Branch, latest.Target)
+		}
+		if err != nil {
+			return err
+		}
+		if branch.Target == latest.Target && !preserve {
+			if err := s.detachHeadFromBranch(ctx, eventRef.RepoID, event.Branch, branch.Target); err != nil {
+				return err
+			}
+			return removeCxtFile(s.refPath("heads", event.Branch))
+		}
+		generation, err := domain.NextBranchLifecycleGeneration(refs, event.Branch)
+		if err != nil {
+			return err
+		}
+		active, err := domain.NewBranchLifecycleRef(eventRef.RepoID, event.Branch, branch.Target, generation, domain.BranchActive)
+		if err != nil {
+			return err
+		}
+		return s.putRefRaw(active)
+	})
+}
+
+// ReconcileBranchLifecycleRefs completes crash-interrupted local projections.
+// The immutable event is the durable intent: an equal branch is removed, a
+// missing branch leaves HEAD detached, and an already-advanced branch records
+// a newer active event before the next push can expose that pointer remotely.
+func (s *FileStore) ReconcileBranchLifecycleRefs(ctx context.Context, repoID string) error {
+	return s.withRefMutationLock(ctx, func() error {
+		refs, err := s.listRefsRaw(ctx, repoID)
+		if err != nil {
+			return err
+		}
+		states, err := domain.BranchLifecycleStates(refs)
+		if err != nil {
+			return err
+		}
+		for branch, latest := range states {
+			if latest.State != domain.BranchArchived {
+				continue
+			}
+			raw, err := s.getRefRaw(ctx, repoID, domain.RefBranch, branch)
+			switch {
+			case errors.Is(err, domain.ErrNotFound):
+				if err := s.detachHeadFromBranch(ctx, repoID, branch, latest.Target); err != nil {
+					return err
+				}
+				continue
+			case err != nil:
+				return err
+			case raw.Target == latest.Target:
+				if err := s.detachHeadFromBranch(ctx, repoID, branch, raw.Target); err != nil {
+					return err
+				}
+				if err := removeCxtFile(s.refPath("heads", branch)); err != nil {
+					return err
+				}
+				continue
+			}
+			generation, err := domain.NextBranchLifecycleGeneration(refs, branch)
+			if err != nil {
+				return err
+			}
+			active, err := domain.NewBranchLifecycleRef(repoID, branch, raw.Target, generation, domain.BranchActive)
+			if err != nil {
+				return err
+			}
+			if err := s.putRefRaw(active); err != nil {
+				return err
+			}
+			refs = append(refs, active)
+		}
+		return nil
+	})
 }
 
 // Manifest returns the catalog (snapshot index + ref list) of a repo.

--- a/cli/internal/app/branch_lifecycle.go
+++ b/cli/internal/app/branch_lifecycle.go
@@ -1,0 +1,122 @@
+package app
+
+import (
+	"context"
+	"errors"
+
+	"github.com/wnsdy95/cxthub/cli/internal/domain"
+	"github.com/wnsdy95/cxthub/cli/internal/ports/inbound"
+	"github.com/wnsdy95/cxthub/cli/internal/ports/outbound"
+)
+
+type BranchLifecycleService struct {
+	gitCtx outbound.GitContext
+	store  outbound.SessionStore
+}
+
+func NewBranchLifecycleService(gitCtx outbound.GitContext, store outbound.SessionStore) *BranchLifecycleService {
+	return &BranchLifecycleService{gitCtx: gitCtx, store: store}
+}
+
+func (s *BranchLifecycleService) Archive(ctx context.Context, in inbound.BranchArchiveInput) (inbound.BranchArchiveOutput, error) {
+	if err := domain.ValidateBranchName(in.Branch); err != nil {
+		return inbound.BranchArchiveOutput{}, err
+	}
+	repoID := in.RepoID
+	if repoID == "" {
+		repo, err := s.gitCtx.CurrentRepo(ctx, in.Cwd)
+		if err != nil {
+			return inbound.BranchArchiveOutput{}, err
+		}
+		repoID = repo.ID
+	}
+	event, err := s.store.ArchiveBranchRef(ctx, repoID, in.Branch)
+	if err != nil {
+		return inbound.BranchArchiveOutput{}, err
+	}
+	parsed, ok, err := domain.ParseBranchLifecycleRef(event)
+	if err != nil || !ok || parsed.State != domain.BranchArchived {
+		if err != nil {
+			return inbound.BranchArchiveOutput{}, err
+		}
+		return inbound.BranchArchiveOutput{}, domain.ErrInvalidRef
+	}
+	return inbound.BranchArchiveOutput{Branch: in.Branch, Target: parsed.Target, Event: event}, nil
+}
+
+// Rename transfers only the mutable branch projection. The destination is
+// activated before the source is archived, so an interrupted rename leaves a
+// recoverable duplicate rather than a missing branch. A force-renamed
+// destination is archived first, preserving its former context as an
+// immutable lifecycle root.
+func (s *BranchLifecycleService) Rename(ctx context.Context, in inbound.BranchRenameInput) (inbound.BranchRenameOutput, error) {
+	if err := domain.ValidateBranchName(in.From); err != nil {
+		return inbound.BranchRenameOutput{}, err
+	}
+	if err := domain.ValidateBranchName(in.To); err != nil {
+		return inbound.BranchRenameOutput{}, err
+	}
+	if in.From == in.To {
+		return inbound.BranchRenameOutput{}, domain.ErrInvalidRef
+	}
+	repoID := in.RepoID
+	if repoID == "" {
+		repo, err := s.gitCtx.CurrentRepo(ctx, in.Cwd)
+		if err != nil {
+			return inbound.BranchRenameOutput{}, err
+		}
+		repoID = repo.ID
+	}
+
+	source, err := s.store.GetRef(ctx, repoID, domain.RefBranch, in.From)
+	sourceArchived := false
+	if errors.Is(err, domain.ErrNotFound) {
+		refs, listErr := s.store.ListRefs(ctx, repoID)
+		if listErr != nil {
+			return inbound.BranchRenameOutput{}, listErr
+		}
+		latest, ok, stateErr := domain.LatestBranchLifecycle(refs, in.From)
+		if stateErr != nil {
+			return inbound.BranchRenameOutput{}, stateErr
+		}
+		if !ok || latest.State != domain.BranchArchived {
+			return inbound.BranchRenameOutput{}, domain.ErrNotFound
+		}
+		source = domain.Ref{Kind: domain.RefBranch, Name: in.From, RepoID: repoID, Target: latest.Target}
+		sourceArchived = true
+	} else if err != nil {
+		return inbound.BranchRenameOutput{}, err
+	}
+
+	destination, destErr := s.store.GetRef(ctx, repoID, domain.RefBranch, in.To)
+	switch {
+	case destErr == nil && destination.Target != source.Target:
+		if _, err := s.store.ArchiveBranchRef(ctx, repoID, in.To); err != nil {
+			return inbound.BranchRenameOutput{}, err
+		}
+		destErr = domain.ErrNotFound
+	case destErr != nil && !errors.Is(destErr, domain.ErrNotFound):
+		return inbound.BranchRenameOutput{}, destErr
+	}
+	if errors.Is(destErr, domain.ErrNotFound) {
+		_, createErr := s.store.CreateBranchRef(ctx, domain.Ref{
+			Kind: domain.RefBranch, Name: in.To, RepoID: repoID, Target: source.Target,
+		})
+		if errors.Is(createErr, domain.ErrBranchExists) {
+			current, getErr := s.store.GetRef(ctx, repoID, domain.RefBranch, in.To)
+			if getErr != nil || current.Target != source.Target {
+				return inbound.BranchRenameOutput{}, createErr
+			}
+		} else if createErr != nil {
+			return inbound.BranchRenameOutput{}, createErr
+		}
+	}
+	if !sourceArchived {
+		if _, err := s.store.ArchiveBranchRef(ctx, repoID, in.From); err != nil {
+			return inbound.BranchRenameOutput{}, err
+		}
+	}
+	return inbound.BranchRenameOutput{From: in.From, To: in.To, Target: source.Target}, nil
+}
+
+var _ inbound.BranchLifecycle = (*BranchLifecycleService)(nil)

--- a/cli/internal/app/branch_lifecycle_test.go
+++ b/cli/internal/app/branch_lifecycle_test.go
@@ -1,0 +1,423 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/wnsdy95/cxthub/cli/internal/adapters/storage"
+	"github.com/wnsdy95/cxthub/cli/internal/domain"
+	"github.com/wnsdy95/cxthub/cli/internal/ports/inbound"
+	"github.com/wnsdy95/cxthub/cli/internal/ports/outbound"
+)
+
+type branchLifecycleGit struct{ repo domain.Repo }
+
+func (g branchLifecycleGit) CurrentRepo(context.Context, string) (domain.Repo, error) {
+	return g.repo, nil
+}
+
+type branchLifecycleRemote struct {
+	outbound.RemoteSync
+	refs []domain.Ref
+}
+
+func (r branchLifecycleRemote) Pull(context.Context, string, map[domain.ContentHash]domain.ContentHash, []domain.ContentHash) ([]domain.Snapshot, []domain.SessionDoc, []domain.Ref, error) {
+	return nil, nil, r.refs, nil
+}
+
+type branchInventoryGit struct {
+	outbound.GitContext
+	branches []string
+	err      error
+}
+
+func (g branchInventoryGit) LocalBranches(context.Context, string) ([]string, error) {
+	if g.err != nil {
+		return nil, g.err
+	}
+	return append([]string(nil), g.branches...), nil
+}
+
+func TestPullArchivePrunesOnlyBranchAbsentFromLocalGit(t *testing.T) {
+	ctx := context.Background()
+	repoID := string(domain.HashContent([]byte("pull archive repo")))
+	target := domain.HashContent([]byte("pull archive target"))
+	archive, err := domain.NewBranchLifecycleRef(repoID, "feature/shared", target, 2, domain.BranchArchived)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range []struct {
+		name        string
+		gitBranches []string
+		wantActive  bool
+	}{
+		{name: "deleted Git branch pruned"},
+		{name: "live local Git branch preserved", gitBranches: []string{"feature/shared"}, wantActive: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store := storage.NewFileStore(t.TempDir())
+			if err := store.PutSnapshot(ctx, domain.Snapshot{ID: target, RepoID: repoID, DocHash: target}); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := store.CreateBranchRef(ctx, domain.Ref{Kind: domain.RefBranch, Name: "feature/shared", RepoID: repoID, Target: target}); err != nil {
+				t.Fatal(err)
+			}
+			// Old servers preserve the lifecycle tag but cannot remove their
+			// branch projection. Pull must treat that exact pointer as shadowed.
+			legacyBranch := domain.Ref{Kind: domain.RefBranch, Name: "feature/shared", RepoID: repoID, Target: target}
+			svc := NewSyncRepoService(store, branchLifecycleRemote{refs: []domain.Ref{archive, legacyBranch}}, branchInventoryGit{branches: tc.gitBranches})
+			if _, err := svc.Pull(ctx, inbound.SyncInput{RepoID: repoID, Cwd: "/repo"}); err != nil {
+				t.Fatal(err)
+			}
+			ref, err := store.GetRef(ctx, repoID, domain.RefBranch, "feature/shared")
+			if !tc.wantActive {
+				if !errors.Is(err, domain.ErrNotFound) {
+					t.Fatalf("stale branch remains: %+v, %v", ref, err)
+				}
+				return
+			}
+			if err != nil || ref.Target != target {
+				t.Fatalf("live branch lost: %+v, %v", ref, err)
+			}
+			refs, err := store.ListRefs(ctx, repoID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			latest, ok, err := domain.LatestBranchLifecycle(refs, "feature/shared")
+			if err != nil || !ok || latest.State != domain.BranchActive || latest.Generation != 3 {
+				t.Fatalf("live compensation = %+v, %v, %v", latest, ok, err)
+			}
+		})
+	}
+}
+
+func TestPullRepairsAdvancedRemoteBranchMissingLifecycleCompensation(t *testing.T) {
+	ctx := context.Background()
+	repoID := string(domain.HashContent([]byte("pull lifecycle crash recovery repo")))
+	archivedTarget := domain.HashContent([]byte("pull lifecycle archived target"))
+	advancedTarget := domain.HashContent([]byte("pull lifecycle advanced target"))
+	const branchName = "feature/recovered-remote"
+	archive, err := domain.NewBranchLifecycleRef(repoID, branchName, archivedTarget, 1, domain.BranchArchived)
+	if err != nil {
+		t.Fatal(err)
+	}
+	branch := domain.Ref{Kind: domain.RefBranch, Name: branchName, RepoID: repoID, Target: advancedTarget}
+
+	store := storage.NewFileStore(t.TempDir())
+	for _, target := range []domain.ContentHash{archivedTarget, advancedTarget} {
+		if err := store.PutSnapshot(ctx, domain.Snapshot{ID: target, RepoID: repoID, DocHash: target, Branch: branchName}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	svc := NewSyncRepoService(store, branchLifecycleRemote{refs: []domain.Ref{archive, branch}}, branchInventoryGit{})
+	if _, err := svc.Pull(ctx, inbound.SyncInput{RepoID: repoID, Cwd: "/repo"}); err != nil {
+		t.Fatalf("pull advanced archive residue: %v", err)
+	}
+	got, err := store.GetRef(ctx, repoID, domain.RefBranch, branchName)
+	if err != nil || got.Target != advancedTarget {
+		t.Fatalf("recovered branch = %+v, %v", got, err)
+	}
+	refs, err := store.ListRefs(ctx, repoID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	latest, ok, err := domain.LatestBranchLifecycle(refs, branchName)
+	if err != nil || !ok || latest.State != domain.BranchActive || latest.Generation != 2 || latest.Target != advancedTarget {
+		t.Fatalf("pull recovery event = %+v, %v, %v", latest, ok, err)
+	}
+}
+
+func TestPullDoesNotReactivateArchivesWhenGitInventoryFails(t *testing.T) {
+	ctx := context.Background()
+	repoID := string(domain.HashContent([]byte("pull archive inventory failure repo")))
+	target := domain.HashContent([]byte("pull archive inventory failure target"))
+	const branchName = "feature/uncertain"
+	store := storage.NewFileStore(t.TempDir())
+	if err := store.PutSnapshot(ctx, domain.Snapshot{ID: target, RepoID: repoID, DocHash: target}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.CreateBranchRef(ctx, domain.Ref{Kind: domain.RefBranch, Name: branchName, RepoID: repoID, Target: target}); err != nil {
+		t.Fatal(err)
+	}
+	archive, err := domain.NewBranchLifecycleRef(repoID, branchName, target, 2, domain.BranchArchived)
+	if err != nil {
+		t.Fatal(err)
+	}
+	inventoryErr := errors.New("injected Git inventory failure")
+	svc := NewSyncRepoService(store, branchLifecycleRemote{refs: []domain.Ref{archive}}, branchInventoryGit{err: inventoryErr})
+	if _, err := svc.Pull(ctx, inbound.SyncInput{RepoID: repoID, Cwd: "/repo"}); !errors.Is(err, inventoryErr) {
+		t.Fatalf("pull error = %v, want inventory failure", err)
+	}
+	ref, err := store.GetRef(ctx, repoID, domain.RefBranch, branchName)
+	if err != nil || ref.Target != target {
+		t.Fatalf("branch changed after uncertain inventory: %+v, %v", ref, err)
+	}
+	refs, err := store.ListRefs(ctx, repoID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	latest, ok, err := domain.LatestBranchLifecycle(refs, branchName)
+	if err != nil || !ok || latest.State != domain.BranchActive || latest.Generation != 1 {
+		t.Fatalf("archive was applied despite inventory failure: %+v, %v, %v", latest, ok, err)
+	}
+}
+
+func TestOrderRefsForPushPublishesLifecycleBeforeBranchProjection(t *testing.T) {
+	repoID := string(domain.HashContent([]byte("push lifecycle order repo")))
+	target := domain.HashContent([]byte("push lifecycle order target"))
+	active, err := domain.NewBranchLifecycleRef(repoID, "feature/order", target, 1, domain.BranchActive)
+	if err != nil {
+		t.Fatal(err)
+	}
+	archive, err := domain.NewBranchLifecycleRef(repoID, "feature/old", target, 1, domain.BranchArchived)
+	if err != nil {
+		t.Fatal(err)
+	}
+	branch := domain.Ref{Kind: domain.RefBranch, Name: "feature/order", RepoID: repoID, Target: target}
+	ordinaryTag := domain.Ref{Kind: domain.RefTag, Name: "v1", RepoID: repoID, Target: target}
+	ordered := orderRefsForPush([]domain.Ref{branch, ordinaryTag, archive, active})
+	for i := 0; i < 2; i++ {
+		if _, ok, err := domain.ParseBranchLifecycleRef(ordered[i]); err != nil || !ok {
+			t.Fatalf("ref %d is not lifecycle: %+v, %v", i, ordered[i], err)
+		}
+	}
+	if ordered[2].Kind == domain.RefTag && ordered[2].Name == archive.Name || ordered[2].Name == active.Name {
+		t.Fatalf("lifecycle event remained after ordinary refs: %+v", ordered)
+	}
+}
+
+func TestTagListHidesInternalBranchLifecycleEvents(t *testing.T) {
+	ctx := context.Background()
+	store := storage.NewFileStore(t.TempDir())
+	repo := domain.Repo{ID: string(domain.HashContent([]byte("tag list lifecycle repo")))}
+	target := domain.HashContent([]byte("tag list lifecycle target"))
+	if err := store.PutRef(ctx, domain.Ref{Kind: domain.RefTag, Name: "release/v1", RepoID: repo.ID, Target: target}); err != nil {
+		t.Fatal(err)
+	}
+	event, err := domain.NewBranchLifecycleRef(repo.ID, "feature/hidden", target, 1, domain.BranchArchived)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.PutRef(ctx, event); err != nil {
+		t.Fatal(err)
+	}
+	tags, err := NewTagService(branchLifecycleGit{repo: repo}, store).Tags(ctx, "/repo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tags) != 1 || tags[0].Name != "release/v1" {
+		t.Fatalf("public tags = %+v", tags)
+	}
+	if _, err := NewTagService(branchLifecycleGit{repo: repo}, store).Tag(ctx, inbound.TagInput{Name: event.Name}); !errors.Is(err, domain.ErrInvalidRef) {
+		t.Fatalf("reserved lifecycle namespace accepted as user tag: %v", err)
+	}
+}
+
+func (g branchLifecycleGit) CurrentBranch(context.Context, string) (string, error) {
+	return "main", nil
+}
+
+func TestBranchLifecycleServiceArchivesPointerWithoutDeletingSnapshot(t *testing.T) {
+	ctx := context.Background()
+	store := storage.NewFileStore(t.TempDir())
+	repo := domain.Repo{ID: string(domain.HashContent([]byte("archive service repo")))}
+	target := domain.HashContent([]byte("archive service target"))
+	if err := store.PutSnapshot(ctx, domain.Snapshot{ID: target, RepoID: repo.ID, DocHash: target}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.CreateBranchRef(ctx, domain.Ref{Kind: domain.RefBranch, Name: "feature/done", RepoID: repo.ID, Target: target}); err != nil {
+		t.Fatal(err)
+	}
+
+	svc := NewBranchLifecycleService(branchLifecycleGit{repo: repo}, store)
+	out, err := svc.Archive(ctx, inbound.BranchArchiveInput{Cwd: "/repo", Branch: "feature/done"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Branch != "feature/done" || out.Target != target || out.Event.Kind != domain.RefTag {
+		t.Fatalf("archive output = %+v", out)
+	}
+	if _, err := store.GetRef(ctx, repo.ID, domain.RefBranch, out.Branch); !errors.Is(err, domain.ErrNotFound) {
+		t.Fatalf("active pointer remains: %v", err)
+	}
+	if _, err := store.GetSnapshot(ctx, target); err != nil {
+		t.Fatalf("snapshot was deleted: %v", err)
+	}
+}
+
+func TestBranchLifecycleServiceRenamePreservesOverwrittenDestination(t *testing.T) {
+	ctx := context.Background()
+	store := storage.NewFileStore(t.TempDir())
+	repo := domain.Repo{ID: string(domain.HashContent([]byte("rename service repo")))}
+	sourceTarget := domain.HashContent([]byte("rename source target"))
+	destinationTarget := domain.HashContent([]byte("rename overwritten destination target"))
+	for _, target := range []domain.ContentHash{sourceTarget, destinationTarget} {
+		if err := store.PutSnapshot(ctx, domain.Snapshot{ID: target, RepoID: repo.ID, DocHash: target}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for name, target := range map[string]domain.ContentHash{
+		"feature/old": sourceTarget,
+		"feature/new": destinationTarget,
+	} {
+		if _, err := store.CreateBranchRef(ctx, domain.Ref{Kind: domain.RefBranch, Name: name, RepoID: repo.ID, Target: target}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	svc := NewBranchLifecycleService(branchLifecycleGit{repo: repo}, store)
+	out, err := svc.Rename(ctx, inbound.BranchRenameInput{Cwd: "/repo", From: "feature/old", To: "feature/new"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.From != "feature/old" || out.To != "feature/new" || out.Target != sourceTarget {
+		t.Fatalf("rename output = %+v", out)
+	}
+	if _, err := store.GetRef(ctx, repo.ID, domain.RefBranch, "feature/old"); !errors.Is(err, domain.ErrNotFound) {
+		t.Fatalf("source pointer remains: %v", err)
+	}
+	if ref, err := store.GetRef(ctx, repo.ID, domain.RefBranch, "feature/new"); err != nil || ref.Target != sourceTarget {
+		t.Fatalf("destination ref = %+v, %v", ref, err)
+	}
+	for _, target := range []domain.ContentHash{sourceTarget, destinationTarget} {
+		if _, err := store.GetSnapshot(ctx, target); err != nil {
+			t.Fatalf("snapshot %s was lost: %v", target, err)
+		}
+	}
+	refs, err := store.ListRefs(ctx, repo.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldState, ok, err := domain.LatestBranchLifecycle(refs, "feature/old")
+	if err != nil || !ok || oldState.State != domain.BranchArchived || oldState.Target != sourceTarget {
+		t.Fatalf("old lifecycle = %+v, %v, %v", oldState, ok, err)
+	}
+	newState, ok, err := domain.LatestBranchLifecycle(refs, "feature/new")
+	if err != nil || !ok || newState.State != domain.BranchActive || newState.Target != sourceTarget {
+		t.Fatalf("new lifecycle = %+v, %v, %v", newState, ok, err)
+	}
+	archivedDestination := false
+	for _, ref := range refs {
+		event, lifecycle, parseErr := domain.ParseBranchLifecycleRef(ref)
+		if parseErr != nil {
+			t.Fatal(parseErr)
+		}
+		if lifecycle && event.Branch == "feature/new" && event.State == domain.BranchArchived && event.Target == destinationTarget {
+			archivedDestination = true
+		}
+	}
+	if !archivedDestination {
+		t.Fatal("overwritten destination context was not archived")
+	}
+	if _, err := svc.Rename(ctx, inbound.BranchRenameInput{Cwd: "/repo", From: "feature/old", To: "feature/new"}); err != nil {
+		t.Fatalf("idempotent rename retry failed: %v", err)
+	}
+}
+
+func TestForkRecordsActiveBranchLifecycleEvent(t *testing.T) {
+	ctx := context.Background()
+	store := storage.NewFileStore(t.TempDir())
+	repoID := string(domain.HashContent([]byte("fork lifecycle repo")))
+	target := domain.HashContent([]byte("fork lifecycle target"))
+	if err := store.PutSnapshot(ctx, domain.Snapshot{ID: target, RepoID: repoID, DocHash: target}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := NewForkSessionService(store).Fork(ctx, inbound.ForkInput{RepoID: repoID, FromSnapshot: target, NewBranch: "feature/new"}); err != nil {
+		t.Fatal(err)
+	}
+	refs, err := store.ListRefs(ctx, repoID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	latest, ok, err := domain.LatestBranchLifecycle(refs, "feature/new")
+	if err != nil || !ok || latest.State != domain.BranchActive || latest.Target != target {
+		t.Fatalf("fork lifecycle = %+v, %v, %v", latest, ok, err)
+	}
+}
+
+type branchLifecycleLoad struct{}
+
+func (branchLifecycleLoad) Load(_ context.Context, in inbound.LoadInput) (inbound.LoadOutput, error) {
+	return inbound.LoadOutput{Fidelity: domain.FidelityFull}, nil
+}
+
+type branchLifecycleFailLoad struct{}
+
+func (branchLifecycleFailLoad) Load(context.Context, inbound.LoadInput) (inbound.LoadOutput, error) {
+	return inbound.LoadOutput{}, errors.New("materialization failed")
+}
+
+func TestCheckoutByArchivedBranchNameRestoresActiveProjection(t *testing.T) {
+	ctx := context.Background()
+	store := storage.NewFileStore(t.TempDir())
+	repoID := string(domain.HashContent([]byte("checkout archived repo")))
+	target := domain.HashContent([]byte("checkout archived target"))
+	branch := domain.Ref{Kind: domain.RefBranch, Name: "feature/restore", RepoID: repoID, Target: target}
+	if err := store.PutSnapshot(ctx, domain.Snapshot{ID: target, RepoID: repoID, DocHash: target}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.CreateBranchRef(ctx, branch); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.ArchiveBranchRef(ctx, repoID, branch.Name); err != nil {
+		t.Fatal(err)
+	}
+
+	checkout := NewCheckoutSessionService(NewForkSessionService(store), branchLifecycleLoad{}, store)
+	out, err := checkout.Checkout(ctx, inbound.CheckoutInput{RepoID: repoID, From: branch.Name})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Branch != branch.Name || out.Head != target {
+		t.Fatalf("checkout output = %+v", out)
+	}
+	if !out.ActivatedBranch {
+		t.Fatalf("checkout did not report lifecycle activation: %+v", out)
+	}
+	if got, err := store.GetRef(ctx, repoID, domain.RefBranch, branch.Name); err != nil || got.Target != target {
+		t.Fatalf("restored ref = %+v, %v", got, err)
+	}
+	refs, err := store.ListRefs(ctx, repoID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	latest, ok, err := domain.LatestBranchLifecycle(refs, branch.Name)
+	if err != nil || !ok || latest.State != domain.BranchActive || latest.Generation != 3 {
+		t.Fatalf("restore lifecycle = %+v, %v, %v", latest, ok, err)
+	}
+}
+
+func TestCheckoutFailureLeavesArchivedBranchInactive(t *testing.T) {
+	ctx := context.Background()
+	store := storage.NewFileStore(t.TempDir())
+	repoID := string(domain.HashContent([]byte("failed archived checkout repo")))
+	target := domain.HashContent([]byte("failed archived checkout target"))
+	branch := domain.Ref{Kind: domain.RefBranch, Name: "feature/still-archived", RepoID: repoID, Target: target}
+	if err := store.PutSnapshot(ctx, domain.Snapshot{ID: target, RepoID: repoID, DocHash: target}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.CreateBranchRef(ctx, branch); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.ArchiveBranchRef(ctx, repoID, branch.Name); err != nil {
+		t.Fatal(err)
+	}
+
+	checkout := NewCheckoutSessionService(NewForkSessionService(store), branchLifecycleFailLoad{}, store)
+	if _, err := checkout.Checkout(ctx, inbound.CheckoutInput{RepoID: repoID, From: branch.Name}); err == nil {
+		t.Fatal("checkout unexpectedly succeeded")
+	}
+	if _, err := store.GetRef(ctx, repoID, domain.RefBranch, branch.Name); !errors.Is(err, domain.ErrNotFound) {
+		t.Fatalf("failed checkout activated branch: %v", err)
+	}
+	refs, err := store.ListRefs(ctx, repoID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	latest, ok, err := domain.LatestBranchLifecycle(refs, branch.Name)
+	if err != nil || !ok || latest.State != domain.BranchArchived || latest.Generation != 2 {
+		t.Fatalf("failed checkout lifecycle = %+v, %v, %v", latest, ok, err)
+	}
+}

--- a/cli/internal/app/branch_seed.go
+++ b/cli/internal/app/branch_seed.go
@@ -232,7 +232,7 @@ func (s *BranchSeedService) Seed(ctx context.Context, in inbound.SeedInput) (inb
 	if err := s.store.PutSnapshot(ctx, snap); err != nil {
 		return inbound.SeedOutput{}, err
 	}
-	if err := s.store.PutRef(ctx, domain.Ref{Kind: domain.RefBranch, Name: in.NewBranch, RepoID: repo.ID, Target: docHash}); err != nil {
+	if _, err := s.store.CreateBranchRef(ctx, domain.Ref{Kind: domain.RefBranch, Name: in.NewBranch, RepoID: repo.ID, Target: docHash}); err != nil {
 		return inbound.SeedOutput{}, err
 	}
 	_ = s.store.PutRef(ctx, domain.Ref{Kind: domain.RefHEAD, Name: "HEAD", RepoID: repo.ID, Symbolic: in.NewBranch})

--- a/cli/internal/app/checkout_session.go
+++ b/cli/internal/app/checkout_session.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"errors"
 	"strings"
 
 	"github.com/wnsdy95/cxthub/cli/internal/domain"
@@ -40,9 +41,15 @@ func (s *CheckoutSessionService) Checkout(ctx context.Context, in inbound.Checko
 	// actual branch ref from From. Tags and direct hashes are detached restores
 	// and must not become symbolic HEAD values.
 	branch := in.NewBranch
+	var missingBranchTarget domain.ContentHash
 	if branch == "" && in.From != "" && in.From != "HEAD" && !strings.HasPrefix(in.From, "sha256:") {
 		if _, branchErr := s.store.GetRef(ctx, in.RepoID, domain.RefBranch, in.From); branchErr == nil {
 			branch = in.From
+		} else if event, ok, lifecycleErr := branchLifecycleByName(ctx, s.store, in.RepoID, in.From); lifecycleErr != nil {
+			return inbound.CheckoutOutput{}, lifecycleErr
+		} else if ok {
+			branch = in.From
+			missingBranchTarget = event.Target
 		}
 	}
 
@@ -66,6 +73,24 @@ func (s *CheckoutSessionService) Checkout(ctx context.Context, in inbound.Checko
 	if err != nil {
 		return inbound.CheckoutOutput{}, err
 	}
+	// Loading is the preflight for an archived (or crash-interrupted active)
+	// branch projection. Record a newer active generation only after the target
+	// provider session was materialized successfully. Otherwise a failed
+	// restore would advertise a branch that cannot actually be resumed.
+	if missingBranchTarget != "" {
+		_, createErr := s.store.CreateBranchRef(ctx, domain.Ref{
+			Kind: domain.RefBranch, Name: branch, RepoID: in.RepoID, Target: missingBranchTarget,
+		})
+		if errors.Is(createErr, domain.ErrBranchExists) {
+			current, currentErr := s.store.GetRef(ctx, in.RepoID, domain.RefBranch, branch)
+			if currentErr == nil && current.Target == missingBranchTarget {
+				createErr = nil // concurrent idempotent restore won
+			}
+		}
+		if createErr != nil {
+			return inbound.CheckoutOutput{}, createErr
+		}
+	}
 	if branch != "" {
 		if err := s.store.PutRef(ctx, domain.Ref{
 			Kind: domain.RefHEAD, Name: "HEAD", RepoID: in.RepoID, Symbolic: branch,
@@ -75,11 +100,12 @@ func (s *CheckoutSessionService) Checkout(ctx context.Context, in inbound.Checko
 	}
 
 	return inbound.CheckoutOutput{
-		Branch:      branch,
-		Head:        snapID,
-		WrittenPath: lo.WrittenPath,
-		ResumeCmd:   lo.ResumeCmd,
-		Fidelity:    lo.Fidelity,
+		Branch:          branch,
+		Head:            snapID,
+		WrittenPath:     lo.WrittenPath,
+		ResumeCmd:       lo.ResumeCmd,
+		Fidelity:        lo.Fidelity,
+		ActivatedBranch: missingBranchTarget != "",
 	}, nil
 }
 

--- a/cli/internal/app/fork_session.go
+++ b/cli/internal/app/fork_session.go
@@ -19,7 +19,7 @@ import (
 //
 // Fork sequence (local, sync protocol fork mental model):
 //  1. SessionStore.GetSnapshot(FromSnapshot) → existence verification
-//  2. SessionStore.PutRef(Ref{Kind:branch, Name:NewBranch, Target:FromSnapshot})
+//  2. SessionStore.CreateBranchRef(Ref{Kind:branch, Name:NewBranch, Target:FromSnapshot})
 //     → new branch ref creation (no snapshot copy; ref duplication only, O(1))
 //  3. ForkOutput{Branch:NewBranch, Head:FromSnapshot} returned
 //
@@ -48,7 +48,7 @@ func (s *ForkSessionService) Fork(ctx context.Context, in inbound.ForkInput) (in
 	if _, err := s.store.GetSnapshot(ctx, in.FromSnapshot); err != nil {
 		return inbound.ForkOutput{}, err
 	}
-	if err := s.store.PutRef(ctx, domain.Ref{
+	if _, err := s.store.CreateBranchRef(ctx, domain.Ref{
 		Kind:   domain.RefBranch,
 		Name:   in.NewBranch,
 		RepoID: in.RepoID,

--- a/cli/internal/app/refresolve.go
+++ b/cli/internal/app/refresolve.go
@@ -59,5 +59,21 @@ func resolveRef(ctx context.Context, store outbound.SessionStore, repoID, ref st
 	if !errors.Is(terr, domain.ErrNotFound) {
 		return "", terr
 	}
+	if event, ok, err := branchLifecycleByName(ctx, store, repoID, ref); err != nil {
+		return "", err
+	} else if ok {
+		return event.Target, nil
+	}
 	return "", fmt.Errorf("%w: ref %q — not found in any branch or tag (list: cxt list)", domain.ErrNotFound, ref)
+}
+
+func branchLifecycleByName(ctx context.Context, store outbound.SessionStore, repoID, branch string) (domain.BranchLifecycleEvent, bool, error) {
+	if err := domain.ValidateBranchName(branch); err != nil {
+		return domain.BranchLifecycleEvent{}, false, err
+	}
+	refs, err := store.ListRefs(ctx, repoID)
+	if err != nil {
+		return domain.BranchLifecycleEvent{}, false, err
+	}
+	return domain.LatestBranchLifecycle(refs, branch)
 }

--- a/cli/internal/app/save_session.go
+++ b/cli/internal/app/save_session.go
@@ -121,9 +121,13 @@ func (s *SaveSessionService) Save(ctx context.Context, in inbound.SaveInput) (in
 
 	var parents []domain.ContentHash
 	var refTarget domain.ContentHash
-	if ref, gerr := s.store.GetRef(ctx, repo.ID, domain.RefBranch, branch); gerr == nil && ref.Target != "" && ref.Target != docHash {
-		refTarget = ref.Target
-		parents = []domain.ContentHash{ref.Target}
+	branchRefExists := false
+	if ref, gerr := s.store.GetRef(ctx, repo.ID, domain.RefBranch, branch); gerr == nil {
+		branchRefExists = true
+		if ref.Target != "" && ref.Target != docHash {
+			refTarget = ref.Target
+			parents = []domain.ContentHash{ref.Target}
+		}
 	}
 
 	msg := in.Message
@@ -204,8 +208,15 @@ func (s *SaveSessionService) Save(ctx context.Context, in inbound.SaveInput) (in
 				return inbound.SaveOutput{}, fmt.Errorf("preservation of reachability (graft) failed — ref move aborted: %w", gerr)
 			}
 		}
-		if err := s.store.PutRef(ctx, domain.Ref{Kind: domain.RefBranch, Name: branch, RepoID: repo.ID, Target: docHash}); err != nil {
-			return inbound.SaveOutput{}, err
+		branchRef := domain.Ref{Kind: domain.RefBranch, Name: branch, RepoID: repo.ID, Target: docHash}
+		if branchRefExists {
+			if err := s.store.PutRef(ctx, branchRef); err != nil {
+				return inbound.SaveOutput{}, err
+			}
+		} else {
+			if _, err := s.store.CreateBranchRef(ctx, branchRef); err != nil {
+				return inbound.SaveOutput{}, err
+			}
 		}
 		// HEAD points to the current branch symbolically. Best-effort.
 		_ = s.store.PutRef(ctx, domain.Ref{Kind: domain.RefHEAD, Name: "HEAD", RepoID: repo.ID, Symbolic: branch})

--- a/cli/internal/app/sync_pending_chain_test.go
+++ b/cli/internal/app/sync_pending_chain_test.go
@@ -134,6 +134,7 @@ func TestSyncPendingsCASResolvesOnlySharedReachableTargets(t *testing.T) {
 	head := mkDoc("head")
 	sessionTarget := mkDoc("session-ref")
 	tagOnly := mkDoc("tag-only")
+	lifecycleTarget := mkDoc("lifecycle-target")
 	unresolved := mkDoc("unresolved")
 	put := func(id domain.ContentHash, parents, grafts []domain.ContentHash) {
 		if err := st.PutSnapshot(ctx, domain.Snapshot{ID: id, DocHash: id, RepoID: repoID, Branch: "main", Parents: parents, GraftParents: grafts}); err != nil {
@@ -145,11 +146,17 @@ func TestSyncPendingsCASResolvesOnlySharedReachableTargets(t *testing.T) {
 	put(head, []domain.ContentHash{natural}, []domain.ContentHash{grafted})
 	put(sessionTarget, nil, nil)
 	put(tagOnly, nil, nil)
+	put(lifecycleTarget, nil, nil)
 	put(unresolved, nil, nil)
+	lifecycleRef, err := domain.NewBranchLifecycleRef(repoID, "feature/archived", lifecycleTarget, 1, domain.BranchArchived)
+	if err != nil {
+		t.Fatal(err)
+	}
 	refs := []domain.Ref{
 		{Kind: domain.RefBranch, Name: "main", RepoID: repoID, Target: head},
 		{Kind: domain.RefSession, Name: "main/session", RepoID: repoID, Target: sessionTarget},
 		{Kind: domain.RefTag, Name: "archive", RepoID: repoID, Target: tagOnly},
+		lifecycleRef,
 	}
 	for _, ref := range refs {
 		if err := st.PutRef(ctx, ref); err != nil {
@@ -161,6 +168,7 @@ func TestSyncPendingsCASResolvesOnlySharedReachableTargets(t *testing.T) {
 		"grafted":    grafted,
 		"session":    sessionTarget,
 		"tag-only":   tagOnly,
+		"lifecycle":  lifecycleTarget,
 		"unresolved": unresolved,
 	} {
 		if err := st.PutPending(ctx, domain.Pending{RepoID: repoID, SessionID: sid, Branch: "main", Target: target, UpdatedAt: time.Now().UTC()}); err != nil {
@@ -173,7 +181,7 @@ func TestSyncPendingsCASResolvesOnlySharedReachableTargets(t *testing.T) {
 	if _, err := svc.SyncPendings(ctx, inbound.SyncInput{RepoID: repoID}, nil); err != nil {
 		t.Fatal(err)
 	}
-	for sid, target := range map[string]domain.ContentHash{"natural": natural, "grafted": grafted, "session": sessionTarget} {
+	for sid, target := range map[string]domain.ContentHash{"natural": natural, "grafted": grafted, "session": sessionTarget, "lifecycle": lifecycleTarget} {
 		if remote.deletedPending[sid] != target {
 			t.Errorf("shared %s CAS delete = %s, want %s", sid, remote.deletedPending[sid], target)
 		}

--- a/cli/internal/app/sync_pull_integrity_test.go
+++ b/cli/internal/app/sync_pull_integrity_test.go
@@ -40,8 +40,8 @@ func TestValidatePullBatchRejectsTamperingAndBrokenGraph(t *testing.T) {
 
 	t.Run("tampered doc", func(t *testing.T) {
 		st := storage.NewFileStore(t.TempDir())
-		bad := doc
-		bad.CIR.Events[0].Blocks[0].Text = "changed"
+		bad := pullDoc(t, "changed")
+		bad.Hash = doc.Hash
 		if err := validatePullBatch(ctx, st, repo, []domain.Snapshot{root}, []domain.SessionDoc{bad}, []domain.Ref{ref}); !errors.Is(err, domain.ErrHashMismatch) {
 			t.Fatalf("error = %v", err)
 		}
@@ -65,6 +65,32 @@ func TestValidatePullBatchRejectsTamperingAndBrokenGraph(t *testing.T) {
 		changed.Parents = []domain.ContentHash{domain.HashContent([]byte("other-parent"))}
 		if err := validatePullBatch(ctx, st, repo, []domain.Snapshot{changed}, []domain.SessionDoc{doc}, []domain.Ref{ref}); !errors.Is(err, domain.ErrHashMismatch) {
 			t.Fatalf("error = %v", err)
+		}
+	})
+
+	t.Run("legacy server may retain a branch projection shadowed by archive", func(t *testing.T) {
+		st := storage.NewFileStore(t.TempDir())
+		archive, err := domain.NewBranchLifecycleRef(repo, ref.Name, ref.Target, 1, domain.BranchArchived)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := validatePullBatch(ctx, st, repo, []domain.Snapshot{root}, []domain.SessionDoc{doc}, []domain.Ref{archive, ref}); err != nil {
+			t.Fatalf("legacy lifecycle projection rejected: %v", err)
+		}
+	})
+
+	t.Run("same generation active lifecycle permits branch projection", func(t *testing.T) {
+		st := storage.NewFileStore(t.TempDir())
+		archive, err := domain.NewBranchLifecycleRef(repo, ref.Name, ref.Target, 1, domain.BranchArchived)
+		if err != nil {
+			t.Fatal(err)
+		}
+		active, err := domain.NewBranchLifecycleRef(repo, ref.Name, ref.Target, 1, domain.BranchActive)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := validatePullBatch(ctx, st, repo, []domain.Snapshot{root}, []domain.SessionDoc{doc}, []domain.Ref{archive, active, ref}); err != nil {
+			t.Fatalf("active winner rejected: %v", err)
 		}
 	})
 }

--- a/cli/internal/app/sync_repo.go
+++ b/cli/internal/app/sync_repo.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"time"
 
 	"github.com/wnsdy95/cxthub/cli/internal/adapters/providerfs"
@@ -13,6 +14,33 @@ import (
 	"github.com/wnsdy95/cxthub/cli/internal/ports/inbound"
 	"github.com/wnsdy95/cxthub/cli/internal/ports/outbound"
 )
+
+func orderRefsForPush(refs []domain.Ref) []domain.Ref {
+	ordered := append([]domain.Ref(nil), refs...)
+	isLifecycle := func(ref domain.Ref) bool {
+		_, ok, _ := domain.ParseBranchLifecycleRef(ref)
+		return ok
+	}
+	sort.SliceStable(ordered, func(i, j int) bool {
+		left, right := isLifecycle(ordered[i]), isLifecycle(ordered[j])
+		if left != right {
+			return left
+		}
+		if left {
+			return ordered[i].Name < ordered[j].Name
+		}
+		return false
+	})
+	return ordered
+}
+
+func sharedTimelineRef(ref domain.Ref) bool {
+	if ref.Kind == domain.RefBranch || ref.Kind == domain.RefSession {
+		return ref.Target != ""
+	}
+	_, lifecycle, _ := domain.ParseBranchLifecycleRef(ref)
+	return lifecycle && ref.Target != ""
+}
 
 // SyncRepoService implements the SyncRepo inbound port as a use-case service.
 //
@@ -186,7 +214,7 @@ func validatePullBatch(ctx context.Context, store outbound.SessionStore, repoID 
 		}
 	}
 
-	branchRefs := map[string]bool{}
+	branchRefs := map[string]domain.Ref{}
 	seenRefs := map[string]bool{}
 	for _, ref := range refs {
 		if err := domain.ValidateRef(ref); err != nil {
@@ -201,7 +229,7 @@ func validatePullBatch(ctx context.Context, store outbound.SessionStore, repoID 
 		}
 		seenRefs[key] = true
 		if ref.Kind == domain.RefBranch {
-			branchRefs[ref.Name] = true
+			branchRefs[ref.Name] = ref
 		}
 		if ref.Target != "" {
 			if _, err := getSnapshot(ref.Target); err != nil {
@@ -217,7 +245,7 @@ func validatePullBatch(ctx context.Context, store outbound.SessionStore, repoID 
 		if len(branch) > len("refs/heads/") && branch[:len("refs/heads/")] == "refs/heads/" {
 			branch = branch[len("refs/heads/"):]
 		}
-		if branchRefs[branch] {
+		if _, ok := branchRefs[branch]; ok {
 			continue
 		}
 		if _, err := store.GetRef(ctx, repoID, domain.RefBranch, branch); err != nil {
@@ -270,6 +298,12 @@ func (s *SyncRepoService) Push(ctx context.Context, in inbound.SyncInput) (inbou
 			return inbound.SyncOutput{}, rerr
 		}
 	}
+	// Finish any local archive/create transition that crashed after its immutable
+	// lifecycle event was written. Without this repair an advanced raw branch can
+	// remain visible locally yet be rejected forever by an already-archived peer.
+	if err := s.store.ReconcileBranchLifecycleRefs(ctx, repoID); err != nil {
+		return inbound.SyncOutput{}, err
+	}
 	man, err := s.store.Manifest(ctx, repoID)
 	if err != nil {
 		return inbound.SyncOutput{}, err
@@ -289,6 +323,7 @@ func (s *SyncRepoService) Push(ctx context.Context, in inbound.SyncInput) (inbou
 		r.RepoID = repoID
 		refs = append(refs, r)
 	}
+	refs = orderRefsForPush(refs)
 
 	if err := s.pushSettingsObjects(ctx, repoID, snaps); err != nil {
 		return inbound.SyncOutput{}, err
@@ -1089,7 +1124,7 @@ func (s *SyncRepoService) sharedReachable(ctx context.Context, refs []domain.Ref
 	shared := make(map[domain.ContentHash]bool)
 	stack := make([]domain.ContentHash, 0, len(refs))
 	for _, ref := range refs {
-		if (ref.Kind == domain.RefBranch || ref.Kind == domain.RefSession) && ref.Target != "" {
+		if sharedTimelineRef(ref) {
 			stack = append(stack, ref.Target)
 		}
 	}
@@ -1449,12 +1484,19 @@ func (s *SyncRepoService) Pull(ctx context.Context, in inbound.SyncInput) (inbou
 		}
 	}
 	s.updateRemoteSnapshotStateCursor(ctx, repoID, cursorStore, cursorEntries, snaps)
+	remoteLifecycleStates, err := domain.BranchLifecycleStates(refs)
+	if err != nil {
+		return inbound.SyncOutput{}, err
+	}
 	// FetchOnly (hook auto-pull): fetch objects only, local refs do not move — context does not force convergence unlike code. Instead, report remote branch ahead hint (pull is user choice).
 	if in.FetchOnly {
 		var ahead []string
 		for _, r := range refs {
 			if r.Kind != domain.RefBranch || r.Target == "" {
 				continue
+			}
+			if latest, ok := remoteLifecycleStates[r.Name]; ok && latest.State == domain.BranchArchived && latest.Target == r.Target {
+				continue // legacy server residue shadowed by its immutable archive event
 			}
 			local, lerr := s.store.GetRef(ctx, repoID, r.Kind, r.Name)
 			if lerr != nil || local.Target == "" || local.Target == r.Target {
@@ -1467,6 +1509,47 @@ func (s *SyncRepoService) Pull(ctx context.Context, in inbound.SyncInput) (inbou
 		return inbound.SyncOutput{Pulled: len(snaps), RemoteAhead: ahead}, nil
 	}
 
+	// Apply immutable branch lifecycle events before ordinary refs. The local
+	// Git ref inventory is authoritative for whether an equal-target branch is
+	// still active on this machine. If inventory cannot be read, stop before ref
+	// mutation: guessing "live" would publish stale active events, while guessing
+	// "deleted" could hide current work. The already-fetched objects remain safe.
+	liveBranches := map[string]bool{}
+	inventoryKnown := false
+	hasArchivedLifecycle := false
+	for _, state := range remoteLifecycleStates {
+		if state.State == domain.BranchArchived {
+			hasArchivedLifecycle = true
+			break
+		}
+	}
+	if hasArchivedLifecycle && in.Cwd != "" {
+		if inventory, ok := s.gitCtx.(outbound.GitBranchInventory); ok {
+			branches, err := inventory.LocalBranches(ctx, in.Cwd)
+			if err != nil {
+				return inbound.SyncOutput{}, fmt.Errorf("list local Git branches before applying archived context refs: %w", err)
+			}
+			inventoryKnown = true
+			for _, branch := range branches {
+				liveBranches[branch] = true
+			}
+		} else {
+			return inbound.SyncOutput{}, fmt.Errorf("%w: local Git branch inventory is unavailable", domain.ErrNotGitRepo)
+		}
+	}
+	for _, ref := range refs {
+		event, lifecycle, err := domain.ParseBranchLifecycleRef(ref)
+		if err != nil {
+			return inbound.SyncOutput{}, err
+		}
+		if !lifecycle {
+			continue
+		}
+		preserve := !inventoryKnown || liveBranches[event.Branch]
+		if err := s.store.ApplyBranchLifecycleRef(ctx, ref, preserve); err != nil {
+			return inbound.SyncOutput{}, err
+		}
+	}
 	// Ref merge — git policy (fast-forward only): move local head only if it is an ancestor of remote head. If diverged, cancel that ref (local kept) and report Conflicts. --force adopts remote.
 	// HEAD is local.
 	var newRefs []domain.Ref
@@ -1474,9 +1557,29 @@ func (s *SyncRepoService) Pull(ctx context.Context, in inbound.SyncInput) (inbou
 		if r.Kind == domain.RefHEAD || r.Target == "" {
 			continue
 		}
+		if _, lifecycle, err := domain.ParseBranchLifecycleRef(r); err != nil {
+			return inbound.SyncOutput{}, err
+		} else if lifecycle {
+			newRefs = append(newRefs, r)
+			continue
+		}
+		if r.Kind == domain.RefBranch {
+			if latest, ok := remoteLifecycleStates[r.Name]; ok && latest.State == domain.BranchArchived && latest.Target == r.Target {
+				continue // old peers retain the branch pointer but cannot apply archive projection
+			}
+		}
 		local, lerr := s.store.GetRef(ctx, repoID, r.Kind, r.Name)
+		localMissing := errors.Is(lerr, domain.ErrNotFound)
+		if lerr != nil && !localMissing {
+			return inbound.SyncOutput{}, lerr
+		}
+		remoteArchiveRecovery := false
+		if r.Kind == domain.RefBranch {
+			latest, ok := remoteLifecycleStates[r.Name]
+			remoteArchiveRecovery = ok && latest.State == domain.BranchArchived && latest.Target != r.Target
+		}
 		switch {
-		case lerr != nil || local.Target == "" || local.Target == r.Target:
+		case localMissing || local.Target == "" || local.Target == r.Target:
 			// Local absent or same → reflect as is.
 		case in.Force:
 			// Force: adopt remote state (local snapshot objects preserved — ref pointers only move).
@@ -1486,7 +1589,15 @@ func (s *SyncRepoService) Pull(ctx context.Context, in inbound.SyncInput) (inbou
 			conflicts = append(conflicts, string(r.Kind)+"/"+r.Name)
 			continue // cancel — local maintenance (equivalent to git pull --ff-only rejection)
 		}
-		if err := s.store.PutRef(ctx, domain.Ref{Kind: r.Kind, Name: r.Name, RepoID: repoID, Target: r.Target}); err != nil {
+		next := domain.Ref{Kind: r.Kind, Name: r.Name, RepoID: repoID, Target: r.Target}
+		if localMissing && remoteArchiveRecovery {
+			// The remote branch advanced beyond an archive target but its active
+			// compensation was interrupted. Treat the surviving projection as
+			// explicit recovery authority and make that fact durable locally.
+			if _, err := s.store.CreateBranchRef(ctx, next); err != nil {
+				return inbound.SyncOutput{}, err
+			}
+		} else if err := s.store.PutRef(ctx, next); err != nil {
 			return inbound.SyncOutput{}, err
 		}
 		newRefs = append(newRefs, r)

--- a/cli/internal/app/tag.go
+++ b/cli/internal/app/tag.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/wnsdy95/cxthub/cli/internal/domain"
 	"github.com/wnsdy95/cxthub/cli/internal/ports/inbound"
@@ -27,6 +28,9 @@ func NewTagService(gitCtx outbound.GitContext, store outbound.SessionStore) *Tag
 func (s *TagService) Tag(ctx context.Context, in inbound.TagInput) (inbound.TagOutput, error) {
 	if in.Name == "" {
 		return inbound.TagOutput{}, fmt.Errorf("tag name is required: cxt tag <name> [ref]")
+	}
+	if strings.HasPrefix(in.Name, domain.BranchLifecycleTagPrefix) {
+		return inbound.TagOutput{}, fmt.Errorf("%w: %s is reserved for branch lifecycle events", domain.ErrInvalidRef, domain.BranchLifecycleTagPrefix)
 	}
 	repo, err := s.gitCtx.CurrentRepo(ctx, in.Cwd)
 	if err != nil {
@@ -63,6 +67,11 @@ func (s *TagService) Tags(ctx context.Context, cwd string) ([]domain.Ref, error)
 	var tags []domain.Ref
 	for _, r := range refs {
 		if r.Kind == domain.RefTag {
+			if _, lifecycle, err := domain.ParseBranchLifecycleRef(r); err != nil {
+				return nil, err
+			} else if lifecycle {
+				continue
+			}
 			tags = append(tags, r)
 		}
 	}

--- a/cli/internal/domain/branch_lifecycle.go
+++ b/cli/internal/domain/branch_lifecycle.go
@@ -1,0 +1,193 @@
+package domain
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// BranchLifecycleTagPrefix is a reserved immutable-tag namespace used as a
+// backward-compatible branch lifecycle event log. Older clients preserve
+// these refs as ordinary tags instead of rejecting an unknown ref kind.
+const BranchLifecycleTagPrefix = "cxt/branch-state/v1/"
+
+type BranchLifecycleState string
+
+const (
+	BranchActive   BranchLifecycleState = "active"
+	BranchArchived BranchLifecycleState = "archived"
+)
+
+type BranchLifecycleEvent struct {
+	Branch     string
+	Generation uint64
+	State      BranchLifecycleState
+	Target     ContentHash
+	Ref        Ref
+}
+
+func parseBranchLifecycleTagName(name string) (BranchLifecycleEvent, bool, error) {
+	if !strings.HasPrefix(name, BranchLifecycleTagPrefix) {
+		return BranchLifecycleEvent{}, false, nil
+	}
+	rest := strings.TrimPrefix(name, BranchLifecycleTagPrefix)
+	parts := strings.SplitN(rest, "/", 4)
+	if len(parts) != 4 || len(parts[0]) != 20 {
+		return BranchLifecycleEvent{}, true, fmt.Errorf("%w: malformed branch lifecycle tag %q", ErrInvalidRef, name)
+	}
+	generation, err := strconv.ParseUint(parts[0], 10, 64)
+	if err != nil || generation == 0 || fmt.Sprintf("%020d", generation) != parts[0] {
+		return BranchLifecycleEvent{}, true, fmt.Errorf("%w: invalid branch lifecycle generation in %q", ErrInvalidRef, name)
+	}
+	state := BranchLifecycleState(parts[1])
+	if state != BranchActive && state != BranchArchived {
+		return BranchLifecycleEvent{}, true, fmt.Errorf("%w: invalid branch lifecycle state in %q", ErrInvalidRef, name)
+	}
+	if len(parts[2]) != 64 || parts[2] != strings.ToLower(parts[2]) {
+		return BranchLifecycleEvent{}, true, fmt.Errorf("%w: invalid branch lifecycle target in %q", ErrInvalidRef, name)
+	}
+	target := ContentHash("sha256:" + parts[2])
+	if err := ValidateContentHash(target); err != nil {
+		return BranchLifecycleEvent{}, true, err
+	}
+	if err := ValidateBranchName(parts[3]); err != nil {
+		return BranchLifecycleEvent{}, true, err
+	}
+	return BranchLifecycleEvent{Branch: parts[3], Generation: generation, State: state, Target: target}, true, nil
+}
+
+func NewBranchLifecycleRef(repoID, branch string, target ContentHash, generation uint64, state BranchLifecycleState) (Ref, error) {
+	if err := ValidateBranchName(branch); err != nil {
+		return Ref{}, err
+	}
+	if err := ValidateContentHash(target); err != nil {
+		return Ref{}, err
+	}
+	if generation == 0 || (state != BranchActive && state != BranchArchived) {
+		return Ref{}, fmt.Errorf("%w: invalid branch lifecycle event", ErrInvalidRef)
+	}
+	name := fmt.Sprintf("%s%020d/%s/%s/%s", BranchLifecycleTagPrefix, generation, state, strings.TrimPrefix(string(target), "sha256:"), branch)
+	ref := Ref{Kind: RefTag, Name: name, RepoID: repoID, Target: target}
+	if err := ValidateRef(ref); err != nil {
+		return Ref{}, err
+	}
+	return ref, nil
+}
+
+func ParseBranchLifecycleRef(ref Ref) (BranchLifecycleEvent, bool, error) {
+	if ref.Kind != RefTag {
+		return BranchLifecycleEvent{}, false, nil
+	}
+	event, ok, err := parseBranchLifecycleTagName(ref.Name)
+	if err != nil || !ok {
+		return BranchLifecycleEvent{}, ok, err
+	}
+	if ref.Target != event.Target {
+		return BranchLifecycleEvent{}, true, fmt.Errorf("%w: lifecycle tag target does not match its name", ErrInvalidRef)
+	}
+	event.Ref = ref
+	return event, true, nil
+}
+
+func branchLifecycleLater(left, right BranchLifecycleEvent) bool {
+	if left.Generation != right.Generation {
+		return left.Generation > right.Generation
+	}
+	if left.State != right.State {
+		return left.State == BranchActive
+	}
+	if left.Target != right.Target {
+		return left.Target > right.Target
+	}
+	return left.Ref.Name > right.Ref.Name
+}
+
+func LatestBranchLifecycle(refs []Ref, branch string) (BranchLifecycleEvent, bool, error) {
+	var latest BranchLifecycleEvent
+	found := false
+	for _, ref := range refs {
+		event, ok, err := ParseBranchLifecycleRef(ref)
+		if err != nil {
+			return BranchLifecycleEvent{}, false, err
+		}
+		if !ok || event.Branch != branch {
+			continue
+		}
+		if !found || branchLifecycleLater(event, latest) {
+			latest, found = event, true
+		}
+	}
+	return latest, found, nil
+}
+
+// BranchLifecycleStates projects the append-only event refs into one latest
+// state per branch in a single pass. List/manifest consumers use this instead
+// of rescanning the complete immutable event history for every branch.
+func BranchLifecycleStates(refs []Ref) (map[string]BranchLifecycleEvent, error) {
+	states := make(map[string]BranchLifecycleEvent)
+	for _, ref := range refs {
+		event, ok, err := ParseBranchLifecycleRef(ref)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			continue
+		}
+		if current, found := states[event.Branch]; !found || branchLifecycleLater(event, current) {
+			states[event.Branch] = event
+		}
+	}
+	return states, nil
+}
+
+// ProjectBranchLifecycleRefs derives the externally visible mutable
+// projections from raw refs plus immutable lifecycle events. An archive hides
+// only the exact branch target it observed. If a crash left symbolic HEAD
+// pointing at that hidden branch, HEAD is exposed as detached at the archived
+// snapshot so manifests never contain a dangling symbolic ref.
+func ProjectBranchLifecycleRefs(refs []Ref) ([]Ref, error) {
+	states, err := BranchLifecycleStates(refs)
+	if err != nil {
+		return nil, err
+	}
+	branches := make(map[string]Ref)
+	for _, ref := range refs {
+		if ref.Kind == RefBranch {
+			branches[ref.Name] = ref
+		}
+	}
+	out := make([]Ref, 0, len(refs))
+	for _, ref := range refs {
+		if ref.Kind == RefBranch {
+			latest, ok := states[ref.Name]
+			if ok && latest.State == BranchArchived && latest.Target == ref.Target {
+				continue
+			}
+		}
+		if ref.Kind == RefHEAD && ref.Symbolic != "" {
+			branch := strings.TrimPrefix(ref.Symbolic, "refs/heads/")
+			latest, ok := states[branch]
+			raw, exists := branches[branch]
+			if ok && latest.State == BranchArchived && (!exists || raw.Target == latest.Target) {
+				ref.Symbolic = ""
+				ref.Target = latest.Target
+			}
+		}
+		out = append(out, ref)
+	}
+	return out, nil
+}
+
+func NextBranchLifecycleGeneration(refs []Ref, branch string) (uint64, error) {
+	latest, ok, err := LatestBranchLifecycle(refs, branch)
+	if err != nil {
+		return 0, err
+	}
+	if !ok {
+		return 1, nil
+	}
+	if latest.Generation == ^uint64(0) {
+		return 0, fmt.Errorf("%w: branch lifecycle generation exhausted", ErrInvalidRef)
+	}
+	return latest.Generation + 1, nil
+}

--- a/cli/internal/domain/branch_lifecycle_test.go
+++ b/cli/internal/domain/branch_lifecycle_test.go
@@ -1,0 +1,71 @@
+package domain
+
+import (
+	"strings"
+	"testing"
+)
+
+func lifecycleHash(ch byte) ContentHash {
+	return ContentHash("sha256:" + strings.Repeat(string(ch), 64))
+}
+
+func TestBranchLifecycleRefRoundTripAndOrdering(t *testing.T) {
+	repo := string(lifecycleHash('0'))
+	target := lifecycleHash('a')
+	archived, err := NewBranchLifecycleRef(repo, "feature/auth", target, 7, BranchArchived)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if archived.Kind != RefTag || !strings.HasPrefix(archived.Name, BranchLifecycleTagPrefix) {
+		t.Fatalf("archive ref = %+v", archived)
+	}
+	event, ok, err := ParseBranchLifecycleRef(archived)
+	if err != nil || !ok {
+		t.Fatalf("parse = %+v, %v, %v", event, ok, err)
+	}
+	if event.Branch != "feature/auth" || event.Target != target || event.Generation != 7 || event.State != BranchArchived {
+		t.Fatalf("round trip = %+v", event)
+	}
+
+	active, err := NewBranchLifecycleRef(repo, "feature/auth", target, 7, BranchActive)
+	if err != nil {
+		t.Fatal(err)
+	}
+	latest, ok, err := LatestBranchLifecycle([]Ref{archived, active}, "feature/auth")
+	if err != nil || !ok || latest.State != BranchActive {
+		t.Fatalf("same-generation preservation = %+v, %v, %v", latest, ok, err)
+	}
+
+	newer, err := NewBranchLifecycleRef(repo, "feature/auth", target, 8, BranchArchived)
+	if err != nil {
+		t.Fatal(err)
+	}
+	latest, ok, err = LatestBranchLifecycle([]Ref{newer, active}, "feature/auth")
+	if err != nil || !ok || latest.State != BranchArchived || latest.Generation != 8 {
+		t.Fatalf("newest generation = %+v, %v, %v", latest, ok, err)
+	}
+	states, err := BranchLifecycleStates([]Ref{newer, active})
+	if err != nil || len(states) != 1 || states["feature/auth"].Ref.Name != newer.Name {
+		t.Fatalf("single-pass states = %+v, %v", states, err)
+	}
+}
+
+func TestBranchLifecycleRefRejectsMalformedReservedTags(t *testing.T) {
+	repo := string(lifecycleHash('0'))
+	target := lifecycleHash('a')
+	malformed := []Ref{
+		{Kind: RefTag, Name: BranchLifecycleTagPrefix + "7/archived/" + strings.TrimPrefix(string(target), "sha256:") + "/main", RepoID: repo, Target: target},
+		{Kind: RefTag, Name: BranchLifecycleTagPrefix + "00000000000000000007/removed/" + strings.TrimPrefix(string(target), "sha256:") + "/main", RepoID: repo, Target: target},
+		{Kind: RefTag, Name: BranchLifecycleTagPrefix + "00000000000000000007/archived/" + strings.Repeat("b", 64) + "/main", RepoID: repo, Target: target},
+	}
+	for _, ref := range malformed {
+		if _, ok, err := ParseBranchLifecycleRef(ref); !ok || err == nil {
+			t.Fatalf("malformed reserved tag accepted: %+v, ok=%v err=%v", ref, ok, err)
+		}
+	}
+
+	ordinary := Ref{Kind: RefTag, Name: "release/v1", RepoID: repo, Target: target}
+	if _, ok, err := ParseBranchLifecycleRef(ordinary); ok || err != nil {
+		t.Fatalf("ordinary tag classified as lifecycle: ok=%v err=%v", ok, err)
+	}
+}

--- a/cli/internal/domain/errors.go
+++ b/cli/internal/domain/errors.go
@@ -47,6 +47,11 @@ var ErrNoActiveSession = errors.New("no active session")
 // This error has the same meaning as in git (Invariant F2): it fails silently without moving the existing branch.
 var ErrBranchExists = errors.New("branch already exists")
 
+// ErrBranchArchived prevents a stale replica from recreating a branch pointer
+// after a newer immutable lifecycle event archived it. Creating the branch
+// explicitly records a newer active event before restoring the pointer.
+var ErrBranchArchived = errors.New("branch is archived")
+
 // ErrNotGitRepo indicates the cwd is not part of a git worktree.
 // cxt is a shadow of git — repository information is always read from the local .git,
 // and it fails like git outside a git repository (no path fallback).

--- a/cli/internal/domain/values.go
+++ b/cli/internal/domain/values.go
@@ -79,6 +79,10 @@ func ValidateRefName(kind RefKind, name string) error {
 		}
 		return nil
 	}
+	if kind == RefTag && strings.HasPrefix(name, BranchLifecycleTagPrefix) {
+		_, _, err := parseBranchLifecycleTagName(name)
+		return err
+	}
 	return ValidateBranchName(name)
 }
 

--- a/cli/internal/ports/inbound/ports.go
+++ b/cli/internal/ports/inbound/ports.go
@@ -21,6 +21,38 @@ type ForkSession interface {
 	Fork(ctx context.Context, in ForkInput) (ForkOutput, error)
 }
 
+type BranchArchiveInput struct {
+	Cwd    string
+	RepoID string
+	Branch string
+}
+
+type BranchArchiveOutput struct {
+	Branch string
+	Target domain.ContentHash
+	Event  domain.Ref
+}
+
+type BranchRenameInput struct {
+	Cwd    string
+	RepoID string
+	From   string
+	To     string
+}
+
+type BranchRenameOutput struct {
+	From   string
+	To     string
+	Target domain.ContentHash
+}
+
+// BranchLifecycle manages only mutable branch projections. Archive events are
+// immutable tags, so snapshots and session documents are never deleted.
+type BranchLifecycle interface {
+	Archive(ctx context.Context, in BranchArchiveInput) (BranchArchiveOutput, error)
+	Rename(ctx context.Context, in BranchRenameInput) (BranchRenameOutput, error)
+}
+
 // LoadSession is a use-case port that restores a snapshot to the target provider session file (domain model).
 // Called from MCP session_load / memory_load / CLI cxt load / cxt memory load.
 // Mode=full|reconstructed for full-context restoration, Mode=memory for memory-form summary injection.
@@ -373,6 +405,9 @@ type CheckoutOutput struct {
 	ResumeCmd string
 	// Fidelity is the actual achieved fidelity (may differ from requested Mode).
 	Fidelity domain.FidelityTier
+	// ActivatedBranch reports that checkout restored a missing lifecycle
+	// projection and recorded a newer active generation.
+	ActivatedBranch bool
 }
 
 // MemorizeInput is the input DTO for Memorize.Memorize (compatibility rules).

--- a/cli/internal/ports/outbound/ports.go
+++ b/cli/internal/ports/outbound/ports.go
@@ -57,6 +57,19 @@ type SessionStore interface {
 	// ListRefs lists all refs (HEAD/branches/tags) of a repo.
 	ListRefs(ctx context.Context, repoID string) ([]domain.Ref, error)
 
+	// CreateBranchRef creates or explicitly restores a branch while recording a
+	// newer immutable active lifecycle event under the same storage lock.
+	CreateBranchRef(ctx context.Context, ref domain.Ref) (domain.Ref, error)
+	// ArchiveBranchRef records the current branch target before removing only
+	// its mutable active pointer. Session/snapshot data remains immutable.
+	ArchiveBranchRef(ctx context.Context, repoID, branch string) (domain.Ref, error)
+	// ApplyBranchLifecycleRef replicates one immutable lifecycle event. preserve
+	// is true when an actual local Git branch still owns the projection.
+	ApplyBranchLifecycleRef(ctx context.Context, event domain.Ref, preserve bool) error
+	// ReconcileBranchLifecycleRefs completes any lifecycle transition interrupted
+	// after its immutable event became durable but before its branch projection.
+	ReconcileBranchLifecycleRefs(ctx context.Context, repoID string) error
+
 	// Configuration folder snapshot object (content-addressed) — attached to commits and pushed/pulled.
 	PutSettingsObject(ctx context.Context, bundle domain.SettingsBundle) (domain.ContentHash, error)
 	GetSettingsObject(ctx context.Context, hash domain.ContentHash) (domain.SettingsBundle, error)
@@ -155,6 +168,14 @@ type GitContext interface {
 	// CurrentBranch returns the current git branch name of the cwd.
 	// Returns an empty value or fallback if not in a repo.
 	CurrentBranch(ctx context.Context, cwd string) (string, error)
+}
+
+// GitBranchInventory is an optional stronger capability used when applying a
+// remote branch archive. A real local Git branch is continuation authority and
+// must not lose its context projection because another replica deleted its
+// copy of the branch.
+type GitBranchInventory interface {
+	LocalBranches(ctx context.Context, cwd string) ([]string, error)
 }
 
 // MergedPullRequest identifies a Git-host PR whose merge commit entered the

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -300,6 +300,26 @@ cxt fork <ref> --as <branch>
 
 Creates a context branch from a specific ref and restores it.
 
+### `cxt branch archive` / `cxt branch restore`
+
+```text
+cxt branch archive <name>
+cxt branch restore <name>
+  [--provider <claude|codex>]
+  [--mode <full|reconstructed|memory>]
+```
+
+`archive` removes only the active context-branch pointer after the matching
+Git branch has been deleted. It first records an immutable lifecycle tag, so
+all snapshots, conversations, compact memory, and graph ancestry remain
+reachable and syncable. Git's branch-deletion hook performs this automatically;
+the command is also available for repairing historical stale pointers.
+
+`restore` resolves the latest archived target, records a newer active lifecycle
+event, recreates the context pointer, and restores the provider session. A
+stale client cannot recreate an archived pointer by an ordinary push; it must
+observe or explicitly create the newer active generation.
+
 ### `cxt load`
 
 ```text

--- a/frontend/web/src/branchLifecycle.ts
+++ b/frontend/web/src/branchLifecycle.ts
@@ -1,0 +1,86 @@
+import type { Ref } from './types';
+
+export const BRANCH_LIFECYCLE_TAG_PREFIX = 'cxt/branch-state/v1/';
+
+export interface BranchLifecycleEvent {
+  branch: string;
+  generation: bigint;
+  state: 'active' | 'archived';
+  target: string;
+  ref: Ref;
+}
+
+export function parseBranchLifecycleRef(ref: Ref): BranchLifecycleEvent | null {
+  if (ref.kind !== 'tag' || !ref.name.startsWith(BRANCH_LIFECYCLE_TAG_PREFIX)) return null;
+  const rest = ref.name.slice(BRANCH_LIFECYCLE_TAG_PREFIX.length);
+  const match = rest.match(/^([0-9]{20})\/(active|archived)\/([0-9a-f]{64})\/(.+)$/);
+  if (!match) return null;
+  const target = `sha256:${match[3]}`;
+  if (ref.target !== target || !match[4]) return null;
+  const generation = BigInt(match[1]);
+  if (generation === 0n || generation.toString().padStart(20, '0') !== match[1]) return null;
+  return { branch: match[4], generation, state: match[2] as 'active' | 'archived', target, ref };
+}
+
+function later(left: BranchLifecycleEvent, right: BranchLifecycleEvent): boolean {
+  if (left.generation !== right.generation) return left.generation > right.generation;
+  if (left.state !== right.state) return left.state === 'active';
+  if (left.target !== right.target) return left.target > right.target;
+  return left.ref.name > right.ref.name;
+}
+
+export function latestBranchLifecycle(refs: Ref[], branch: string): BranchLifecycleEvent | null {
+  let latest: BranchLifecycleEvent | null = null;
+  for (const ref of refs) {
+    const event = parseBranchLifecycleRef(ref);
+    if (!event || event.branch !== branch) continue;
+    if (!latest || later(event, latest)) latest = event;
+  }
+  return latest;
+}
+
+export function branchLifecycleStates(refs: Ref[]): Map<string, BranchLifecycleEvent> {
+  const states = new Map<string, BranchLifecycleEvent>();
+  for (const ref of refs) {
+    const event = parseBranchLifecycleRef(ref);
+    if (!event) continue;
+    const current = states.get(event.branch);
+    if (!current || later(event, current)) states.set(event.branch, event);
+  }
+  return states;
+}
+
+/** Projects internal lifecycle events into the active branch list while
+ * retaining the events themselves for reachability and replica convergence. */
+export function projectBranchRefs(refs: Ref[]): Ref[] {
+  const states = branchLifecycleStates(refs);
+  const branches = new Map(refs.filter((ref) => ref.kind === 'branch').map((ref) => [ref.name, ref]));
+  const out: Ref[] = [];
+  for (const input of refs) {
+    const ref = { ...input };
+    if (ref.kind === 'branch') {
+      const latest = states.get(ref.name);
+      if (latest?.state === 'archived' && latest.target === ref.target) continue;
+    }
+    if (ref.kind === 'head' && ref.symbolic) {
+      const branch = ref.symbolic.replace(/^refs\/heads\//, '');
+      const latest = states.get(branch);
+      const raw = branches.get(branch);
+      if (latest?.state === 'archived' && (!raw || raw.target === latest.target)) {
+        ref.symbolic = '';
+        ref.target = latest.target;
+      }
+    }
+    out.push(ref);
+  }
+  return out;
+}
+
+export function archivedBranchMarkers(refs: Ref[]): { branch: string; target: string }[] {
+  const projected = projectBranchRefs(refs);
+  const active = new Set(projected.filter((ref) => ref.kind === 'branch').map((ref) => ref.name));
+  return [...branchLifecycleStates(refs).values()]
+    .filter((event) => event.state === 'archived' && !active.has(event.branch))
+    .map((event) => ({ branch: event.branch, target: event.target }))
+    .sort((left, right) => left.branch.localeCompare(right.branch));
+}

--- a/frontend/web/src/components/CommitGraph.tsx
+++ b/frontend/web/src/components/CommitGraph.tsx
@@ -292,9 +292,10 @@ export function CommitGraph({
   // Track label: topmost (latest) node of each track — ref badge (branch name) first, then snapshot label.
   // Pin track (default branch) has fixed label — append promotion after main ref points to the snapshot of the feature birth label, making the left track read as main.
   const laneLabels = useMemo(() => {
-    const labels: (string | null)[] = Array(laneCount).fill(null);
+    type LaneLabel = { text: string; archived: boolean };
+    const labels: (LaneLabel | null)[] = Array(laneCount).fill(null);
     if (pinHead && pinBranch && rows.some((r) => r.lane === 0 && r.snap.id === pinHead)) {
-      labels[0] = pinBranch;
+      labels[0] = { text: pinBranch, archived: false };
     }
     for (const r of rows) {
       if (labels[r.lane] !== null) continue;
@@ -302,25 +303,30 @@ export function CommitGraph({
       const branchBadge =
         (pinBranch ? rowBadges.find((b) => b.kind === 'branch' && b.name === pinBranch && r.lane === 0) : undefined) ??
         rowBadges.find((b) => b.kind === 'branch');
-      labels[r.lane] = branchBadge?.name ?? r.snap.branch ?? '';
+      const archivedBadge = rowBadges.find((b) => b.kind === 'archived');
+      labels[r.lane] = branchBadge
+        ? { text: branchBadge.name, archived: false }
+        : archivedBadge
+          ? { text: t('graph.archivedLane', { branch: archivedBadge.name }), archived: true }
+          : { text: r.snap.branch ?? '', archived: false };
     }
     return labels;
-  }, [rows, laneCount, badges, pinHead, pinBranch]);
+  }, [rows, laneCount, badges, pinHead, pinBranch, t]);
 
   return (
     <div className="graph-wrap">
       {/* Top: branch labels per track (track color, tilt — to prevent overlap) */}
       <div className="graph-head" style={{ width: svgW }}>
         {laneLabels.map((label, i) =>
-          label ? (
+          label?.text ? (
             <span
               key={i}
-              className={`graph-lane-label${label.length > 6 ? ' truncated' : ''}`}
-              style={{ left: cx(i), color: laneColor(i) }}
+              className={`graph-lane-label${label.archived ? ' archived' : ''}${label.text.length > 6 ? ' truncated' : ''}`}
+              style={{ left: cx(i), color: label.archived ? TICK : laneColor(i) }}
             >
               {/* Truncate after 6 characters (to prevent overflow) — show full name as background chip on hover */}
-              <span className="lane-label-short">{label.length > 6 ? label.slice(0, 6) + '…' : label}</span>
-              {label.length > 6 && <span className="lane-label-full">{label}</span>}
+              <span className="lane-label-short">{label.text.length > 6 ? label.text.slice(0, 6) + '…' : label.text}</span>
+              {label.text.length > 6 && <span className="lane-label-full">{label.text}</span>}
             </span>
           ) : null,
         )}
@@ -550,9 +556,13 @@ export function CommitGraph({
           {badges.get(tipRow.snap.id)?.length ? (
             <span className="tip-badges">
               {badges.get(tipRow.snap.id)!.map((b) => (
-                <span key={b.kind + b.name} className={`ref-badge ${b.kind}`}>
-                  {b.kind === 'tag' ? '⌂ ' : ''}
-                  {b.name}
+                <span
+                  key={b.kind + b.name}
+                  className={`ref-badge ${b.kind}`}
+                  title={b.kind === 'archived' ? t('context.archivedBranchTitle') : undefined}
+                >
+                  {b.kind === 'tag' ? '⌂ ' : b.kind === 'archived' ? '⊟ ' : ''}
+                  {b.kind === 'archived' ? t('context.archivedBranchBadge', { branch: b.name }) : b.name}
                 </span>
               ))}
             </span>

--- a/frontend/web/src/components/ContextView.tsx
+++ b/frontend/web/src/components/ContextView.tsx
@@ -276,9 +276,13 @@ export function ContextView({ repo, ws, role }: { repo: Repo; ws: ContextWorkspa
                 // (other branch/tag badges keep their names).
                 const isHead = b.kind === 'branch' && b.name === branch;
                 return (
-                  <span key={b.kind + b.name} className={`ref-badge ${isHead ? 'head' : b.kind}`}>
-                    {b.kind === 'tag' ? '⌂ ' : ''}
-                    {isHead ? '⌑ head' : b.name}
+                  <span
+                    key={b.kind + b.name}
+                    className={`ref-badge ${isHead ? 'head' : b.kind}`}
+                    title={b.kind === 'archived' ? t('context.archivedBranchTitle') : undefined}
+                  >
+                    {b.kind === 'tag' ? '⌂ ' : b.kind === 'archived' ? '⊟ ' : ''}
+                    {isHead ? '⌑ head' : b.kind === 'archived' ? t('context.archivedBranchBadge', { branch: b.name }) : b.name}
                   </span>
                 );
               })}

--- a/frontend/web/src/components/Settings.tsx
+++ b/frontend/web/src/components/Settings.tsx
@@ -25,6 +25,7 @@ import { GearBtn } from './About';
 import { Portal } from './Portal';
 import { useT, Rich } from '../i18n';
 import { safeAvatarUrl } from '../urls';
+import { projectBranchRefs } from '../branchLifecycle';
 
 // resizeToDataURL reduces uploaded images to a 256px square JPEG data URL (center crop).
 // Stores the record as is, keeping it small (server limit ~700KB).
@@ -453,7 +454,8 @@ function RepoBranchSettings({ repo, label }: { repo: Repo; label: string | null 
   const [protect, setProtect] = useState(repo.protect_default ?? false);
   const save = useUpdateAbout();
   // Candidate = list of actual branch refs on the server — not free input; must be chosen from actual remote branches (prevents creating non-existent default branches by typo). Current setting is always included.
-  const refs = useRefs(repo.id).data ?? [];
+  const rawRefs = useRefs(repo.id).data ?? [];
+  const refs = useMemo(() => projectBranchRefs(rawRefs), [rawRefs]);
   const branches = useMemo(() => {
     const names = new Set<string>();
     for (const r of refs) if (r.kind === 'branch' && r.name) names.add(r.name);

--- a/frontend/web/src/hooks.ts
+++ b/frontend/web/src/hooks.ts
@@ -7,6 +7,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { api } from './api';
 import type { User } from './types';
 import { sharedReachable, unsyncChains } from './onhold';
+import { archivedBranchMarkers, parseBranchLifecycleRef, projectBranchRefs } from './branchLifecycle';
 import { firebaseEnabled, devIdpToken, firebaseEmailIdToken, firebaseEmailSignUp, firebaseGoogleIdToken, firebaseSignOut } from './auth';
 import { useT } from './i18n';
 
@@ -127,11 +128,24 @@ export function useRepos(workspaceId: string | null) {
 }
 // Context Browser: Branch List → Commit Log → Body(CIR). Immutable data(doc) is infinite cache.
 export function useRefs(repoId: string | null) {
-  return useQuery({
+  const qc = useQueryClient();
+  const q = useQuery({
     queryKey: ['refs', repoId],
     queryFn: () => api.listRefs(repoId as string),
     enabled: Boolean(repoId),
+    refetchInterval: 15_000,
   });
+  const signature = (q.data ?? [])
+    .map((ref) => `${ref.kind}:${ref.name}@${ref.target}`)
+    .sort()
+    .join(',');
+  const previous = useRef(signature);
+  useEffect(() => {
+    if (previous.current === signature) return;
+    previous.current = signature;
+    void qc.invalidateQueries({ queryKey: ['snapshots', repoId, '*'] });
+  }, [signature, qc, repoId]);
+  return q;
 }
 export function useAllSnapshots(repoId: string | null, enabled: boolean) {
   return useQuery({
@@ -278,7 +292,8 @@ export function useDismissPending() {
 // Ensure "badge count = tab row count" is guaranteed by logic (onhold.ts) and input equality, so
 // exclude stash, hook capture leaves, and badge map must be created here only (review front #2).
 export function useRepoView(repoId: string | null) {
-  const refs = useRefs(repoId).data ?? [];
+  const rawRefs = useRefs(repoId).data ?? [];
+  const refs = useMemo(() => projectBranchRefs(rawRefs), [rawRefs]);
   const allData = useAllSnapshots(repoId, true).data;
   const snapshots = useMemo(() => {
     const all = (allData ?? []).filter((s) => s.branch !== '(stash)');
@@ -292,9 +307,15 @@ export function useRepoView(repoId: string | null) {
     const m = new Map<string, { name: string; kind: string }[]>();
     for (const r of refs) {
       if (r.kind !== 'branch' && r.kind !== 'tag') continue;
+      if (parseBranchLifecycleRef(r)) continue;
       const list = m.get(r.target) ?? [];
       list.push({ name: r.name, kind: r.kind });
       m.set(r.target, list);
+    }
+    for (const marker of archivedBranchMarkers(refs)) {
+      const list = m.get(marker.target) ?? [];
+      list.push({ name: marker.branch, kind: 'archived' });
+      m.set(marker.target, list);
     }
     return m;
   }, [refs]);

--- a/frontend/web/src/i18n/locales/en.ts
+++ b/frontend/web/src/i18n/locales/en.ts
@@ -76,6 +76,8 @@ export const en: Messages = {
     reflog: '⟲ reflog — ref move history',
     reflogEmpty: 'No entries',
     memoryBadgeTitle: 'Has a stored memory digest — select to inspect the snapshot archive',
+    archivedBranchBadge: 'archived · {branch}',
+    archivedBranchTitle: 'Context from a deleted Git branch — history is preserved and can be restored with cxt branch restore',
     compactSummary: 'Context compaction summary (agent-written)',
     cxtSeedSummary: 'cxt seed summary (auto-generated — inherited context)',
     branchOff: '⎇ branch off (checkout -b)',
@@ -454,5 +456,6 @@ export const en: Messages = {
     joinAlreadyHead: 'This commit is already the branch head.',
     uncommitted: '◌ Uncommitted — hook capture not yet linked to a commit',
     uncommittedDivider: '◌ above: uncommitted captures',
+    archivedLane: 'archive · {branch}',
   },
 };

--- a/frontend/web/src/i18n/locales/ko.ts
+++ b/frontend/web/src/i18n/locales/ko.ts
@@ -79,6 +79,8 @@ export const ko = {
     reflog: '⟲ reflog — ref 이동 기록',
     reflogEmpty: '기록 없음',
     memoryBadgeTitle: '저장된 메모리 digest 보유 — 선택하면 이 스냅샷의 원본 기록을 표시합니다',
+    archivedBranchBadge: '보관됨 · {branch}',
+    archivedBranchTitle: '삭제된 Git 브랜치의 컨텍스트 — 이력은 보존되며 cxt branch restore로 복구할 수 있습니다',
     compactSummary: '컨텍스트 압축 요약 (에이전트 생성)',
     cxtSeedSummary: 'cxt 시드 요약 (자동 생성 — 상속 컨텍스트)',
     branchOff: '⎇ 분기 (checkout -b)',
@@ -457,6 +459,7 @@ export const ko = {
     joinAlreadyHead: '이 커밋이 이미 브랜치 head 입니다.',
     uncommitted: '◌ 미커밋 — 아직 commit에 연결되지 않은 훅 캡처',
     uncommittedDivider: '◌ 위는 미커밋 (commit 전)',
+    archivedLane: '보관 · {branch}',
   },
 };
 

--- a/frontend/web/src/onhold.ts
+++ b/frontend/web/src/onhold.ts
@@ -1,6 +1,7 @@
 // On Hold logic — ContextView (badge count) and OnHoldView (tab render) share it.
 // The badge number and the number of rows shown in the tab must match, so a single definition is used.
 import type { Ref, Snapshot, Pending, Unsync } from './types';
+import { parseBranchLifecycleRef } from './branchLifecycle';
 
 /** Snapshot IDs reachable from explicit roots under cxthub's immutable graph
  *  rule. Natural parents and graft overlay parents are equally valid for
@@ -27,7 +28,9 @@ export function reachableSnapshotIds(targets: Iterable<string>, snapshots: Snaps
  *  will reappear as an uncommitted one, and the graph will show orphaned history before the merge. */
 export function sharedReachable(refs: Ref[], snapshots: Snapshot[]): Set<string> {
   // session ref preserves residual sessions from partial merges but not git branch membership.
-  const roots = refs.filter((r) => r.kind === 'branch' || r.kind === 'session').map((r) => r.target);
+  const roots = refs
+    .filter((r) => r.kind === 'branch' || r.kind === 'session' || parseBranchLifecycleRef(r) !== null)
+    .map((r) => r.target);
   return reachableSnapshotIds(roots, snapshots);
 }
 

--- a/frontend/web/src/styles.css
+++ b/frontend/web/src/styles.css
@@ -266,6 +266,7 @@ button.copy.done { color: var(--ok); border-color: var(--ok); }
   border-radius: 99px; border: 1px solid var(--line); color: var(--muted); white-space: nowrap; }
 .ref-badge.branch { color: var(--ok); border-color: rgba(46, 125, 91, 0.35); }
 .ref-badge.tag { color: var(--ink); border-color: var(--faint); }
+.ref-badge.archived { color: var(--faint); border-color: var(--faint); border-style: dashed; }
 /* Current branch tip — branch name is already provided in the dropdown (fill style = current position). */
 .ref-badge.head { background: var(--ok); border-color: var(--ok); color: #fff; }
 /* Pending — session continues even after commits (yellow = progress/change semantic). */
@@ -432,6 +433,7 @@ button.copy.done { color: var(--ok); border-color: var(--ok); }
 .graph-head { position: relative; height: 44px; }
 .graph-lane-label { position: absolute; bottom: 2px; font-family: var(--mono); font-size: 0.68rem;
   white-space: nowrap; transform: rotate(-35deg); transform-origin: left bottom; }
+.graph-lane-label.archived { font-style: italic; text-decoration: line-through; text-decoration-thickness: 1px; }
 /* Long branch name: default is 6 chars + … truncated, full name shown as background/shadow chip —
    raised above other rail labels to ensure readability. */
 .lane-label-full { display: none; }

--- a/frontend/web/src/types.ts
+++ b/frontend/web/src/types.ts
@@ -134,6 +134,7 @@ export interface Ref {
   name: string;
   repo_id: string;
   target: string;
+  symbolic?: string;
 }
 
 /** Context snapshot (= git commit) */

--- a/frontend/web/tests/reachability.test.ts
+++ b/frontend/web/tests/reachability.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import { mainlineOf } from '../src/graph.ts';
 import { reachableSnapshotIds, sharedReachable } from '../src/onhold.ts';
+import { archivedBranchMarkers, parseBranchLifecycleRef, projectBranchRefs } from '../src/branchLifecycle.ts';
 import type { Ref, Snapshot } from '../src/types.ts';
 
 function snapshot(id: string, parents: string[] = [], graftParents: string[] = []): Snapshot {
@@ -49,3 +50,62 @@ const refs: Ref[] = [
   { kind: 'tag', name: 'unshared', repo_id: 'repo', target: 'unreachable' },
 ];
 assert.equal(sharedReachable(refs, snapshots).has('unreachable'), false, 'tags are not shared timeline roots');
+
+const archiveTarget = 'sha256:' + 'a'.repeat(64);
+const archiveRef: Ref = {
+  kind: 'tag',
+  name: `cxt/branch-state/v1/00000000000000000001/archived/${'a'.repeat(64)}/feature/deleted`,
+  repo_id: 'repo',
+  target: archiveTarget,
+};
+const archivedRefs: Ref[] = [
+  { kind: 'branch', name: 'feature/deleted', repo_id: 'repo', target: archiveTarget },
+  archiveRef,
+];
+assert.equal(parseBranchLifecycleRef(archiveRef)?.branch, 'feature/deleted');
+assert.equal(projectBranchRefs(archivedRefs).some((r) => r.kind === 'branch'), false, 'archived branch projection must be hidden');
+assert.equal(
+  sharedReachable(archivedRefs, [snapshot(archiveTarget)]).has(archiveTarget),
+  true,
+  'archived lifecycle tags must preserve shared reachability',
+);
+
+const activeRef: Ref = {
+  kind: 'tag',
+  name: `cxt/branch-state/v1/00000000000000000001/active/${'a'.repeat(64)}/feature/deleted`,
+  repo_id: 'repo',
+  target: archiveTarget,
+};
+assert.equal(
+  projectBranchRefs([...archivedRefs, activeRef]).some((r) => r.kind === 'branch'),
+  true,
+  'same-generation active event must preserve the branch',
+);
+
+const advancedTarget = 'sha256:' + 'b'.repeat(64);
+assert.equal(
+  projectBranchRefs([
+    { kind: 'branch', name: 'feature/deleted', repo_id: 'repo', target: advancedTarget },
+    archiveRef,
+  ]).some((r) => r.kind === 'branch' && r.target === advancedTarget),
+  true,
+  'an archive may hide only the exact target it observed',
+);
+
+const interruptedArchive = projectBranchRefs([
+  { kind: 'head', name: 'HEAD', repo_id: 'repo', target: '', symbolic: 'feature/deleted' },
+  ...archivedRefs,
+]);
+const projectedHead = interruptedArchive.find((ref) => ref.kind === 'head');
+assert.equal(projectedHead?.symbolic, '', 'interrupted archive must not expose dangling symbolic HEAD');
+assert.equal(projectedHead?.target, archiveTarget, 'interrupted archive HEAD detaches at the preserved target');
+assert.deepEqual(
+  archivedBranchMarkers(archivedRefs),
+  [{ branch: 'feature/deleted', target: archiveTarget }],
+  'archived branch must remain visible as a recoverable graph marker',
+);
+assert.deepEqual(
+  archivedBranchMarkers([...archivedRefs, activeRef]),
+  [],
+  'an active winner must remove the archived graph marker',
+);

--- a/schemas/manifest.schema.json
+++ b/schemas/manifest.schema.json
@@ -52,27 +52,30 @@
     },
     "refKind": {
       "type": "string",
-      "description": "Ref type: head=current checkout symbolic ref, branch=actual Git branch pointer, session=preserved pointer within the same Git branch, tag=immutable label.",
+      "description": "Ref type: head=current checkout symbolic ref, branch=actual Git branch pointer, session=preserved pointer within the same Git branch, tag=immutable label (including reserved cxt/branch-state/v1 lifecycle events).",
       "enum": ["head", "branch", "session", "tag"]
     },
     "ref": {
       "type": "object",
-      "description": "Mutable HEAD/branch/session/tag pointer serialized from domain.Ref.",
+      "description": "HEAD/branch/session pointers or immutable tags serialized from domain.Ref. Reserved cxt/branch-state/v1 tags preserve branch archive/restore events without deleting history.",
       "additionalProperties": false,
       "required": ["kind", "name", "repo_id", "target"],
       "properties": {
         "kind": { "$ref": "#/$defs/refKind" },
         "name": {
           "type": "string",
-          "description": "Ref name. A branch uses the Git branch name, a session uses an internal session name, a tag uses its tag name, and HEAD is fixed at 'HEAD'."
+          "description": "Ref name. A branch uses the Git branch name, a session uses an internal session name, a tag uses its tag name, and HEAD is fixed at 'HEAD'. The cxt/branch-state/v1 tag namespace is reserved."
         },
         "repo_id": {
           "type": "string",
           "description": "Owner repo ID."
         },
         "target": {
-          "$ref": "#/$defs/contentHash",
-          "description": "Referenced Snapshot.ID. It must identify an existing snapshot (referential-integrity invariant)."
+          "description": "Referenced Snapshot.ID, or an empty string for symbolic HEAD.",
+          "oneOf": [
+            { "$ref": "#/$defs/contentHash" },
+            { "const": "" }
+          ]
         },
         "symbolic": {
           "type": "string",

--- a/schemas/openapi.yaml
+++ b/schemas/openapi.yaml
@@ -85,7 +85,7 @@ components:
 
     Ref:
       type: object
-      description: "Mutable pointer (HEAD/branch/session/tag). domain.Ref serialization. Original format: schemas/manifest.schema.json."
+      description: "Pointer or immutable tag (HEAD/branch/session/tag). Tags under cxt/branch-state/v1/ are reserved branch lifecycle events: modern peers apply them before branch refs, archived generations remove only the mutable branch projection, and snapshot/session history remains reachable. Older peers preserve them as ordinary immutable tags. domain.Ref serialization. Original format: schemas/manifest.schema.json."
       required: [kind, name, repo_id, target]
       additionalProperties: false
       properties:
@@ -93,11 +93,14 @@ components:
           $ref: "#/components/schemas/RefKind"
         name:
           type: string
-          description: "Branch/session/tag name or HEAD (fixed)."
+          description: "Branch/session/tag name or HEAD (fixed). The cxt/branch-state/v1/ tag namespace is reserved for immutable active/archived branch lifecycle events."
         repo_id:
           $ref: "#/components/schemas/ContentHash"
         target:
-          $ref: "#/components/schemas/ContentHash"
+          description: "Referenced snapshot hash, or an empty string for symbolic HEAD."
+          oneOf:
+            - $ref: "#/components/schemas/ContentHash"
+            - const: ""
         symbolic:
           type: string
           description: "Symbolic target (branch name when HEAD points to a branch). Direct reference is an empty string."
@@ -1059,19 +1062,95 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                required: [refs]
-                properties:
-                  refs:
-                    type: array
-                    items:
-                      $ref: "#/components/schemas/Ref"
+                type: array
+                items:
+                  $ref: "#/components/schemas/Ref"
         "401":
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
+
+  /repos/{repoID}/refs/batch:
+    parameters:
+      - $ref: "#/components/parameters/repoID"
+    post:
+      operationId: updateRefs
+      summary: Apply a bounded ref projection batch
+      description: |
+        Applies ordered ref updates with the same policy as the single-ref endpoint,
+        then reconciles pending reachability exactly once. An empty batch is valid
+        and repairs cleanup interrupted after a prior durable ref write.
+      tags: [refs]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [updates]
+              additionalProperties: false
+              properties:
+                updates:
+                  type: array
+                  maxItems: 4096
+                  items:
+                    type: object
+                    required: [ref]
+                    additionalProperties: false
+                    properties:
+                      ref:
+                        $ref: "#/components/schemas/Ref"
+                      force:
+                        type: boolean
+                        description: "Force a non-fast-forward branch move. Never applied to lifecycle events."
+                      append:
+                        type: boolean
+                        description: "Losslessly graft a diverged branch behind the server head."
+      responses:
+        "200":
+          description: Batch applied and pending reachability reconciled.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [applied]
+                additionalProperties: false
+                properties:
+                  applied:
+                    type: integer
+                    minimum: 0
+        "400":
+          description: Invalid batch or ref.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: Ref conflict, non-fast-forward move, or archived branch.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "413":
+          description: Batch JSON body exceeds the 8 MiB transport limit.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "422":
+          description: Invalid batch size, lifecycle event, or ref value.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
 
   # Implementation note: Actual route is {name...} (allows branch names with slashes). Diverged automatic fork removal —
   # Non-fast-forward is 409 non_fast_forward (only pass with force), diverged is resolved by append (lossless reordering).
@@ -1091,7 +1170,6 @@ paths:
         (`force: true` only), diverged is resolved by a lossless rebase (graft) with `append: true`.
         objects (snapshot+doc) must arrive first via push/objects (object precedence invariant).
         `kind=session` is an internal pointer managed by join. General ref API only allows idempotent echo for the same target, and creation/movement/force are rejected with 403.
-        only allows idempotent echo for the same target, and creation/movement/force are rejected with 403.
       tags: [refs]
       parameters:
         - name: X-Cxt-Identity
@@ -1105,13 +1183,16 @@ paths:
           application/json:
             schema:
               type: object
-              required: [ref, expected_target]
               additionalProperties: false
               properties:
-                ref:
-                  $ref: "#/components/schemas/Ref"
-                expected_target:
+                target:
                   $ref: "#/components/schemas/ContentHash"
+                expected_target:
+                  type: string
+                  description: "Optional compare-and-swap target. Empty means use the observed server target."
+                symbolic:
+                  type: string
+                  description: "Symbolic branch name for HEAD; mutually exclusive with target."
                 force:
                   type: boolean
                   description: "Force non-fast-forward move (git push --force). Protected branches are rejected."
@@ -1130,9 +1211,17 @@ paths:
                 properties:
                   result:
                     type: string
-                    enum: [fast_forward, up_to_date]
+                    enum: [fast_forward, up_to_date, forced, appended]
                   ref:
                     $ref: "#/components/schemas/Ref"
+                  requested_target:
+                    $ref: "#/components/schemas/ContentHash"
+                  server_target:
+                    $ref: "#/components/schemas/ContentHash"
+                  forked_ref:
+                    $ref: "#/components/schemas/Ref"
+                  merge_base:
+                    $ref: "#/components/schemas/ContentHash"
         "400":
           description: "Invalid request."
           content:
@@ -1150,6 +1239,7 @@ paths:
             ref Move conflict:
             - `ref_conflict`: expected_target differs from server current value (concurrent update). Retry after pull.
             - `non_fast_forward`: Server is ahead. Rejected without `force` or `append`.
+            - `branch_archived`: a stale branch projection cannot recreate an archived branch; pull lifecycle state or explicitly restore it.
             (diverged automatic fork is removed — replaced by append lossless reordering.)
           content:
             application/json:
@@ -2782,11 +2872,11 @@ tags:
   - name: docs
     description: "content-addressed blob (SessionDoc/CIR). Creation is only allowed via the push/objects path."
   - name: refs
-    description: "mutable pointer (HEAD/branch/session/tag). CAS move."
+    description: "HEAD/branch/session pointers and immutable tags. Ref movement uses CAS; cxt/branch-state/v1 tags carry branch lifecycle events."
   - name: memories
     description: "snapshot attachment MemoryDigest."
   - name: push
-    description: "Push negotiation in three stages (negotiate → objects → ref PUT)."
+    description: "Push negotiation in three stages (negotiate → objects → bounded ref batch, with single-ref fallback for older servers)."
   - name: pull
     description: "Pull negotiation (manifest GET → pull/objects → local ref merge)."
   - name: actions

--- a/scripts/e2e-sync.sh
+++ b/scripts/e2e-sync.sh
@@ -378,6 +378,43 @@ sleep 2 # Confirm fork-connect backed off after the seed won.
 expect "helper does not overwrite seed" "$([ "$(cat .cxt/refs/heads/web-fork-y)" != "$FORK_FROM" ] && echo yes)" yes
 git checkout -q main >/dev/null 2>&1
 
+echo "── I. Branch lifecycle: rename transfers context; deletion archives without deleting history"
+RENAME_OUT=$(git branch -m web-fork-x web-fork-renamed 2>&1)
+expect "Git branch rename transfers context projection" "$(echo "$RENAME_OUT" | grep -c 'context moved')" 1
+expect "renamed context keeps its exact target" "$(cat .cxt/refs/heads/web-fork-renamed 2>/dev/null)" "$FORK_FROM"
+expect "renamed source context projection is gone" "$([ ! -e .cxt/refs/heads/web-fork-x ] && echo yes)" yes
+expect "rename keeps all context objects readable" "$(cxt fsck | grep -c 'Missing 0')" 1
+
+DELETE_OUT=$(git branch -D web-fork-renamed 2>&1)
+expect "normal branch deletion invokes context archive" "$(echo "$DELETE_OUT" | grep -c 'context archived')" 1
+expect "deleted Git branch has no active context projection" "$([ ! -e .cxt/refs/heads/web-fork-renamed ] && echo yes)" yes
+expect "archive keeps the target snapshot readable" "$(cxt fsck | grep -c 'Missing 0')" 1
+expect "archive records an immutable lifecycle event" "$(find .cxt/refs/tags/cxt/branch-state/v1 -type f -path '*/archived/*/web-fork-renamed' 2>/dev/null | wc -l | tr -d ' ')" 1
+
+# Detached HEAD used to return before reading deletion transactions. Delete a
+# second branch while detached to exercise the real hook and zeros→zeros Git
+# transaction form, not only the parser unit test.
+git checkout -q --detach HEAD >/dev/null 2>&1
+DETACHED_DELETE_OUT=$(git branch -D web-fork-y 2>&1)
+expect "detached branch deletion still invokes context archive" "$(echo "$DETACHED_DELETE_OUT" | grep -c 'context archived')" 1
+expect "detached deletion removes only the active projection" "$([ ! -e .cxt/refs/heads/web-fork-y ] && echo yes)" yes
+expect "detached archive preserves immutable history" "$(cxt fsck | grep -c 'Missing 0')" 1
+
+# The archive helper pushes asynchronously. The server must converge to no
+# branch projection while retaining the lifecycle tags as reachability roots.
+for i in $(seq 1 40); do
+  SERVER_ARCHIVE_STATE=$(curl -sb "$J" "$B/repos/$RID/refs" | python3 -c "
+import json,sys
+refs=json.load(sys.stdin)
+branches={r['name'] for r in refs if r['kind']=='branch'}
+archives=[r for r in refs if r['kind']=='tag' and '/archived/' in r['name'] and r['name'].startswith('cxt/branch-state/v1/')]
+print('ready' if 'web-fork-x' not in branches and 'web-fork-renamed' not in branches and 'web-fork-y' not in branches and len(archives) >= 3 else 'waiting')
+")
+  [ "$SERVER_ARCHIVE_STATE" = ready ] && break
+  sleep 0.25
+done
+expect "server applies both recoverable archive projections" "$SERVER_ARCHIVE_STATE" ready
+
 echo "── J. cxt setup: onboarding single command (idempotent, merge preservation)"
 mkdir -p "$HOME/.codex"
 cat > "$HOME/.codex/hooks.json" <<'EOF'


### PR DESCRIPTION
Closes #114

## Summary
- record branch active/archive transitions as immutable generational tags while deleting only the mutable branch projection
- make Git rename and deletion hooks recoverable across files-backend zero-to-zero transactions and process interruption
- synchronize lifecycle refs through bounded ref batches with old-server fallback and stale-resurrection protection
- preserve archived snapshots as reachability roots and expose recoverable archived markers in the web graph
- add explicit cxt branch archive and restore commands, protected-default enforcement, reflog coverage, and FS/PostgreSQL parity

## Design
The issue sketch used timestamped archive-only refs. This implementation uses cxt/branch-state/v1/<generation>/<active|archived>/<target>/<branch>. Explicit active generations make restore, concurrent stale-client resolution, crash compensation, and deterministic replica convergence possible while remaining compatible with old peers that preserve the events as ordinary immutable tags.

No snapshot, document, memory, or session object is deleted.

## Validation
- CLI and backend full tests, vet, race, and PostgreSQL-tag tests
- real binary product E2E and sync E2E, including rename, normal delete, detached delete, and server convergence
- web unit, i18n, Vercel, typecheck, build, and npm audit
- OpenAPI drift, public history and secret scan, deploy static and Terraform checks
- govulncheck for CLI and backend