### PR TITLE
Route signed-in outsiders through public workspace view

### DIFF
--- a/frontend/web/e2e/ui-regressions.spec.ts
+++ b/frontend/web/e2e/ui-regressions.spec.ts
@@ -363,6 +363,37 @@ test('anonymous public settings URL renders access denial instead of workspace c
   expect(unexpected).toEqual([]);
 });
 
+test('signed-in non-member stays on the public workspace route and gets settings denial', async ({ page }) => {
+  const pageErrors = capturePageErrors(page);
+  const publicApi = publicWorkspaceApi([], []);
+  const unexpected = await installApiFixture(page, (request) => {
+    const { method, pathname } = request;
+    if (method === 'GET' && pathname === '/api/v1/me') {
+      return {
+        body: {
+          id: 'outsider-1',
+          email: 'outsider@example.test',
+          name: 'Outsider',
+          username: 'outsider',
+          nickname: 'Outsider',
+          locale: 'en',
+        },
+      };
+    }
+    if (method === 'GET' && pathname === '/api/v1/workspaces') return { body: [] };
+    return publicApi(request);
+  });
+
+  await page.goto('/alice/cxthub/settings');
+  await expect(page).toHaveURL(/\/alice\/cxthub\/settings$/);
+  await expect(page.getByText('Public view', { exact: true })).toBeVisible();
+  await expect(page.locator('.access-denied')).toContainText('Workspace settings require owner access');
+  await expect(page.locator('.app-side')).toHaveCount(0);
+  await expect(page.getByRole('button', { name: 'Sign in' })).toHaveCount(0);
+  expect(pageErrors).toEqual([]);
+  expect(unexpected).toEqual([]);
+});
+
 test('profile survives nullable activity arrays and keeps the legend inside the calendar', async ({ page }) => {
   const pageErrors = capturePageErrors(page);
   const unexpected = await installApiFixture(page, ({ method, pathname }) => {

--- a/frontend/web/src/App.tsx
+++ b/frontend/web/src/App.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { wsPath, parseRoute, replacePath } from './route';
-import { useMe, useAcceptInvite } from './hooks';
+import { wsPath, parseRoute, replacePath, findByRoute, type WsTab } from './route';
+import { useMe, useAcceptInvite, useWorkspaces } from './hooks';
 import { useLocale, useT } from './i18n';
 import { Login } from './components/Login';
 import { Dashboard } from './components/Dashboard';
@@ -91,6 +91,7 @@ function Root() {
     if (r?.kind === 'device') return <DeviceApprove code={r.code} />;
     if (r?.kind === 'user') return <UserProfile username={r.username} />;
     if (r?.kind === 'pricing') return <Pricing />;
+    if (r?.kind === 'ws') return <AuthenticatedWorkspace username={r.username} slug={r.slug} tab={r.tab} />;
     // Home (/) shows landing even in login state — clicking logo does not redirect to workspace. (Dashboard mounts only in workspace paths, so automatic redirects do not occur)
     if (r === null) return <Landing />;
   }
@@ -104,4 +105,18 @@ function Root() {
       )}
     </>
   );
+}
+
+function AuthenticatedWorkspace({ username, slug, tab }: { username: string; slug: string; tab?: WsTab }) {
+  const workspaces = useWorkspaces();
+  if (workspaces.isLoading) return <div className="loading">…</div>;
+  if (workspaces.isError) return <Dashboard />;
+
+  const route = { kind: 'ws' as const, username, slug, tab };
+  if (findByRoute(route, workspaces.data ?? [])) return <Dashboard />;
+
+  // A signed-in non-member still uses the public read-only surface. Routing
+  // every authenticated workspace URL through Dashboard would redirect away
+  // before public visibility and access-denial rules can be evaluated.
+  return <PublicBrowse username={username} slug={slug} tab={tab} />;
 }

--- a/frontend/web/src/components/PublicBrowse.tsx
+++ b/frontend/web/src/components/PublicBrowse.tsx
@@ -23,7 +23,7 @@ export function PublicBrowse({
   username: string;
   slug: string;
   tab?: WsTab;
-  onLogin: () => void;
+  onLogin?: () => void;
 }) {
   const t = useT();
   const wsQ = useQuery<PublicWorkspace>({
@@ -44,11 +44,12 @@ export function PublicBrowse({
   // private or non-existent — Do not leak existence, redirect to login (no setState during render → effect).
   const notFound = !wsQ.isLoading && !ws;
   useEffect(() => {
-    if (notFound) onLogin();
+    if (notFound) onLogin?.();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [notFound]);
 
-  if (wsQ.isLoading || notFound) return <div className="loading">…</div>;
+  if (wsQ.isLoading || (notFound && onLogin)) return <div className="loading">…</div>;
+  if (notFound) return <div className="loading">{t('common.workspaceUnavailable')}</div>;
   if (!ws) return null;
 
   return (
@@ -65,15 +66,17 @@ export function PublicBrowse({
         <div className="who">
           <LocaleSwitcher />
           <span className="vis-chip">{t('common.publicView')}</span>
-          <button
-            className="ghost"
-            onClick={() => {
-              navigate('/');
-              onLogin();
-            }}
-          >
-            {t('common.signIn')}
-          </button>
+          {onLogin && (
+            <button
+              className="ghost"
+              onClick={() => {
+                navigate('/');
+                onLogin();
+              }}
+            >
+              {t('common.signIn')}
+            </button>
+          )}
         </div>
       </header>
 

--- a/frontend/web/src/i18n/locales/en.ts
+++ b/frontend/web/src/i18n/locales/en.ts
@@ -50,6 +50,7 @@ export const en: Messages = {
     commitGraphTotal: 'Commit graph · {count} total',
     close: 'Close',
     accessDenied: 'Access denied',
+    workspaceUnavailable: 'This workspace is unavailable or private.',
     expand: 'Expand',
     collapse: 'Collapse',
   },

--- a/frontend/web/src/i18n/locales/ko.ts
+++ b/frontend/web/src/i18n/locales/ko.ts
@@ -53,6 +53,7 @@ export const ko = {
     commitGraphTotal: '커밋 그래프 · 전체 {count}',
     close: '닫기',
     accessDenied: '접근할 수 없음',
+    workspaceUnavailable: '이 워크스페이스는 없거나 비공개입니다.',
     expand: '펼치기',
     collapse: '접기',
   },


### PR DESCRIPTION
Closes #137

## Summary
- resolve authenticated workspace routes against the user membership list before mounting Dashboard
- keep signed-in non-members on the public read-only workspace surface instead of redirecting them to another workspace
- preserve explicit `/settings` access denial for signed-in public visitors and avoid showing a misleading Sign in action
- fail back to Dashboard if membership lookup itself errors

## Verification
- frontend unit, typecheck, i18n, build, Vercel config, and audit
- Playwright full suite: 11 passed, 1 real-wire test skipped by default
- public preflight and secret scan
- clean live localhost load: owner settings visible, no console errors