### PR TITLE
Move role capabilities into Members

### DIFF
--- a/frontend/web/e2e/ui-regressions.spec.ts
+++ b/frontend/web/e2e/ui-regressions.spec.ts
@@ -170,7 +170,7 @@ test('pricing publishes the storage-only contract and calculates GitHub-aligned 
   expect(unexpected).toEqual([]);
 });
 
-test('workspace settings show the cumulative role matrix above permission overrides', async ({ page }) => {
+test('members page orders invites, role capabilities, and members without page overflow', async ({ page }) => {
   await page.setViewportSize({ width: 390, height: 844 });
   const pageErrors = capturePageErrors(page);
   const unexpected = await installApiFixture(page, ({ method, pathname, searchParams }) => {
@@ -201,12 +201,22 @@ test('workspace settings show the cumulative role matrix above permission overri
         }],
       };
     }
-    if (pathname === `/api/v1/workspaces/${workspaceId}/members`) return { body: [] };
+    if (pathname === `/api/v1/workspaces/${workspaceId}/members`) {
+      return {
+        body: [{
+          workspace_id: workspaceId,
+          user_id: 'user-1',
+          role: 'owner',
+          user: { id: 'user-1', name: 'Alice', nickname: 'Alice', email: 'alice@example.test' },
+        }],
+      };
+    }
+    if (pathname === `/api/v1/workspaces/${workspaceId}/invites`) return { body: [] };
     if (pathname === '/api/v1/repos' && searchParams.get('workspace') === workspaceId) return { body: [] };
     return undefined;
   });
 
-  await page.goto('/alice/cxthub/settings');
+  await page.goto('/alice/cxthub/members');
   const matrix = page.locator('.role-capabilities');
   await expect(matrix).toBeVisible();
   await expect(matrix.locator('thead code')).toHaveText(['viewer', 'puller', 'member', 'maintainer', 'owner']);
@@ -214,13 +224,16 @@ test('workspace settings show the cumulative role matrix above permission overri
   await expect(matrix.locator('td.allowed')).toHaveCount(15);
   await expect(matrix.locator('td.denied')).toHaveCount(10);
 
-  const matrixBeforeControls = await page.locator('.ws-settings-form').evaluate((form) => {
-    const capability = form.querySelector('.role-capabilities');
-    const controls = form.querySelector('.permission-controls');
-    if (!capability || !controls) return false;
-    return Boolean(capability.compareDocumentPosition(controls) & Node.DOCUMENT_POSITION_FOLLOWING);
+  const correctSectionOrder = await page.locator('main.main').evaluate((main) => {
+    const invites = main.querySelector('.invite-panel');
+    const capabilities = main.querySelector('.role-capabilities');
+    const members = main.querySelector('.members-panel');
+    if (!invites || !capabilities || !members) return false;
+    const follows = Node.DOCUMENT_POSITION_FOLLOWING;
+    return Boolean(invites.compareDocumentPosition(capabilities) & follows)
+      && Boolean(capabilities.compareDocumentPosition(members) & follows);
   });
-  expect(matrixBeforeControls).toBe(true);
+  expect(correctSectionOrder).toBe(true);
 
   const overflow = await matrix.locator('.role-capabilities-scroll').evaluate((element) => ({
     client: element.clientWidth,
@@ -228,6 +241,10 @@ test('workspace settings show the cumulative role matrix above permission overri
   }));
   expect(overflow.scroll).toBeGreaterThan(overflow.client);
   expect(await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth)).toBe(true);
+
+  await page.goto('/alice/cxthub/settings');
+  await expect(page.locator('.permission-controls')).toBeVisible();
+  await expect(page.locator('.role-capabilities')).toHaveCount(0);
   expect(pageErrors).toEqual([]);
   expect(unexpected).toEqual([]);
 });

--- a/frontend/web/src/components/Dashboard.tsx
+++ b/frontend/web/src/components/Dashboard.tsx
@@ -23,6 +23,7 @@ import { Breadcrumb } from './Breadcrumb';
 import { ContextView } from './ContextView';
 import { OnHoldView } from './OnHoldView';
 import { AccountSettings, WorkspaceSettings } from './Settings';
+import { RoleCapabilities } from './RoleCapabilities';
 import { LockIcon } from './Breadcrumb';
 import { myRole, atLeast, ROLES } from '../roles';
 import { gitWebUrl, sanitizeRemoteUrl } from '../urls';
@@ -233,7 +234,11 @@ export function Dashboard() {
 
               {tab === 'members' ? (
                 <>
-                  <section className="panel">
+                  {atLeast(role, 'maintainer') && <InvitePanel key={selected.id} wsId={selected.id} />}
+
+                  <RoleCapabilities />
+
+                  <section className="panel members-panel">
                     <div className="panel-head">
                       <h4>
                         {t('dashboard.members')} <span className="count-badge">{members.length}</span>
@@ -287,7 +292,6 @@ export function Dashboard() {
                     )}
                   </section>
 
-                  {atLeast(role, 'maintainer') && <InvitePanel key={selected.id} wsId={selected.id} />}
                 </>
               ) : tab === 'context' ? (
                 <section className="panel">
@@ -441,7 +445,7 @@ function InvitePanel({ wsId }: { wsId: string }) {
   }
 
   return (
-    <section className="panel">
+    <section className="panel invite-panel">
       <div className="panel-head">
         <h4>
           {t('dashboard.invites')} <span className="count-badge">{list.length}</span>

--- a/frontend/web/src/components/Settings.tsx
+++ b/frontend/web/src/components/Settings.tsx
@@ -26,7 +26,6 @@ import { Portal } from './Portal';
 import { useT, Rich } from '../i18n';
 import { safeAvatarUrl } from '../urls';
 import { projectBranchRefs } from '../branchLifecycle';
-import { RoleCapabilities } from './RoleCapabilities';
 
 // resizeToDataURL reduces uploaded images to a 256px square JPEG data URL (center crop).
 // Stores the record as is, keeping it small (server limit ~700KB).
@@ -611,8 +610,6 @@ export function WorkspaceSettings({ ws, isCreator }: { ws: Workspace; isCreator:
                   {syncNow.error && <p className="err">{syncNow.error.message}</p>}
                 </div>
               )}
-
-              <RoleCapabilities />
 
               <div className="settings-upload permission-controls">
                 <span className="label">{t('settings.permissions')}</span>

--- a/frontend/web/src/i18n/locales/en.ts
+++ b/frontend/web/src/i18n/locales/en.ts
@@ -371,7 +371,7 @@ export const en: Messages = {
     permissionsHint: 'Per-action scope (enforced on web & CLI). On the role ladder, writing team assets needs maintainer+; this policy can narrow it to Owner only. Adjust per-user via role changes in the Members tab.',
     roleCapabilitiesTitle: 'Role capabilities',
     roleLadder: 'Cumulative from lower to higher access',
-    roleCapabilitiesHint: 'Every role includes the capabilities to its left. The policies below can narrow maintainer team-asset writes to Owner only, but can never grant access below the baseline role.',
+    roleCapabilitiesHint: 'Every role includes the capabilities to its left. Policies in Workspace Settings can narrow maintainer team-asset writes to Owner only, but can never grant access below the baseline role.',
     roleCapabilitiesTable: 'Workspace capabilities by role',
     capabilityColumn: 'Capability',
     capabilityViewContext: 'View web context',

--- a/frontend/web/src/i18n/locales/ko.ts
+++ b/frontend/web/src/i18n/locales/ko.ts
@@ -374,7 +374,7 @@ export const ko = {
     permissionsHint: '동작별 허용 범위(웹·CLI 공통 강제). 역할 사다리상 팀 자산 쓰기는 maintainer 이상이며, 이 정책으로 Owner 만으로 더 좁힐 수 있습니다. 사용자 단위 조정은 멤버 탭의 역할 변경으로.',
     roleCapabilitiesTitle: '역할별 기본 권한',
     roleLadder: '낮은 권한에서 높은 권한으로 누적',
-    roleCapabilitiesHint: '높은 역할은 왼쪽 역할의 권한을 모두 포함합니다. 아래 권한 정책은 maintainer의 팀 자산 쓰기를 Owner 전용으로 더 좁힐 수 있지만, 기본 역할보다 넓힐 수는 없습니다.',
+    roleCapabilitiesHint: '높은 역할은 왼쪽 역할의 권한을 모두 포함합니다. 워크스페이스 설정의 권한 정책은 maintainer의 팀 자산 쓰기를 Owner 전용으로 더 좁힐 수 있지만, 기본 역할보다 넓힐 수는 없습니다.',
     roleCapabilitiesTable: '워크스페이스 역할별 권한표',
     capabilityColumn: '할 수 있는 일',
     capabilityViewContext: '웹 컨텍스트 열람',

--- a/frontend/web/src/styles.css
+++ b/frontend/web/src/styles.css
@@ -555,6 +555,7 @@ button.copy.done { color: var(--ok); border-color: var(--ok); }
   border-radius: 6px; padding: 5px 8px; background: transparent; color: var(--text); }
 .role-capabilities { margin-top: 4px; padding: 15px 16px 13px; border: 1px solid var(--line); border-radius: 10px;
   background: color-mix(in srgb, var(--hover) 38%, var(--bg)); min-width: 0; }
+.ws-head + .role-capabilities, .invite-panel + .role-capabilities { margin-top: 24px; }
 .role-capabilities-head { display: flex; align-items: center; justify-content: space-between; gap: 14px; }
 .role-ladder { color: var(--muted); font-family: var(--mono); font-size: 0.68rem; white-space: nowrap; }
 .role-ladder span { color: var(--faint); padding: 0 4px; }


### PR DESCRIPTION
## Summary
- move the cumulative role-capability matrix out of Workspace Settings
- order the Members tab as Invites, Role capabilities, then Members
- update policy copy for the new location and preserve maintainer-only invite controls
- add mobile browser regression coverage for placement, order, overflow, and Settings removal

## Verification
- npm run build
- npm test
- npm run check:i18n
- npm run check:vercel
- npm audit --audit-level=high
- npm run test:e2e (8 passed, 1 full-stack-only skipped)
- signed-in localhost visual check

Closes #135