### PR TITLE
Gate public workspace management controls

### DIFF
--- a/backend/internal/adapters/delivery/http/server_test.go
+++ b/backend/internal/adapters/delivery/http/server_test.go
@@ -1209,3 +1209,49 @@ func TestWorkspacePolicyLookupFailureBlocksAction(t *testing.T) {
 		t.Fatalf("policy lookup failure code %d, want 404", code)
 	}
 }
+
+func TestPublicPullerCannotManageWorkspaceOrTeamAssets(t *testing.T) {
+	ts := newTestServer(t)
+	defer ts.Close()
+
+	var me struct {
+		Username string `json:"username"`
+	}
+	if code := doJSON(t, "GET", ts.URL+"/api/v1/me", nil, &me); code != http.StatusOK {
+		t.Fatalf("owner lookup code %d", code)
+	}
+	var ws struct {
+		ID   string `json:"id"`
+		Slug string `json:"slug"`
+	}
+	if code := doJSON(t, "POST", ts.URL+"/api/v1/workspaces", map[string]any{"name": "PublicAssets"}, &ws); code != http.StatusOK {
+		t.Fatalf("workspace create code %d", code)
+	}
+	if code := doJSON(t, "PATCH", ts.URL+"/api/v1/workspaces/"+url.PathEscape(ws.ID), map[string]any{
+		"visibility": "public", "public_role": "puller",
+	}, nil); code != http.StatusOK {
+		t.Fatalf("workspace public patch code %d", code)
+	}
+
+	remoteURL := "http://cxthub.test/" + me.Username + "/" + ws.Slug
+	rid := repoIDForRemoteURLForTest(remoteURL)
+	if code := doJSON(t, "POST", ts.URL+"/api/v1/repos", map[string]any{
+		"id": rid, "remote_url": remoteURL, "default_branch": "main",
+	}, nil); code != http.StatusOK {
+		t.Fatalf("repo create code %d", code)
+	}
+
+	outsider := "dev:outsider@t.io:Outsider"
+	workspaceURL := ts.URL + "/api/v1/workspaces/" + url.PathEscape(ws.ID)
+	if code := doJSONAs(t, outsider, "PATCH", workspaceURL, map[string]any{"name": "Hijacked"}, nil); code != http.StatusForbidden {
+		t.Fatalf("public puller workspace patch code %d, want 403", code)
+	}
+	settingsURL := ts.URL + "/api/v1/repos/" + url.PathEscape(string(rid)) + "/settings/claude"
+	if code := doJSONAs(t, outsider, "PUT", settingsURL, map[string]any{"files": []any{}}, nil); code != http.StatusForbidden {
+		t.Fatalf("public puller settings write code %d, want 403", code)
+	}
+	secretsURL := ts.URL + "/api/v1/repos/" + url.PathEscape(string(rid)) + "/secrets"
+	if code := doJSONAs(t, outsider, "PUT", secretsURL, map[string]any{"fingerprint": "fp"}, nil); code != http.StatusForbidden {
+		t.Fatalf("public puller secrets write code %d, want 403", code)
+	}
+}

--- a/frontend/web/e2e/ui-regressions.spec.ts
+++ b/frontend/web/e2e/ui-regressions.spec.ts
@@ -249,6 +249,120 @@ test('members page orders invites, role capabilities, and members without page o
   expect(unexpected).toEqual([]);
 });
 
+test('public workspace management controls deny non-maintainers without opening dialogs', async ({ page }) => {
+  const pageErrors = capturePageErrors(page);
+  const unexpected = await installApiFixture(page, ({ method, pathname, searchParams }) => {
+    if (method !== 'GET') return undefined;
+    if (pathname === '/api/v1/me') {
+      return {
+        body: {
+          id: 'member-1',
+          email: 'member@example.test',
+          name: 'Member',
+          username: 'member',
+          nickname: 'Member',
+          locale: 'en',
+        },
+      };
+    }
+    if (pathname === '/api/v1/workspaces') {
+      return {
+        body: [{
+          id: workspaceId,
+          name: 'cxthub',
+          slug: 'cxthub',
+          owner_id: 'owner-1',
+          owner_username: 'alice',
+          visibility: 'public',
+          public_role: 'viewer',
+          created_at: '2026-08-01T00:00:00Z',
+        }],
+      };
+    }
+    if (pathname === `/api/v1/workspaces/${workspaceId}/members`) {
+      return {
+        body: [{
+          workspace_id: workspaceId,
+          user_id: 'member-1',
+          role: 'member',
+          user: { id: 'member-1', name: 'Member', nickname: 'Member', email: 'member@example.test' },
+        }],
+      };
+    }
+    if (pathname === '/api/v1/repos' && searchParams.get('workspace') === workspaceId) {
+      return {
+        body: [{
+          id: repoId,
+          remote_url: 'https://github.com/wnsdy95/cxthub.git',
+          default_branch: 'main',
+        }],
+      };
+    }
+    if (pathname === `/api/v1/repos/${repoId}/refs`) {
+      return { body: [{ kind: 'branch', name: 'main', repo_id: repoId, target: pushedHead }] };
+    }
+    if (pathname === `/api/v1/repos/${repoId}/snapshots`) {
+      return {
+        body: [{
+          id: pushedHead,
+          repo_id: repoId,
+          parents: [],
+          graft_parents: [],
+          doc_hash: pushedHead,
+          message: 'shared main head',
+          author: 'Alice',
+          session_id: 'session-1',
+          provider: 'codex',
+          models: ['gpt-5.6-sol'],
+          created_at: '2026-08-31T03:00:00Z',
+        }],
+      };
+    }
+    if (pathname === `/api/v1/repos/${repoId}/pending`) return { body: [] };
+    if (pathname === `/api/v1/repos/${repoId}/unsync`) return { body: [] };
+    if (pathname.startsWith(`/api/v1/repos/${repoId}/settings/`)) return { body: null };
+    if (pathname === `/api/v1/repos/${repoId}/secrets`) return { body: null };
+    if (pathname.startsWith(`/api/v1/repos/${repoId}/docs/`)) {
+      return { body: sessionDoc(decodeURIComponent(pathname.split('/').at(-1) ?? '')) };
+    }
+    return undefined;
+  });
+
+  await page.goto('/alice/cxthub');
+  const settingsTab = page.locator('nav.tabs').getByRole('button', { name: 'Settings', exact: true });
+  await expect(settingsTab).toBeVisible();
+  await settingsTab.click();
+  await expect(page.getByRole('alert')).toContainText('Workspace settings require owner access');
+  await expect(page).toHaveURL(/\/alice\/cxthub$/);
+
+  const teamSection = page.locator('.side-sec').filter({ hasText: 'Team defaults' });
+  await teamSection.getByRole('button', { name: 'Upload team defaults' }).click();
+  await expect(teamSection.getByRole('alert')).toContainText('maintainer or owner');
+  await expect(page.getByRole('dialog', { name: 'Upload team defaults' })).toHaveCount(0);
+
+  const secretsSection = page.locator('.side-sec').filter({ hasText: '.cxtsecrets' });
+  await secretsSection.getByRole('button', { name: '.cxtsecrets settings' }).click();
+  await expect(secretsSection.getByRole('alert')).toContainText('maintainer or owner');
+  await expect(page.getByRole('dialog', { name: '.cxtsecrets settings' })).toHaveCount(0);
+
+  await page.goto('/alice/cxthub/settings');
+  await expect(page.locator('.access-denied')).toContainText('Workspace settings require owner access');
+  await expect(page.locator('.ws-settings-form')).toHaveCount(0);
+  expect(pageErrors).toEqual([]);
+  expect(unexpected).toEqual([]);
+});
+
+test('anonymous public settings URL renders access denial instead of workspace context', async ({ page }) => {
+  const pageErrors = capturePageErrors(page);
+  const unexpected = await installApiFixture(page, publicWorkspaceApi([], []));
+
+  await page.goto('/alice/cxthub/settings');
+  await expect(page.locator('.access-denied')).toContainText('Workspace settings require owner access');
+  await expect(page.locator('.ctx-layout')).toHaveCount(0);
+  expect(pageErrors).toEqual([]);
+  expect(unexpected).toEqual([]);
+});
+
 test('profile survives nullable activity arrays and keeps the legend inside the calendar', async ({ page }) => {
   const pageErrors = capturePageErrors(page);
   const unexpected = await installApiFixture(page, ({ method, pathname }) => {

--- a/frontend/web/src/App.tsx
+++ b/frontend/web/src/App.tsx
@@ -72,7 +72,7 @@ function Root() {
     // Non-logged in + /<username>/<slug> → public workspace: read-only view (determined by server). /login/device re-renders to approval page after login.
     const r = parseRoute();
     if (!forceLogin && r?.kind === 'ws') {
-      return <PublicBrowse username={r.username} slug={r.slug} onLogin={() => setForceLogin(true)} />;
+      return <PublicBrowse username={r.username} slug={r.slug} tab={r.tab} onLogin={() => setForceLogin(true)} />;
     }
     if (!forceLogin && r?.kind === 'user') {
       return <UserProfile username={r.username} onLogin={() => setForceLogin(true)} />;

--- a/frontend/web/src/components/About.tsx
+++ b/frontend/web/src/components/About.tsx
@@ -199,19 +199,46 @@ export function About({ repo, canEdit }: { repo: Repo; canEdit: boolean }) {
 
 
 // TeamSettings manages shared .claude/.agents/.codex defaults in the side rail.
-// Pullers can view status and download; the upload control requires canWrite.
-export function TeamSettings({ repoId, canWrite }: { repoId: string; canWrite: boolean }) {
+// Pullers can view status and download. Public workspaces keep the management
+// affordance visible, but deny it before mounting the dialog when canWrite is false.
+export function TeamSettings({
+  repoId,
+  canWrite,
+  showLockedControl = false,
+}: {
+  repoId: string;
+  canWrite: boolean;
+  showLockedControl?: boolean;
+}) {
   const t = useT();
   const [open, setOpen] = useState(false);
+  const [denied, setDenied] = useState(false);
   return (
     <div className="side-sec">
       <div className="about-head">
         <span className="label">{t('about.teamSettings')}</span>
-        {canWrite && <GearBtn label={t('about.uploadTeamSettings')} onClick={() => setOpen(true)} />}
+        {(canWrite || showLockedControl) && (
+          <GearBtn
+            label={t('about.uploadTeamSettings')}
+            onClick={() => {
+              if (!canWrite) {
+                setDenied(true);
+                return;
+              }
+              setDenied(false);
+              setOpen(true);
+            }}
+          />
+        )}
       </div>
       <SettingsRow repoId={repoId} kind="claude" />
       <SettingsRow repoId={repoId} kind="agents" />
       <SettingsRow repoId={repoId} kind="codex" />
+      {denied && (
+        <p className="err slot-msg" role="alert">
+          {t('about.teamSettingsAccessDenied')}
+        </p>
+      )}
 
       {open && (
         <Portal>
@@ -338,7 +365,15 @@ function SettingsSlot({ repoId, kind }: { repoId: string; kind: 'claude' | 'agen
 // the settings modal. Plaintext, passphrases, and keys never leave the browser. Only a
 // PBKDF2 (600k) + AES-256-GCM envelope reaches the server, and teammates decrypt it with
 // `cxt secrets pull -p <pw>`.
-export function SecretsPanel({ repoId, canWrite }: { repoId: string; canWrite: boolean }) {
+export function SecretsPanel({
+  repoId,
+  canWrite,
+  showLockedControl = false,
+}: {
+  repoId: string;
+  canWrite: boolean;
+  showLockedControl?: boolean;
+}) {
   const t = useT();
   const [open, setOpen] = useState(false);
   const [lines, setLines] = useState('');
@@ -486,7 +521,19 @@ export function SecretsPanel({ repoId, canWrite }: { repoId: string; canWrite: b
     <div className="side-sec">
       <div className="about-head">
         <span className="label">.cxtsecrets</span>
-        {canWrite && <GearBtn label={t('about.secretsSettings')} onClick={() => setOpen(true)} />}
+        {(canWrite || showLockedControl) && (
+          <GearBtn
+            label={t('about.secretsSettings')}
+            onClick={() => {
+              if (!canWrite) {
+                setMsg(t('about.secretsSettingsAccessDenied'));
+                return;
+              }
+              setMsg(null);
+              setOpen(true);
+            }}
+          />
+        )}
       </div>
       <div className="settings-slot">
         <div className="settings-slot-info">
@@ -499,7 +546,11 @@ export function SecretsPanel({ repoId, canWrite }: { repoId: string; canWrite: b
           {busy ? '…' : t('about.saveLocal')}
         </button>
       </div>
-      {!open && msg && <p className={msg.startsWith('✓') ? 'hint ok-msg slot-msg' : 'err slot-msg'}>{msg}</p>}
+      {!open && msg && (
+        <p className={msg.startsWith('✓') ? 'hint ok-msg slot-msg' : 'err slot-msg'} role="alert">
+          {msg}
+        </p>
+      )}
 
       {open && (
         <Portal>

--- a/frontend/web/src/components/AccessDenied.tsx
+++ b/frontend/web/src/components/AccessDenied.tsx
@@ -1,0 +1,17 @@
+import { useT } from '../i18n';
+
+export function AccessDenied({ message }: { message: string }) {
+  const t = useT();
+
+  return (
+    <div className="access-denied" role="alert">
+      <span className="access-denied-mark" aria-hidden="true">
+        ⊘
+      </span>
+      <div>
+        <strong>{t('common.accessDenied')}</strong>
+        <p>{message}</p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/web/src/components/ContextView.tsx
+++ b/frontend/web/src/components/ContextView.tsx
@@ -42,7 +42,7 @@ export function commonEventPrefix(a: CIREvent[], b: CIREvent[]): number {
 // → leftmost, z-order also leftmost (behind participants not claiming representation).
 function AIDots({ s }: { s: Snapshot }) {
   // "<synthetic>" is a harness synthetic placeholder — it is not drawn even if it remains in the old version snapshot meta.
-  const models = (s.models ?? []).filter((m) => m !== '<synthetic>');
+  const models = [...new Set((s.models ?? []).filter((m) => m !== '<synthetic>'))];
   const items = models.length
     ? models.map((m) => ({ key: m, logo: modelLogo(m), color: modelColor(m), title: m }))
     : [
@@ -93,7 +93,7 @@ function pickDefaultBranch(names: string[], preferred: string): string | null {
   return names[0] ?? null;
 }
 
-type ContextWorkspace = Pick<Workspace, 'id' | 'owner_username' | 'slug'> &
+type ContextWorkspace = Pick<Workspace, 'id' | 'owner_username' | 'slug' | 'visibility'> &
   Partial<Pick<Workspace, 'settings_policy' | 'secrets_policy'>>;
 
 export function ContextView({ repo, ws, role }: { repo: Repo; ws: ContextWorkspace | null; role: Role | null }) {
@@ -546,10 +546,18 @@ export function ContextView({ repo, ws, role }: { repo: Repo; ws: ContextWorkspa
       <aside className="ctx-side">
         <About repo={repo} canEdit={canWriteAsset(role, undefined)} />
         {atLeast(role, 'puller') && (
-          <TeamSettings repoId={repo.id} canWrite={canWriteAsset(role, ws?.settings_policy)} />
+          <TeamSettings
+            repoId={repo.id}
+            canWrite={canWriteAsset(role, ws?.settings_policy)}
+            showLockedControl={ws?.visibility === 'public'}
+          />
         )}
         {atLeast(role, 'puller') && (
-          <SecretsPanel repoId={repo.id} canWrite={canWriteAsset(role, ws?.secrets_policy)} />
+          <SecretsPanel
+            repoId={repo.id}
+            canWrite={canWriteAsset(role, ws?.secrets_policy)}
+            showLockedControl={ws?.visibility === 'public'}
+          />
         )}
         <span className="label">{t('common.commitGraphTotal', { count: committedSnapshots.length })}</span>
         <CommitGraph snapshots={graphSnapshots} selectedId={snapId} onSelect={setSnapId} badges={badges} refs={refs} uncommitted={uncommittedIds} pinBranch={repo.default_branch || 'main'} joinBranch={branch ?? undefined} repoId={atLeast(role, 'member') ? repo.id : null} />

--- a/frontend/web/src/components/Dashboard.tsx
+++ b/frontend/web/src/components/Dashboard.tsx
@@ -27,6 +27,7 @@ import { RoleCapabilities } from './RoleCapabilities';
 import { LockIcon } from './Breadcrumb';
 import { myRole, atLeast, ROLES } from '../roles';
 import { gitWebUrl, sanitizeRemoteUrl } from '../urls';
+import { AccessDenied } from './AccessDenied';
 
 function short(hash: string): string {
   return hash.replace(/^sha256:/, '').slice(0, 12);
@@ -56,6 +57,7 @@ export function Dashboard() {
 
   // View the repo context — default is the first repo (usually one per workspace), switch by clicking in the list.
   const [activeRepoId, setActiveRepoId] = useState<string | null>(null);
+  const [accessNotice, setAccessNotice] = useState<string | null>(null);
   const activeRepo = repos.find((r) => r.id === activeRepoId) ?? repos[0] ?? null;
 
   // URL (/<username>/<slug>) → synchronize selection. The URL is the source of truth on entry, refresh, and back navigation.
@@ -86,6 +88,7 @@ export function Dashboard() {
 
   // Workspace click = navigate to that path (history is pushed for back action).
   function goWorkspace(w: Workspace) {
+    setAccessNotice(null);
     selectWs(w.id);
     navigate(wsPath(w));
   }
@@ -102,7 +105,13 @@ export function Dashboard() {
       ? route.tab
       : 'context';
   function goTab(next: 'context' | 'connections' | 'members' | 'onhold' | 'settings') {
-    if (!selected || next === tab) return;
+    if (!selected) return;
+    if (next === 'settings' && !atLeast(role, 'owner')) {
+      setAccessNotice(t('dashboard.workspaceAccessDenied'));
+      return;
+    }
+    setAccessNotice(null);
+    if (next === tab) return;
     navigate(wsPath(selected, next === 'context' ? undefined : next));
   }
 
@@ -224,13 +233,19 @@ export function Dashboard() {
                   <button className={`tab${tab === 'members' ? ' on' : ''}`} onClick={() => goTab('members')}>
                     {t('dashboard.members')} <span className="count-badge">{members.length}</span>
                   </button>
-                  {user && atLeast(role, 'owner') && (
+                  {(selected.visibility === 'public' || (user && atLeast(role, 'owner'))) && (
                     <button className={`tab${tab === 'settings' ? ' on' : ''}`} onClick={() => goTab('settings')}>
                       {t('dashboard.settings')}
                     </button>
                   )}
                 </nav>
               </div>
+
+              {accessNotice && (
+                <div className="toast" role="alert" onClick={() => setAccessNotice(null)}>
+                  {accessNotice}
+                </div>
+              )}
 
               {tab === 'members' ? (
                 <>
@@ -336,6 +351,14 @@ export function Dashboard() {
                     <h4>{t('dashboard.wsSettings')}</h4>
                   </div>
                   <WorkspaceSettings ws={selected} isCreator={user.id === selected.owner_id} />
+                </section>
+              )}
+              {tab === 'settings' && (!user || !atLeast(role, 'owner')) && (
+                <section className="panel">
+                  <div className="panel-head">
+                    <h4>{t('dashboard.wsSettings')}</h4>
+                  </div>
+                  <AccessDenied message={t('dashboard.workspaceAccessDenied')} />
                 </section>
               )}
 

--- a/frontend/web/src/components/OnHoldView.tsx
+++ b/frontend/web/src/components/OnHoldView.tsx
@@ -415,10 +415,18 @@ export function OnHoldView({ repo, ws, role }: { repo: Repo; ws: Workspace | nul
       <aside className="ctx-side">
         <About repo={repo} canEdit={canWriteAsset(role, undefined)} />
         {atLeast(role, 'puller') && (
-          <TeamSettings repoId={repo.id} canWrite={canWriteAsset(role, ws?.settings_policy)} />
+          <TeamSettings
+            repoId={repo.id}
+            canWrite={canWriteAsset(role, ws?.settings_policy)}
+            showLockedControl={ws?.visibility === 'public'}
+          />
         )}
         {atLeast(role, 'puller') && (
-          <SecretsPanel repoId={repo.id} canWrite={canWriteAsset(role, ws?.secrets_policy)} />
+          <SecretsPanel
+            repoId={repo.id}
+            canWrite={canWriteAsset(role, ws?.secrets_policy)}
+            showLockedControl={ws?.visibility === 'public'}
+          />
         )}
         <span className="label">{t('common.commitGraphTotal', { count: committedSnapshots.length })}</span>
         <CommitGraph

--- a/frontend/web/src/components/PublicBrowse.tsx
+++ b/frontend/web/src/components/PublicBrowse.tsx
@@ -5,15 +5,26 @@ import { useEffect, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import type { PublicWorkspace } from '../types';
 import { api } from '../api';
-import { navigate } from '../route';
+import { navigate, type WsTab } from '../route';
 import { Logo } from './Logo';
 import { LocaleSwitcher } from './LocaleSwitcher';
 import { Breadcrumb } from './Breadcrumb';
 import { useT } from '../i18n';
 import { ContextView } from './ContextView';
 import { sanitizeRemoteUrl } from '../urls';
+import { AccessDenied } from './AccessDenied';
 
-export function PublicBrowse({ username, slug, onLogin }: { username: string; slug: string; onLogin: () => void }) {
+export function PublicBrowse({
+  username,
+  slug,
+  tab,
+  onLogin,
+}: {
+  username: string;
+  slug: string;
+  tab?: WsTab;
+  onLogin: () => void;
+}) {
   const t = useT();
   const wsQ = useQuery<PublicWorkspace>({
     queryKey: ['public-ws', username, slug],
@@ -80,7 +91,7 @@ export function PublicBrowse({ username, slug, onLogin }: { username: string; sl
             </p>
           </div>
 
-          {repos.length > 1 && (
+          {tab !== 'settings' && repos.length > 1 && (
             <div className="pub-repos">
               {repos.map((r) => (
                 <button
@@ -95,7 +106,9 @@ export function PublicBrowse({ username, slug, onLogin }: { username: string; sl
           )}
 
           <section className="panel">
-            {activeRepo ? (
+            {tab === 'settings' ? (
+              <AccessDenied message={t('dashboard.workspaceAccessDenied')} />
+            ) : activeRepo ? (
               <ContextView repo={activeRepo} ws={ws} role={null} />
             ) : (
               <div className="empty-box">{t('common.noPushedContext')}</div>

--- a/frontend/web/src/i18n/locales/en.ts
+++ b/frontend/web/src/i18n/locales/en.ts
@@ -49,6 +49,7 @@ export const en: Messages = {
     noMessage: '(no message)',
     commitGraphTotal: 'Commit graph · {count} total',
     close: 'Close',
+    accessDenied: 'Access denied',
     expand: 'Expand',
     collapse: 'Collapse',
   },
@@ -201,6 +202,7 @@ export const en: Messages = {
     connectedRepos: 'Connected repos',
     settings: 'Settings',
     wsSettings: 'Workspace settings',
+    workspaceAccessDenied: 'Workspace settings require owner access.',
     roleChangeAria: 'Change role',
     ownerCreator: 'owner · creator',
     leave: 'Leave',
@@ -266,6 +268,8 @@ export const en: Messages = {
     saveChanges: 'Save changes',
     teamSettings: 'Team defaults',
     uploadTeamSettings: 'Upload team defaults',
+    teamSettingsAccessDenied:
+      'Team defaults settings require maintainer or owner access. Workspace policy may restrict them to owners.',
     teamGuideIntro: 'Upload shared `.claude/`·`.agents/`·`.codex/` defaults to the repo. Teammates apply them locally with one `cxt settings pull`.',
     teamGuide1: 'Pick a **dot-less folder name** — copy `.claude` into a folder named `claude` and upload that (browsers can’t pick hidden folders).',
     teamGuide2: 'Internal structure is preserved. e.g. `claude/commands/review.md` → `.claude/commands/review.md`',
@@ -290,6 +294,8 @@ export const en: Messages = {
     noFsApi: 'This browser can’t write folders — downloaded as "cxtsecrets". Move it to the repo root as .cxtsecrets, or use cxt secrets pull -p',
     configured: 'Configured',
     secretsSettings: '.cxtsecrets settings',
+    secretsSettingsAccessDenied:
+      '.cxtsecrets settings require maintainer or owner access. Workspace policy may restrict them to owners.',
     e2e: 'End-to-end encrypted',
     saveLocal: 'Save locally',
     secretsGuideIntro: 'Values auto-masked when context is captured. **One value per line** (the value, not the key name).',

--- a/frontend/web/src/i18n/locales/ko.ts
+++ b/frontend/web/src/i18n/locales/ko.ts
@@ -52,6 +52,7 @@ export const ko = {
     noMessage: '(메시지 없음)',
     commitGraphTotal: '커밋 그래프 · 전체 {count}',
     close: '닫기',
+    accessDenied: '접근할 수 없음',
     expand: '펼치기',
     collapse: '접기',
   },
@@ -204,6 +205,7 @@ export const ko = {
     connectedRepos: '연결된 저장소',
     settings: '설정',
     wsSettings: '워크스페이스 설정',
+    workspaceAccessDenied: '워크스페이스 설정은 owner만 열 수 있습니다.',
     roleChangeAria: '역할 변경',
     ownerCreator: 'owner ·생성자',
     leave: '나가기',
@@ -269,6 +271,8 @@ export const ko = {
     saveChanges: '변경 저장',
     teamSettings: '팀 기본 세팅',
     uploadTeamSettings: '팀 기본 세팅 업로드',
+    teamSettingsAccessDenied:
+      '팀 기본 세팅은 maintainer(관리자) 또는 owner만 설정할 수 있습니다. 워크스페이스 정책에 따라 owner 전용일 수 있습니다.',
     teamGuideIntro: '팀 공용 `.claude/`·`.agents/`·`.codex/` 기본 세팅을 저장소에 올립니다. 팀원은 `cxt settings pull` 한 번으로 로컬에 적용합니다.',
     teamGuide1: '**점 없는 폴더명**으로 선택 — `.claude` 를 `claude` 이름의 폴더로 복사해 올립니다(브라우저가 숨김 폴더를 선택하지 못하기 때문).',
     teamGuide2: '내부 구조는 그대로 보존됩니다. 예: `claude/commands/review.md` → `.claude/commands/review.md`',
@@ -293,6 +297,8 @@ export const ko = {
     noFsApi: '이 브라우저는 폴더 쓰기 미지원 — "cxtsecrets" 로 다운로드됨. repo 루트에 .cxtsecrets 로 옮기거나 cxt secrets pull -p 를 사용하세요',
     configured: '설정됨',
     secretsSettings: '.cxtsecrets 설정',
+    secretsSettingsAccessDenied:
+      '.cxtsecrets는 maintainer(관리자) 또는 owner만 설정할 수 있습니다. 워크스페이스 정책에 따라 owner 전용일 수 있습니다.',
     e2e: '종단간 암호화',
     saveLocal: '로컬에 저장',
     secretsGuideIntro: '컨텍스트 저장 시 자동 마스킹할 시크릿 값 목록입니다. **한 줄에 값 하나**(키 이름이 아니라 값).',

--- a/frontend/web/src/styles.css
+++ b/frontend/web/src/styles.css
@@ -224,6 +224,12 @@ button.ghost:hover { color: var(--ink); opacity: 1; }
 .empty-box code { font-size: 0.9em; color: var(--text); }
 .main > .empty-box { margin-top: 10vh; text-align: center; }
 
+.access-denied { display: flex; align-items: flex-start; gap: 12px; max-width: 620px; padding: 16px 18px;
+  border: 1px solid var(--line); border-radius: 8px; background: var(--hover); color: var(--text); }
+.access-denied-mark { color: var(--danger); font-family: var(--mono); font-size: 1.05rem; line-height: 1.25; }
+.access-denied strong { display: block; color: var(--ink); font-size: 0.86rem; }
+.access-denied p { margin: 4px 0 0; color: var(--muted); font-size: 0.82rem; line-height: 1.5; }
+
 /* Invitation */
 .invite { margin-top: 2px; }
 .invite-row { display: flex; gap: 8px; align-items: stretch; }


### PR DESCRIPTION
Closes #137

## Summary
- keep public workspace management affordances visible while denying unauthorized users before navigation or dialog mount
- render an explicit access-denied state for direct workspace settings URLs, including anonymous public browsing
- preserve backend authorization and add public-puller 403 regressions for workspace, team defaults, and `.cxtsecrets` writes
- add browser coverage for locked controls and modal non-mounting

## Verification
- `go test ./...` and `go vet ./...` (backend)
- `npm test`, `npm run build`, `npm run check:i18n`, `npm run check:vercel`, `npm audit`
- `npm run test:e2e` (10 passed, 1 real-wire test skipped by default)
- `bash scripts/public-preflight.sh tree`
- live localhost owner settings render and console errors checked in browser