### PR TITLE
Remove impossible server load endpoint

### DIFF
--- a/backend/internal/adapters/delivery/http/server.go
+++ b/backend/internal/adapters/delivery/http/server.go
@@ -204,10 +204,10 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("POST /api/v1/repos/{repoID}/pull/chunks", s.guard(domain.RolePuller, s.pullChunks))
 	mux.HandleFunc("POST /api/v1/repos/{repoID}/pull/objects", s.guard(domain.RolePuller, s.pullObjects))
 
-	// Actions (for web UI). Diff is read operation (viewer), Fork is write operation (member). Load is local CLI exclusive (501 error).
+	// Actions exposed by the server. Provider-session restoration remains a local
+	// CLI operation and is deliberately absent from the HTTP surface.
 	mux.HandleFunc("POST /api/v1/repos/{repoID}/diff", s.guard(domain.RoleViewer, s.diff))
 	mux.HandleFunc("POST /api/v1/repos/{repoID}/fork", s.guard(domain.RoleMember, s.fork))
-	mux.HandleFunc("POST /api/v1/repos/{repoID}/load", s.notImplemented)
 
 	// Authentication · Workspace · Invite (all Firebase/dev tokens required — requireUser middleware).
 	s.registerIdentity(mux)
@@ -1222,10 +1222,6 @@ func (s *Server) writeError(w http.ResponseWriter, status int, code, msg string)
 	_ = json.NewEncoder(w).Encode(map[string]any{
 		"error": map[string]any{"code": code, "message": msg, "details": map[string]any{}},
 	})
-}
-
-func (s *Server) notImplemented(w http.ResponseWriter, _ *http.Request) {
-	s.writeError(w, http.StatusNotImplemented, "not_implemented", "endpoint not implemented in this slice")
 }
 
 func unsafeMethod(method string) bool {

--- a/backend/internal/adapters/delivery/http/server_test.go
+++ b/backend/internal/adapters/delivery/http/server_test.go
@@ -951,6 +951,51 @@ func TestContentTypeGuard(t *testing.T) {
 	}
 }
 
+func TestServerDoesNotExposeLocalLoad(t *testing.T) {
+	ts := newTestServer(t)
+	defer ts.Close()
+
+	for _, token := range []string{"", "dev:load@t.io:Load"} {
+		req, err := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/repos/repo-1/load", strings.NewReader(`{}`))
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		if token != "" {
+			req.Header.Set("Authorization", "Bearer "+token)
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var body bytes.Buffer
+		_, _ = body.ReadFrom(resp.Body)
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("token %q status = %d, want 404", token, resp.StatusCode)
+		}
+		if strings.Contains(body.String(), "not_implemented") {
+			t.Fatalf("removed load capability still advertised: %s", body.String())
+		}
+	}
+
+	// The route is absent, but cookie-authenticated unsafe requests still pass
+	// through the global CSRF boundary before mux dispatch.
+	req, err := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/repos/repo-1/load", strings.NewReader(`{}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.AddCookie(&http.Cookie{Name: sessionCookie, Value: "removed-load-session"})
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("cookie-authenticated removed load route status = %d, want 403", resp.StatusCode)
+	}
+}
+
 func TestRateLimitDoesNotCountRejectedRequests(t *testing.T) {
 	s := &Server{}
 	accepted := 0

--- a/schemas/openapi.yaml
+++ b/schemas/openapi.yaml
@@ -1895,21 +1895,6 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
 
-  /repos/{repoID}/load:
-    parameters:
-      - $ref: "#/components/parameters/repoID"
-    post:
-      operationId: loadSession
-      summary: (Unavailable) Session loading is local-CLI only — always returns 501
-      description: |
-        Session loading (file materialization and memory injection) is a local filesystem
-        operation and is not performed by the server. This informational endpoint always
-        returns 501; use `cxt load <ref>`. (Audit 2026-07-09: corrected a drift where the
-        specification documented behavior that the server did not implement.)
-      tags: [actions]
-      responses:
-        "501":
-          description: "not implemented — use the local cxt load command"
   /hooks/github:
     post:
       operationId: githubWebhook


### PR DESCRIPTION
## Summary

- remove the permanently failing `POST /repos/{repoID}/load` route from cxtd
- remove the phantom operation from OpenAPI and the now-unused generic 501 handler
- keep provider-session restoration exclusively in local `cxt load` and `cxt checkout`
- add a regression test proving anonymous and bearer requests receive 404 while cookie-authenticated unsafe requests still pass through the global CSRF boundary

## Verification

- backend builds for filesystem and PostgreSQL tags
- backend vet for both build modes
- backend full tests and OpenAPI bidirectional drift guard
- `make e2e`
- `make e2e-sync`
- `scripts/public-preflight.sh tree`

Closes #124
