### PR TITLE
Fix oversized off-mainline context rows

### DIFF
--- a/frontend/web/src/components/ContextView.tsx
+++ b/frontend/web/src/components/ContextView.tsx
@@ -261,7 +261,7 @@ export function ContextView({ repo, ws, role }: { repo: Repo; ws: ContextWorkspa
         {pagedCommits.visible.map((s) => (
           <li key={s.id}>
             <button
-              className={`commit-row${s.id === snapId ? ' on' : ''}${mainline.has(s.id) ? '' : ' side'}`}
+              className={`commit-row${s.id === snapId ? ' on' : ''}${mainline.has(s.id) ? '' : ' off-mainline'}`}
               onClick={() => setSnapId(s.id)}
             >
               <code>{short(s.id)}</code>

--- a/frontend/web/src/components/Dashboard.tsx
+++ b/frontend/web/src/components/Dashboard.tsx
@@ -150,7 +150,7 @@ export function Dashboard() {
       </header>
 
       <div className="cols">
-        <aside className="side">
+        <aside className="app-side">
           <div className="side-head">
             <span className="label">{t('common.workspaces')}</span>
             <span className="count-badge">{workspaces.length}</span>

--- a/frontend/web/src/styles.css
+++ b/frontend/web/src/styles.css
@@ -111,7 +111,7 @@ button.ghost:hover { color: var(--ink); opacity: 1; }
 .cols { display: grid; grid-template-columns: 240px 1fr; flex: 1; min-height: 0; }
 
 /* Sidebar — Sticky, remains in place (topbar 52px below viewport height). */
-.side { border-right: 1px solid var(--line); padding: 28px 20px; display: flex; flex-direction: column; gap: 16px; min-height: 0; overflow: hidden;
+.app-side { border-right: 1px solid var(--line); padding: 28px 20px; display: flex; flex-direction: column; gap: 16px; min-height: 0; overflow: hidden;
   position: sticky; top: 52px; height: calc(100vh - 52px); align-self: start; }
 .side-head { display: flex; align-items: baseline; justify-content: space-between; padding: 0 8px; }
 .count-badge { font-family: var(--mono); font-size: 0.7rem; color: var(--faint); }
@@ -254,7 +254,7 @@ button.copy.done { color: var(--ok); border-color: var(--ok); }
 /* Mobile: Replaces app shell (fixed height + internal scroll) with page scroll (stack layout). */
   .app { height: auto; min-height: 100vh; }
   .cols { grid-template-columns: 1fr; }
-  .side { border-right: 0; border-bottom: 1px solid var(--line); padding: 20px; overflow: visible; }
+  .app-side { border-right: 0; border-bottom: 1px solid var(--line); padding: 20px; overflow: visible; }
   .ws-list { flex: initial; min-height: 0; overflow-y: visible; }
   .newws { margin-top: 4px; }
   .main { padding: 28px 20px 48px; overflow-y: visible; }
@@ -809,8 +809,8 @@ button.copy.done { color: var(--ok); border-color: var(--ok); }
 .commit-row.dismissed .commit-msg { flex: 1; }
 
 /* merge lineage — commits outside the mainline (first-parent). Graph opacity 0.6, list light. */
-.commit-row.side { opacity: 0.66; }
-.commit-row.side:hover, .commit-row.side.on { opacity: 1; }
+.commit-row.off-mainline { opacity: 0.66; }
+.commit-row.off-mainline:hover, .commit-row.off-mainline.on { opacity: 1; }
 
 /* compressed memory box — collapsible (default closed). ◆ badge with the same purple series label. */
 details.memory-box > summary { cursor: pointer; color: #8957e5; list-style: revert; }

--- a/frontend/web/tests/style-scope.test.ts
+++ b/frontend/web/tests/style-scope.test.ts
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const source = (path: string) => readFileSync(resolve(process.cwd(), path), 'utf8');
+const styles = source('src/styles.css');
+const contextView = source('src/components/ContextView.tsx');
+const dashboard = source('src/components/Dashboard.tsx');
+
+assert.doesNotMatch(
+  styles,
+  /(^|\n)\.side(?=[\s,{])/,
+  'generic .side layout selectors can collide with row state classes',
+);
+assert.match(styles, /\.app-side\s*\{[^}]*height:\s*calc\(100vh - 52px\)/s);
+assert.match(dashboard, /<aside className="app-side">/);
+
+assert.match(contextView, /' off-mainline'/);
+assert.match(styles, /\.commit-row\.off-mainline\s*\{/);
+assert.doesNotMatch(contextView, /' side'/, 'off-mainline rows must not inherit the app sidebar layout');


### PR DESCRIPTION
## Summary
- separate the app sidebar layout class from the off-mainline row state
- rename the sidebar class to app-side and the row state to off-mainline
- add a source-level regression test that rejects a generic .side layout selector

## Root cause
A context row with class commit-row side inherited the app sidebar height, sticky positioning, overflow, and column layout. Each joined row therefore reserved almost one viewport of blank space.

## Verification
- frontend unit tests
- TypeScript typecheck
- i18n parity
- production build
- Vite-served module assertions
- public tree and secret preflight