### PR TITLE
Fix profile activity crash on empty collections

### DIFF
--- a/backend/internal/app/activity_test.go
+++ b/backend/internal/app/activity_test.go
@@ -1,0 +1,77 @@
+package app
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/wnsdy95/cxthub/backend/internal/adapters/store"
+	"github.com/wnsdy95/cxthub/backend/internal/domain"
+)
+
+func TestActivitySerializesEmptyCollectionsAsArrays(t *testing.T) {
+	ctx := context.Background()
+	st := store.NewFSStore(t.TempDir())
+	svc := NewService(st, st, nil, nil, st)
+
+	commitWorkspace := domain.Workspace{
+		ID:            "ws_commit",
+		Name:          "Commit only",
+		Slug:          "commit-only",
+		OwnerUsername: "alice",
+	}
+	createdWorkspace := domain.Workspace{
+		ID:            "ws_created",
+		Name:          "Created only",
+		Slug:          "created-only",
+		OwnerUsername: "alice",
+		CreatedAt:     time.Date(2026, time.July, 3, 0, 0, 0, 0, time.UTC),
+	}
+	repoID := domain.HashContent([]byte("activity-repo"))
+	if _, err := st.PutRepo(ctx, domain.Repo{
+		ID:          repoID,
+		WorkspaceID: commitWorkspace.ID,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	snapshotID := domain.HashContent([]byte("activity-snapshot"))
+	if err := st.PutSnapshot(ctx, domain.Snapshot{
+		ID:        snapshotID,
+		RepoID:    repoID,
+		DocHash:   snapshotID,
+		CreatedAt: time.Date(2026, time.August, 4, 0, 0, 0, 0, time.UTC),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	months, err := svc.Activity(ctx, []domain.Workspace{commitWorkspace, createdWorkspace})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(months) != 2 {
+		t.Fatalf("months = %d, want 2", len(months))
+	}
+	byMonth := make(map[string]domain.ActivityMonth, len(months))
+	for _, month := range months {
+		byMonth[month.Month] = month
+	}
+	if got := byMonth["2026-08"].Created; got == nil || len(got) != 0 {
+		t.Fatalf("commit-only created = %#v, want non-nil empty slice", got)
+	}
+	if got := byMonth["2026-07"].CommitRepos; got == nil || len(got) != 0 {
+		t.Fatalf("created-only commit_repos = %#v, want non-nil empty slice", got)
+	}
+
+	encoded, err := json.Marshal(months)
+	if err != nil {
+		t.Fatal(err)
+	}
+	jsonText := string(encoded)
+	for _, forbidden := range []string{`"created":null`, `"commit_repos":null`} {
+		if strings.Contains(jsonText, forbidden) {
+			t.Fatalf("activity response contains %s: %s", forbidden, jsonText)
+		}
+	}
+}

--- a/backend/internal/app/service.go
+++ b/backend/internal/app/service.go
@@ -1837,7 +1837,14 @@ func (s *Service) Activity(ctx context.Context, workspaces []domain.Workspace) (
 	path := func(w domain.Workspace) string { return w.OwnerUsername + "/" + w.Slug }
 	out := make([]domain.ActivityMonth, 0, len(months))
 	for _, m := range months {
-		am := domain.ActivityMonth{Month: m}
+		// These fields are required arrays in the public API. A nil Go slice is
+		// encoded as JSON null, which makes otherwise valid commit-only or
+		// creation-only months unsafe for clients to consume as collections.
+		am := domain.ActivityMonth{
+			Month:       m,
+			CommitRepos: make([]domain.ActivityRepo, 0),
+			Created:     make([]domain.ActivityCreated, 0),
+		}
 		for wsID, c := range commits[m] {
 			w := wsByID[wsID]
 			am.CommitTotal += c

--- a/frontend/web/src/activity.ts
+++ b/frontend/web/src/activity.ts
@@ -1,0 +1,62 @@
+import type { ActivityCreated, ActivityMonth, ActivityRepo } from './types';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function activityRepo(value: unknown): ActivityRepo | null {
+  if (
+    !isRecord(value) ||
+    typeof value.name !== 'string' ||
+    typeof value.path !== 'string' ||
+    typeof value.count !== 'number' ||
+    !Number.isFinite(value.count)
+  ) {
+    return null;
+  }
+  return { name: value.name, path: value.path, count: value.count };
+}
+
+function activityCreated(value: unknown): ActivityCreated | null {
+  if (
+    !isRecord(value) ||
+    typeof value.name !== 'string' ||
+    typeof value.path !== 'string' ||
+    typeof value.visibility !== 'string' ||
+    typeof value.date !== 'string'
+  ) {
+    return null;
+  }
+  return {
+    name: value.name,
+    path: value.path,
+    visibility: value.visibility,
+    date: value.date,
+  };
+}
+
+function normalizeItems<T>(value: unknown, normalize: (item: unknown) => T | null): T[] {
+  if (!Array.isArray(value)) return [];
+  return value.map(normalize).filter((item): item is T => item !== null);
+}
+
+function activityMonth(value: unknown): ActivityMonth | null {
+  if (!isRecord(value) || typeof value.month !== 'string') return null;
+  return {
+    month: value.month,
+    commit_total:
+      typeof value.commit_total === 'number' && Number.isFinite(value.commit_total) ? value.commit_total : 0,
+    commit_repos: normalizeItems(value.commit_repos, activityRepo),
+    created: normalizeItems(value.created, activityCreated),
+  };
+}
+
+/**
+ * Normalize the public activity wire response at the API boundary. Older
+ * servers encoded empty Go slices as null; malformed rows must not take down
+ * the entire profile page while a client and server are on different versions.
+ */
+export function normalizeActivityResponse(value: unknown): { months: ActivityMonth[] } {
+  if (!isRecord(value)) return { months: [] };
+  return { months: normalizeItems(value.months, activityMonth) };
+}

--- a/frontend/web/src/api.ts
+++ b/frontend/web/src/api.ts
@@ -5,6 +5,7 @@
 // Exception: exchangeSession only sends the IDP token in the Authorization header once,
 // and the server sets the session cookie in the Set-Cookie response.
 import type { RefLogEntry, User, PublicUser, Workspace, PublicWorkspace, WorkspacePatch, Membership, Invite, Repo, Ref, Snapshot, SessionDoc, MemoryDigest, SettingsUpload, DiffEntry, SearchHit, Pending, Unsync } from './types';
+import { normalizeActivityResponse } from './activity';
 
 // Default is same-origin relative path (/api/v1). Dev uses Vite proxy, prod assumes same-domain deployment.
 // To serve from a different origin, use an absolute URL with VITE_API_BASE, but cookies must be same-site.
@@ -64,10 +65,9 @@ export const api = {
       'GET',
       `/public/users/${encodeURIComponent(username)}/contributions`,
     ),
-  userActivity: (username: string) =>
-    call<{ months: import('./types').ActivityMonth[] }>(
-      'GET',
-      `/public/users/${encodeURIComponent(username)}/activity`,
+  userActivity: async (username: string) =>
+    normalizeActivityResponse(
+      await call<unknown>('GET', `/public/users/${encodeURIComponent(username)}/activity`),
     ),
   listCliTokens: () =>
     call<{ suffix: string; label?: string; created_at: string; expires_at: string }[] | null>('GET', '/me/cli-tokens'),

--- a/frontend/web/src/components/ActivityFeed.tsx
+++ b/frontend/web/src/components/ActivityFeed.tsx
@@ -5,6 +5,7 @@
 import { useQuery } from '@tanstack/react-query';
 import type { ActivityMonth } from '../types';
 import { api } from '../api';
+import { normalizeActivityResponse } from '../activity';
 import { navigate } from '../route';
 import { LockIcon } from './Breadcrumb';
 import { useT } from '../i18n';
@@ -92,7 +93,9 @@ export function ActivityFeed({ username }: { username: string }) {
     queryFn: () => api.userActivity(username),
     retry: false,
   });
-  const months = (q.data?.months ?? []).filter((m) => m.commit_total > 0 || m.created.length > 0);
+  // Normalize again at the render boundary so a pre-fix React Query cache
+  // retained across hot reload cannot crash the profile before it refetches.
+  const months = normalizeActivityResponse(q.data).months.filter((m) => m.commit_total > 0 || m.created.length > 0);
   if (months.length === 0) return null;
 
   return (

--- a/frontend/web/tests/activity.test.ts
+++ b/frontend/web/tests/activity.test.ts
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict';
+import { normalizeActivityResponse } from '../src/activity.ts';
+
+assert.deepEqual(normalizeActivityResponse(null), { months: [] });
+assert.deepEqual(normalizeActivityResponse({ months: null }), { months: [] });
+
+const normalized = normalizeActivityResponse({
+  months: [
+    {
+      month: '2026-08',
+      commit_total: 2,
+      commit_repos: [{ name: 'repo', path: 'alice/repo', count: 2 }],
+      created: null,
+    },
+    {
+      month: '2026-07',
+      commit_total: 0,
+      commit_repos: null,
+      created: [{ name: 'new', path: 'alice/new', visibility: 'private', date: '2026-07-03' }],
+    },
+  ],
+});
+
+assert.deepEqual(normalized.months[0], {
+  month: '2026-08',
+  commit_total: 2,
+  commit_repos: [{ name: 'repo', path: 'alice/repo', count: 2 }],
+  created: [],
+});
+assert.deepEqual(normalized.months[1], {
+  month: '2026-07',
+  commit_total: 0,
+  commit_repos: [],
+  created: [{ name: 'new', path: 'alice/new', visibility: 'private', date: '2026-07-03' }],
+});
+
+assert.deepEqual(
+  normalizeActivityResponse({
+    months: [{ month: '2026-06', commit_total: 'bad', commit_repos: [{}], created: [null] }, null],
+  }),
+  { months: [{ month: '2026-06', commit_total: 0, commit_repos: [], created: [] }] },
+  'malformed activity data is contained at the API boundary',
+);

--- a/schemas/openapi.yaml
+++ b/schemas/openapi.yaml
@@ -2581,11 +2581,13 @@ paths:
             application/json:
               schema:
                 type: object
+                required: [months]
                 properties:
                   months:
                     type: array
                     items:
                       type: object
+                      required: [month, commit_total, commit_repos, created]
                       properties:
                         month: { type: string, description: "YYYY-MM" }
                         commit_total: { type: integer }
@@ -2593,6 +2595,7 @@ paths:
                           type: array
                           items:
                             type: object
+                            required: [name, path, count]
                             properties:
                               name: { type: string }
                               path: { type: string }
@@ -2601,6 +2604,7 @@ paths:
                           type: array
                           items:
                             type: object
+                            required: [name, path, visibility, date]
                             properties:
                               name: { type: string }
                               path: { type: string }


### PR DESCRIPTION
## Summary
- serialize empty activity collections as JSON arrays in the backend
- normalize legacy or malformed activity responses at the frontend API and render boundaries
- make the non-null array contract explicit in OpenAPI

## Regression coverage
- commit-only and creation-only activity months
- legacy null nested collections and malformed rows
- backend test/vet, PostgreSQL-tag tests, frontend unit/type/i18n/build, public preflight