### PR TITLE
Clarify fsck unreachable snapshot reporting

### DIFF
--- a/backend/internal/app/service.go
+++ b/backend/internal/app/service.go
@@ -962,7 +962,7 @@ func (s *Service) snapshotBranchMemberships(ctx context.Context, repoID domain.C
 	return members, nil
 }
 
-// Fsck: reference reachability audit (read-only, git fsck equivalent). Creates a reachability set by following parents from all refs and reports dangling snapshots, missing parent references (corruption), and parentless roots. Does not fix anything — parentless roots are treated as normal roots (not artificially attaching parents).
+// Fsck: reference reachability audit (read-only, git fsck equivalent). Creates a reachability set by following parents from all refs and pending sessions, then reports unreferenced snapshots, missing parent references (corruption), and parentless roots. Unreferenced snapshots remain stored and are not necessarily corrupt. Does not fix anything — parentless roots are treated as normal roots (not artificially attaching parents).
 func (s *Service) Fsck(ctx context.Context, repoID domain.ContentHash) (inbound.FsckReport, error) {
 	if err := domain.ValidateContentHash(repoID); err != nil {
 		return inbound.FsckReport{}, err

--- a/backend/internal/ports/inbound/inbound.go
+++ b/backend/internal/ports/inbound/inbound.go
@@ -351,6 +351,6 @@ type FsckReport struct {
 	Total           int                  `json:"total"`            // Total number of snapshots
 	Reachable       int                  `json:"reachable"`        // Number of snapshots reachable from any ref
 	Roots           []domain.ContentHash `json:"roots"`            // Snapshots without parents (normal roots)
-	Unreachable     []domain.ContentHash `json:"unreachable"`      // Snapshots that cannot be reached (dangling/lost)
+	Unreachable     []domain.ContentHash `json:"unreachable"`      // Stored snapshots not reachable from current refs or pending sessions
 	DanglingParents []DanglingParent     `json:"dangling_parents"` // Non-existent parent references (corrupted)
 }

--- a/cli/internal/adapters/delivery/cli/root.go
+++ b/cli/internal/adapters/delivery/cli/root.go
@@ -376,7 +376,9 @@ func Run(c *Container, args []string) error {
 		return nil
 
 	case "fsck":
-		// Reference reachability audit (read-only): The server calculates the reachability set for all refs and reports orphans, missing parents, and roots. No changes are made.
+		// Reference reachability audit (read-only): The server calculates the
+		// reachability set for all refs and pending sessions, then reports
+		// unreferenced snapshots, missing parents, and roots. No changes are made.
 		if err := requireRemote(cwd); err != nil {
 			return err
 		}
@@ -390,17 +392,7 @@ func Run(c *Container, args []string) error {
 		if ferr != nil {
 			return ferr
 		}
-		fmt.Printf("Snapshots %d · Reach %d · Roots %d · Orphans %d · Missing %d\n",
-			rep.Total, rep.Reachable, len(rep.Roots), len(rep.Unreachable), len(rep.DanglingParents))
-		for _, u := range rep.Unreachable {
-			fmt.Printf("  orphan (unreachable): %s\n", u)
-		}
-		for _, d := range rep.DanglingParents {
-			fmt.Printf("  corrupt (missing parent): %s → %s\n", d.Snapshot, d.Missing)
-		}
-		if len(rep.Unreachable) == 0 && len(rep.DanglingParents) == 0 {
-			fmt.Println("  ✓ No issues — all snapshots are reachable from refs")
-		}
+		fmt.Print(formatFsckReport(rep))
 		return nil
 
 	case "reflog":
@@ -840,6 +832,34 @@ func Run(c *Container, args []string) error {
 	default:
 		return unknownCommandError(cmd)
 	}
+}
+
+// formatFsckReport deliberately distinguishes reachability from integrity.
+// An unreachable object is still stored and may be a superseded capture or
+// intentionally detached history. A missing parent is the structural
+// corruption class that fsck must call out as an error.
+func formatFsckReport(rep backendclient.FsckReport) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "Snapshots %d · Reach %d · Roots %d · Unreachable %d · Missing %d\n",
+		rep.Total, rep.Reachable, len(rep.Roots), len(rep.Unreachable), len(rep.DanglingParents))
+	for _, u := range rep.Unreachable {
+		fmt.Fprintf(&b, "  unreachable (unreferenced): %s\n", u)
+	}
+	for _, d := range rep.DanglingParents {
+		fmt.Fprintf(&b, "  corrupt (missing parent): %s → %s\n", d.Snapshot, d.Missing)
+	}
+
+	if len(rep.Unreachable) == 0 && len(rep.DanglingParents) == 0 {
+		fmt.Fprintln(&b, "  ✓ No issues — all snapshots are referenced and no parents are missing")
+		return b.String()
+	}
+	if len(rep.Unreachable) > 0 {
+		fmt.Fprintln(&b, "  note: unreachable snapshots are preserved; they may be superseded captures or intentionally detached history")
+	}
+	if len(rep.DanglingParents) == 0 {
+		fmt.Fprintln(&b, "  ✓ No missing-parent corruption")
+	}
+	return b.String()
 }
 
 // requireRemote checks if the destination is set before push/pull.

--- a/cli/internal/adapters/delivery/cli/root_fsck_test.go
+++ b/cli/internal/adapters/delivery/cli/root_fsck_test.go
@@ -1,0 +1,59 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/wnsdy95/cxthub/cli/internal/adapters/backendclient"
+)
+
+func TestFormatFsckReportDoesNotMislabelUnreachableSnapshotsAsLost(t *testing.T) {
+	rep := backendclient.FsckReport{
+		Total:       4,
+		Reachable:   2,
+		Roots:       []string{"root"},
+		Unreachable: []string{"superseded-capture"},
+	}
+
+	got := formatFsckReport(rep)
+	for _, want := range []string{
+		"Snapshots 4 · Reach 2 · Roots 1 · Unreachable 1 · Missing 0",
+		"unreachable (unreferenced): superseded-capture",
+		"unreachable snapshots are preserved",
+		"No missing-parent corruption",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("fsck output missing %q:\n%s", want, got)
+		}
+	}
+	for _, misleading := range []string{"Orphans", "orphan (", "lost"} {
+		if strings.Contains(got, misleading) {
+			t.Fatalf("fsck output retained misleading label %q:\n%s", misleading, got)
+		}
+	}
+}
+
+func TestFormatFsckReportKeepsMissingParentsExplicitlyCorrupt(t *testing.T) {
+	rep := backendclient.FsckReport{Total: 2, Reachable: 1}
+	rep.DanglingParents = append(rep.DanglingParents, struct {
+		Snapshot string `json:"snapshot"`
+		Missing  string `json:"missing"`
+	}{Snapshot: "child", Missing: "absent-parent"})
+
+	got := formatFsckReport(rep)
+	if !strings.Contains(got, "corrupt (missing parent): child → absent-parent") {
+		t.Fatalf("fsck output did not preserve corruption warning:\n%s", got)
+	}
+	if strings.Contains(got, "No missing-parent corruption") {
+		t.Fatalf("fsck output contradicted missing parent:\n%s", got)
+	}
+}
+
+func TestFormatFsckReportCleanRepository(t *testing.T) {
+	got := formatFsckReport(backendclient.FsckReport{Total: 3, Reachable: 3})
+	want := "Snapshots 3 · Reach 3 · Roots 0 · Unreachable 0 · Missing 0\n" +
+		"  ✓ No issues — all snapshots are referenced and no parents are missing\n"
+	if got != want {
+		t.Fatalf("clean fsck output:\n%s\nwant:\n%s", got, want)
+	}
+}

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -602,7 +602,10 @@ cxt fsck
 ```
 
 Runs a read-only server audit for reachability, roots, unreachable snapshots,
-and missing parents. Requires a configured remote.
+and missing parents. An unreachable snapshot remains stored but is not
+referenced by a current ref or pending session; this can include superseded
+captures or intentionally detached history. A missing parent is the structural
+integrity error. Requires a configured remote.
 
 ### `cxt reflog`
 

--- a/schemas/openapi.yaml
+++ b/schemas/openapi.yaml
@@ -805,7 +805,7 @@ paths:
     get:
       operationId: fsck
       summary: Reference reachability audit (read-only, git fsck response)
-      description: "Calculates the reachability set of parents from all refs, reporting unreachable (dangling) references, non-existent parent references (corruption), and parentless roots. Does not modify anything; parentless roots are treated as normal roots."
+      description: "Calculates parent reachability from all refs and pending sessions. Reports stored snapshots not referenced by those current roots, non-existent parent references (corruption), and parentless roots. Unreachable snapshots remain stored and may be superseded captures or intentionally detached history. Does not modify anything; parentless roots are normal roots."
       tags: [repos]
       responses:
         "200":


### PR DESCRIPTION
Closes #127.

Separates reachability from integrity in cxt fsck output. Stored snapshots outside current refs and pending sessions are reported neutrally as Unreachable, while missing parent references remain explicitly corrupt. The API field remains unchanged and no data is deleted, grafted, or rewritten.

Validation:
- CLI full test, vet, and race
- Backend full test, PostgreSQL-tag test, vet, and race
- OpenAPI drift tests
- Public preflight
- Live read-only fsck against dogfood data