### PR TITLE
Align local daemon auth with Firebase web config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
           cache: false
       - name: Validate the publishable tree
         run: bash scripts/public-preflight.sh tree
+      - name: Verify local dogfood auth resolution
+        run: bash scripts/test-dogfood-daemon.sh
       - name: Validate the complete public history
         if: github.event.repository.private == false
         run: bash scripts/public-preflight.sh full

--- a/frontend/web/.env.example
+++ b/frontend/web/.env.example
@@ -11,8 +11,9 @@
 
 # Firebase configuration. Leave these values empty for development mode, which accepts an
 # email address and uses a dev:<email> token compatible with a local cxtd running with auth=dev.
-# Set them to enable Firebase Email/Password and Google sign-in. Start the backend with
-# CXT_AUTH=firebase and CXT_FIREBASE_PROJECT configured.
+# Set them to enable Firebase Email/Password and Google sign-in. The macOS
+# dogfood-daemon install/restart commands automatically align cxtd with this project;
+# other backend launch methods need CXT_AUTH=firebase and CXT_FIREBASE_PROJECT.
 VITE_FIREBASE_API_KEY=
 VITE_FIREBASE_AUTH_DOMAIN=
 VITE_FIREBASE_PROJECT_ID=

--- a/scripts/dogfood-daemon.sh
+++ b/scripts/dogfood-daemon.sh
@@ -4,12 +4,14 @@
 #
 #   scripts/dogfood-daemon.sh install    # create and load the plist
 #   scripts/dogfood-daemon.sh uninstall  # unload and remove the plist
-#   scripts/dogfood-daemon.sh restart    # restart with the newly installed binary
+#   scripts/dogfood-daemon.sh restart    # rewrite config and restart with the installed binary
 #   scripts/dogfood-daemon.sh status     # show status and recent logs
 #   scripts/dogfood-daemon.sh logs       # tail logs
+#   scripts/dogfood-daemon.sh config     # print resolved auth without changing anything
 #
-# Defaults to development authentication on 127.0.0.1:8907. To use Firebase,
-# set both CXT_AUTH=firebase and CXT_FIREBASE_PROJECT=<project-id> before install.
+# When CXT_AUTH is not explicit, the daemon follows the effective
+# VITE_FIREBASE_PROJECT_ID from frontend/web's development env files. A fresh
+# checkout with no Firebase config still defaults to local dev authentication.
 set -euo pipefail
 
 LABEL="com.cxthub.cxtd"
@@ -17,25 +19,79 @@ PLIST="$HOME/Library/LaunchAgents/$LABEL.plist"
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 BIN="$(command -v cxtd || echo "$HOME/go/bin/cxtd")"
 ADDR="${CXT_ADDR:-127.0.0.1:8907}"
-AUTH="${CXT_AUTH:-dev}"
-FIREBASE="${CXT_FIREBASE_PROJECT:-}"
 DATA="$ROOT/cxt-data"
 LOGDIR="$ROOT/.cxt-daemon"
 GUI="gui/$(id -u)"
 
-case "$AUTH" in
-  dev) ;;
-  firebase)
-    if [[ ! "$FIREBASE" =~ ^[a-z][a-z0-9-]{4,28}[a-z0-9]$ ]]; then
-      echo "CXT_FIREBASE_PROJECT must be a valid Firebase project ID when CXT_AUTH=firebase." >&2
-      exit 2
-    fi
-    ;;
-  *)
-    echo "CXT_AUTH must be dev or firebase." >&2
-    exit 2
-    ;;
-esac
+vite_env_value() {
+  local key="$1"
+  local file line value found=""
+  if [[ -n "${!key+x}" ]]; then
+    printf '%s' "${!key}"
+    return
+  fi
+  for file in \
+    "$ROOT/frontend/web/.env" \
+    "$ROOT/frontend/web/.env.local" \
+    "$ROOT/frontend/web/.env.development" \
+    "$ROOT/frontend/web/.env.development.local"; do
+    [[ -f "$file" ]] || continue
+    while IFS= read -r line || [[ -n "$line" ]]; do
+      line="${line%$'\r'}"
+      if [[ "$line" =~ ^[[:space:]]*(export[[:space:]]+)?${key}[[:space:]]*=[[:space:]]*(.*)$ ]]; then
+        value="${BASH_REMATCH[2]}"
+        value="${value%%#*}"
+        value="${value#"${value%%[![:space:]]*}"}"
+        value="${value%"${value##*[![:space:]]}"}"
+        if [[ ${#value} -ge 2 ]] && {
+          [[ "$value" == \"*\" ]] || [[ "$value" == \'*\' ]];
+        }; then
+          value="${value:1:${#value}-2}"
+        fi
+        found="$value"
+      fi
+    done < "$file"
+  done
+  printf '%s' "$found"
+}
+
+WEB_FIREBASE_API_KEY="$(vite_env_value VITE_FIREBASE_API_KEY)"
+WEB_FIREBASE_PROJECT="$(vite_env_value VITE_FIREBASE_PROJECT_ID)"
+if [[ -n "${CXT_AUTH+x}" ]]; then
+  AUTH="$CXT_AUTH"
+  AUTH_SOURCE="CXT_AUTH"
+elif [[ -n "${CXT_FIREBASE_PROJECT:-}" ]]; then
+  AUTH="firebase"
+  AUTH_SOURCE="CXT_FIREBASE_PROJECT"
+elif [[ -n "$WEB_FIREBASE_API_KEY" ]]; then
+  AUTH="firebase"
+  AUTH_SOURCE="Vite development env"
+else
+  AUTH="dev"
+  AUTH_SOURCE="default"
+fi
+
+if [[ "$AUTH" == "firebase" ]]; then
+  FIREBASE="${CXT_FIREBASE_PROJECT:-$WEB_FIREBASE_PROJECT}"
+else
+  FIREBASE=""
+fi
+
+validate_auth() {
+  case "$AUTH" in
+    dev) ;;
+    firebase)
+      if [[ ! "$FIREBASE" =~ ^[a-z][a-z0-9-]{4,28}[a-z0-9]$ ]]; then
+        echo "CXT_FIREBASE_PROJECT must be a valid Firebase project ID when CXT_AUTH=firebase." >&2
+        return 2
+      fi
+      ;;
+    *)
+      echo "CXT_AUTH must be dev or firebase." >&2
+      return 2
+      ;;
+  esac
+}
 
 write_plist() {
   mkdir -p "$LOGDIR" "$(dirname "$PLIST")"
@@ -68,19 +124,32 @@ write_plist() {
 PLIST
 }
 
+reload_plist() {
+  launchctl bootout "$GUI" "$PLIST" 2>/dev/null || true
+  launchctl bootstrap "$GUI" "$PLIST"
+  launchctl enable "$GUI/$LABEL"
+}
+
+auth_label() {
+  if [[ "$AUTH" == "firebase" ]]; then
+    printf 'firebase:%s' "$FIREBASE"
+  else
+    printf 'dev'
+  fi
+}
+
 case "${1:-}" in
   install)
+    validate_auth
     # Stop an existing shell-background cxtd process if it owns the port.
     pkill -x cxtd 2>/dev/null || true
     sleep 1
     write_plist
-    launchctl bootout "$GUI" "$PLIST" 2>/dev/null || true
-    launchctl bootstrap "$GUI" "$PLIST"
-    launchctl enable "$GUI/$LABEL"
+    reload_plist
     echo "✓ installed and started: $LABEL"
     echo "  binary: $BIN"
     echo "  address: http://$ADDR  data: $DATA"
-    echo "  auth: $AUTH"
+    echo "  auth: $(auth_label) ($AUTH_SOURCE)"
     echo "  logs: $LOGDIR/cxtd.{out,err}.log"
     ;;
   uninstall)
@@ -89,8 +158,11 @@ case "${1:-}" in
     echo "✓ unloaded and removed: $LABEL"
     ;;
   restart)
-    launchctl kickstart -k "$GUI/$LABEL"
-    echo "✓ restarted with the newly installed binary: $LABEL"
+    validate_auth
+    write_plist
+    reload_plist
+    echo "✓ rewrote config and restarted: $LABEL"
+    echo "  auth: $(auth_label) ($AUTH_SOURCE)"
     ;;
   status)
     if launchctl print "$GUI/$LABEL" >/dev/null 2>&1; then
@@ -104,6 +176,12 @@ case "${1:-}" in
   logs)
     tail -n 40 -F "$LOGDIR/cxtd.err.log" "$LOGDIR/cxtd.out.log"
     ;;
+  config)
+    validate_auth
+    echo "auth=$AUTH"
+    echo "firebase_project=$FIREBASE"
+    echo "source=$AUTH_SOURCE"
+    ;;
   *)
-    echo "Usage: $0 {install|uninstall|restart|status|logs}"; exit 1 ;;
+    echo "Usage: $0 {install|uninstall|restart|status|logs|config}"; exit 1 ;;
 esac

--- a/scripts/test-dogfood-daemon.sh
+++ b/scripts/test-dogfood-daemon.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+mkdir -p "$TMP/repo/scripts" "$TMP/repo/frontend/web" "$TMP/home"
+cp "$ROOT/scripts/dogfood-daemon.sh" "$TMP/repo/scripts/dogfood-daemon.sh"
+
+run_config() {
+  env -u CXT_AUTH -u CXT_FIREBASE_PROJECT HOME="$TMP/home" \
+    bash "$TMP/repo/scripts/dogfood-daemon.sh" config
+}
+
+assert_line() {
+  local output="$1" expected="$2"
+  if ! grep -Fxq "$expected" <<<"$output"; then
+    echo "missing '$expected' in:" >&2
+    echo "$output" >&2
+    exit 1
+  fi
+}
+
+out="$(run_config)"
+assert_line "$out" "auth=dev"
+assert_line "$out" "firebase_project="
+assert_line "$out" "source=default"
+
+printf 'VITE_FIREBASE_API_KEY=local-key\n' > "$TMP/repo/frontend/web/.env"
+if run_config >/dev/null 2>&1; then
+  echo "partial Firebase web config unexpectedly succeeded" >&2
+  exit 1
+fi
+
+printf 'VITE_FIREBASE_PROJECT_ID=from-base-1\n' > "$TMP/repo/frontend/web/.env"
+out="$(run_config)"
+assert_line "$out" "auth=dev"
+assert_line "$out" "firebase_project="
+
+printf 'VITE_FIREBASE_API_KEY=local-key\nVITE_FIREBASE_PROJECT_ID=from-base-1\n' > "$TMP/repo/frontend/web/.env"
+out="$(run_config)"
+assert_line "$out" "auth=firebase"
+assert_line "$out" "firebase_project=from-base-1"
+assert_line "$out" "source=Vite development env"
+
+printf 'export VITE_FIREBASE_PROJECT_ID="from-local-2" # local override\r\n' > "$TMP/repo/frontend/web/.env.development.local"
+out="$(run_config)"
+assert_line "$out" "firebase_project=from-local-2"
+
+out="$(VITE_FIREBASE_API_KEY=process-key VITE_FIREBASE_PROJECT_ID=from-process-3 \
+  run_config)"
+assert_line "$out" "auth=firebase"
+assert_line "$out" "firebase_project=from-process-3"
+
+out="$(CXT_AUTH=dev HOME="$TMP/home" bash "$TMP/repo/scripts/dogfood-daemon.sh" config)"
+assert_line "$out" "auth=dev"
+assert_line "$out" "firebase_project="
+assert_line "$out" "source=CXT_AUTH"
+
+out="$(CXT_AUTH=firebase CXT_FIREBASE_PROJECT=explicit-project-3 HOME="$TMP/home" \
+  bash "$TMP/repo/scripts/dogfood-daemon.sh" config)"
+assert_line "$out" "auth=firebase"
+assert_line "$out" "firebase_project=explicit-project-3"
+assert_line "$out" "source=CXT_AUTH"
+
+if CXT_AUTH=firebase CXT_FIREBASE_PROJECT=bad HOME="$TMP/home" \
+  bash "$TMP/repo/scripts/dogfood-daemon.sh" config >/dev/null 2>&1; then
+  echo "invalid Firebase project unexpectedly succeeded" >&2
+  exit 1
+fi
+
+echo "dogfood daemon auth resolution: passed"


### PR DESCRIPTION
## Summary
- resolve the effective Vite Firebase configuration without sourcing env files
- default the macOS dogfood daemon to the same Firebase project as the local web
- preserve explicit CXT_AUTH and CXT_FIREBASE_PROJECT precedence
- rewrite the LaunchAgent configuration during restart so changed auth actually applies
- add a read-only config command and Linux-safe CI regression matrix

## Root cause
The web loaded Firebase and produced a valid Firebase ID token, while cxtd was silently installed with auth=dev and rejected that token at POST /api/v1/auth/session with 401.

## Verification
- bash scripts/test-dogfood-daemon.sh
- bash scripts/public-preflight.sh tree
- make test
- real macOS restart resolved firebase:cxthub-9fb16
- backend health 200
- Chrome Firebase login completed; signed-in header visible and no new console errors

Closes #131