### PR TITLE
Preserve PR-joined branch lanes in the context graph

### DIFF
--- a/frontend/web/e2e/ui-regressions.spec.ts
+++ b/frontend/web/e2e/ui-regressions.spec.ts
@@ -785,14 +785,18 @@ test('branch labels exist only for visible graph lanes and share horizontal scro
   expect(second.unexpected).toEqual([]);
 });
 
-test('archived branches stay discoverable even when their history is shared with an active branch', async ({ page }) => {
-  const archivedHead = id('9');
+test('PR-joined branch lanes keep their name while truly deleted branches stay archived', async ({ page }) => {
+  const root = id('8');
+  const joinedHead = id('9');
+  const archivedHead = id('7');
   const snapshots = [
     {
       id: pushedHead,
       repo_id: repoId,
       branch: 'main',
-      parents: [],
+      parents: [root],
+      graft_parents: [joinedHead],
+      grafted: true,
       doc_hash: pushedHead,
       provider: 'codex',
       fidelity: 'full',
@@ -800,15 +804,37 @@ test('archived branches stay discoverable even when their history is shared with
       created_at: '2026-08-31T04:00:00Z',
     },
     {
+      id: joinedHead,
+      repo_id: repoId,
+      branch: 'feature/merged',
+      parents: [root],
+      doc_hash: joinedHead,
+      provider: 'claude',
+      fidelity: 'full',
+      message: 'merged branch history',
+      created_at: '2026-08-31T03:30:00Z',
+    },
+    {
       id: archivedHead,
       repo_id: repoId,
-      branch: 'feature/archived-only',
-      parents: [],
+      branch: 'feature/abandoned',
+      parents: [root],
       doc_hash: archivedHead,
       provider: 'claude',
       fidelity: 'full',
       message: 'archived-only history',
       created_at: '2026-08-31T03:00:00Z',
+    },
+    {
+      id: root,
+      repo_id: repoId,
+      branch: 'main',
+      parents: [],
+      doc_hash: root,
+      provider: 'codex',
+      fidelity: 'full',
+      message: 'shared root',
+      created_at: '2026-08-31T02:00:00Z',
     },
   ];
   const lifecycleRef = (branch: string, target: string, generation: number) => ({
@@ -819,27 +845,34 @@ test('archived branches stay discoverable even when their history is shared with
   });
   const refs = [
     { kind: 'branch', name: 'main', repo_id: repoId, target: pushedHead },
-    lifecycleRef('feature/shared-history', pushedHead, 1),
-    lifecycleRef('feature/archived-only', archivedHead, 2),
+    lifecycleRef('feature/merged', joinedHead, 1),
+    lifecycleRef('feature/abandoned', archivedHead, 2),
   ];
   const { pageErrors, unexpected } = await openGraph(page, publicWorkspaceApi(snapshots, refs));
 
+  await expect(page.locator('.graph-row')).toHaveCount(3);
+  const joinedRow = page.locator('.graph-row[aria-label^="merged branch history"]');
+  await expect(joinedRow).toBeVisible();
+  const joinedLane = page.locator('.graph-lane-label[aria-label="feature/merged"]');
+  await expect(joinedLane).toBeVisible();
+  await expect(joinedLane).not.toHaveClass(/archived/);
+  await joinedRow.hover();
+  await expect(page.locator('.graph-tip .tip-badges')).toContainText('joined · feature/merged');
+
   const panel = page.locator('.graph-archive-panel');
-  await expect(panel.locator('summary')).toContainText('Archived branches 2');
+  await expect(panel.locator('summary')).toContainText('Archived branches 1');
   await panel.locator('summary').click();
-  const sharedEntry = panel.locator('.graph-archive-entry').filter({ hasText: 'feature/shared-history' });
-  const uniqueEntry = panel.locator('.graph-archive-entry').filter({ hasText: 'feature/archived-only' });
-  await expect(sharedEntry).toContainText('Shared with an active lineage');
+  await expect(panel).not.toContainText('feature/merged');
+  const uniqueEntry = panel.locator('.graph-archive-entry').filter({ hasText: 'feature/abandoned' });
   await expect(uniqueEntry).toContainText('1 unique commit');
-  await expect(page.locator('.graph-row')).toHaveCount(1);
 
   await uniqueEntry.click();
-  await expect(page.locator('.graph-row')).toHaveCount(2);
+  await expect(page.locator('.graph-row')).toHaveCount(4);
   await expect(page.locator('.graph-row.on')).toHaveAttribute('aria-label', /^archived-only history/);
   const hide = panel.locator('.graph-archive-toggle');
   await expect(hide).toContainText('Hide 1 archived');
   await hide.click();
-  await expect(page.locator('.graph-row')).toHaveCount(1);
+  await expect(page.locator('.graph-row')).toHaveCount(3);
   await expect(page.locator('.graph-row.on')).toHaveAttribute('aria-label', /^active main head/);
   expect(pageErrors).toEqual([]);
   expect(unexpected).toEqual([]);

--- a/frontend/web/src/components/CommitGraph.tsx
+++ b/frontend/web/src/components/CommitGraph.tsx
@@ -84,8 +84,8 @@ export function CommitGraph({
   const t = useT();
   const [showArchived, setShowArchived] = useState(false);
   const status = useMemo(
-    () => classifyGraphSnapshots(refs ?? [], snapshots, uncommitted),
-    [refs, snapshots, uncommitted],
+    () => classifyGraphSnapshots(refs ?? [], snapshots, uncommitted, pinBranch),
+    [refs, snapshots, uncommitted, pinBranch],
   );
   const selectedArchived = selectedId !== null && status.archivedOnly.has(selectedId);
   const archivedVisible = showArchived || selectedArchived;
@@ -352,11 +352,14 @@ export function CommitGraph({
           ? rowBadges.find((badge) => badge.kind === 'branch' && badge.name === pinBranch)
           : undefined) ?? rowBadges.find((badge) => badge.kind === 'branch');
       const archivedBadge = rowBadges.find((badge) => badge.kind === 'archived');
+      const joinedBadge = rowBadges.find((badge) => badge.kind === 'joined');
       return branchBadge
         ? { text: branchBadge.name, archived: false }
-        : archivedBadge
-          ? { text: t('graph.archivedLane', { branch: archivedBadge.name }), archived: true }
-          : { text: snapshot.branch ?? '', archived: false };
+        : joinedBadge
+          ? { text: joinedBadge.name, archived: false }
+          : archivedBadge
+            ? { text: t('graph.archivedLane', { branch: archivedBadge.name }), archived: true }
+            : { text: snapshot.branch ?? '', archived: false };
     };
   }, [badges, pinBranch, t]);
 
@@ -781,10 +784,20 @@ export function CommitGraph({
                 <span
                   key={b.kind + b.name}
                   className={`ref-badge ${b.kind}`}
-                  title={b.kind === 'archived' ? t('context.archivedBranchTitle') : undefined}
+                  title={
+                    b.kind === 'archived'
+                      ? t('context.archivedBranchTitle')
+                      : b.kind === 'joined'
+                        ? t('context.joinedBranchTitle')
+                        : undefined
+                  }
                 >
-                  {b.kind === 'tag' ? '⌂ ' : b.kind === 'archived' ? '⊟ ' : ''}
-                  {b.kind === 'archived' ? t('context.archivedBranchBadge', { branch: b.name }) : b.name}
+                  {b.kind === 'tag' ? '⌂ ' : b.kind === 'archived' ? '⊟ ' : b.kind === 'joined' ? '⎘ ' : ''}
+                  {b.kind === 'archived'
+                    ? t('context.archivedBranchBadge', { branch: b.name })
+                    : b.kind === 'joined'
+                      ? t('context.joinedBranchBadge', { branch: b.name })
+                      : b.name}
                 </span>
               ))}
             </span>

--- a/frontend/web/src/components/ContextView.tsx
+++ b/frontend/web/src/components/ContextView.tsx
@@ -99,7 +99,8 @@ type ContextWorkspace = Pick<Workspace, 'id' | 'owner_username' | 'slug' | 'visi
 export function ContextView({ repo, ws, role }: { repo: Repo; ws: ContextWorkspace | null; role: Role | null }) {
   // repo derivative state (excluding refs·stash snapshots·badges·graph sources) must use the same assembly point as the On Hold tab — if input splits, badge count = tab row count guarantee is broken.
   const t = useT();
-  const { refs, snapshots: allSnapshots, badges, graphSnapshots, committedSnapshots, uncommittedIds, localAhead } = useRepoView(repo.id);
+  const { refs, snapshots: allSnapshots, badges, graphSnapshots, committedSnapshots, uncommittedIds, localAhead } =
+    useRepoView(repo.id, repo.default_branch || 'main');
   const branches = useMemo(() => refs.filter((r) => r.kind === 'branch').map((r) => r.name).sort(), [refs]);
 
   const [branch, setBranch] = useState<string | null>(null);
@@ -279,10 +280,22 @@ export function ContextView({ repo, ws, role }: { repo: Repo; ws: ContextWorkspa
                   <span
                     key={b.kind + b.name}
                     className={`ref-badge ${isHead ? 'head' : b.kind}`}
-                    title={b.kind === 'archived' ? t('context.archivedBranchTitle') : undefined}
+                    title={
+                      b.kind === 'archived'
+                        ? t('context.archivedBranchTitle')
+                        : b.kind === 'joined'
+                          ? t('context.joinedBranchTitle')
+                          : undefined
+                    }
                   >
-                    {b.kind === 'tag' ? '⌂ ' : b.kind === 'archived' ? '⊟ ' : ''}
-                    {isHead ? '⌑ head' : b.kind === 'archived' ? t('context.archivedBranchBadge', { branch: b.name }) : b.name}
+                    {b.kind === 'tag' ? '⌂ ' : b.kind === 'archived' ? '⊟ ' : b.kind === 'joined' ? '⎘ ' : ''}
+                    {isHead
+                      ? '⌑ head'
+                      : b.kind === 'archived'
+                        ? t('context.archivedBranchBadge', { branch: b.name })
+                        : b.kind === 'joined'
+                          ? t('context.joinedBranchBadge', { branch: b.name })
+                          : b.name}
                   </span>
                 );
               })}

--- a/frontend/web/src/components/OnHoldView.tsx
+++ b/frontend/web/src/components/OnHoldView.tsx
@@ -32,7 +32,8 @@ export function OnHoldView({ repo, ws, role }: { repo: Repo; ws: Workspace | nul
   const me = useMe().data;
   // Repo derivative state is the same assembly point (useRepoView) as the context tab — excluding stash, badges, and graph.
   // If the source forks, the "badge count = tab row count" guarantee from the input phase breaks (review front #2).
-  const { refs, snapshots: allSnapshots, badges, graphSnapshots, committedSnapshots, uncommittedIds, localAhead } = useRepoView(repo.id);
+  const { refs, snapshots: allSnapshots, badges, graphSnapshots, committedSnapshots, uncommittedIds, localAhead } =
+    useRepoView(repo.id, repo.default_branch || 'main');
   const pendings = usePendings(repo.id).data ?? [];
   const unsyncs = useUnsyncs(repo.id).data ?? [];
   const dismissPending = useDismissPending();

--- a/frontend/web/src/graphStatus.ts
+++ b/frontend/web/src/graphStatus.ts
@@ -8,6 +8,7 @@ export interface GraphSnapshotStatus {
   uncommitted: Set<string>;
   archivedOnly: Set<string>;
   archivedBranches: number;
+  joined: BranchHistoryMarker[];
   archived: Array<{
     branch: string;
     target: string;
@@ -16,19 +17,51 @@ export interface GraphSnapshotStatus {
   }>;
 }
 
-/** Classifies every rendered graph snapshot into one workflow tier. Archived
- * history is a fourth, orthogonal lifecycle state, but only snapshots unique
- * to archived branches are collapsed; shared ancestors and appended history
- * remain visible in the active graph. */
+export interface BranchHistoryMarker {
+  branch: string;
+  target: string;
+  kind: 'joined' | 'archived';
+}
+
+/** A deleted Git ref is not necessarily archived context. If its recorded tip
+ * is reachable from the primary branch, the branch was joined and remains a
+ * named historical lane. Only tips outside that lineage are true archives. */
+export function classifyBranchHistoryMarkers(
+  refs: Ref[],
+  snapshots: Snapshot[],
+  primaryBranch?: string,
+): BranchHistoryMarker[] {
+  const branches = refs.filter((ref) => ref.kind === 'branch');
+  const primary =
+    (primaryBranch && branches.find((ref) => ref.name === primaryBranch)) ||
+    branches.find((ref) => ref.name === 'main') ||
+    branches.find((ref) => ref.name === 'master') ||
+    branches[0];
+  const primaryReachable = reachableSnapshotIds(primary ? [primary.target] : [], snapshots);
+  return archivedBranchMarkers(refs).map((marker) => ({
+    ...marker,
+    kind: primaryReachable.has(marker.target) ? 'joined' : 'archived',
+  }));
+}
+
+/** Classifies every rendered graph snapshot into one workflow tier. Joined
+ * branch history stays in the active graph; only snapshots unique to genuinely
+ * archived branches are collapsed. */
 export function classifyGraphSnapshots(
   refs: Ref[],
   snapshots: Snapshot[],
   uncommittedInput: ReadonlySet<string> = new Set<string>(),
+  primaryBranch?: string,
 ): GraphSnapshotStatus {
   const ids = new Set(snapshots.map((snapshot) => snapshot.id));
   const shared = sharedReachable(refs, snapshots);
-  const markers = archivedBranchMarkers(refs);
-  const archivedReachable = reachableSnapshotIds(markers.map((marker) => marker.target), snapshots);
+  const historyMarkers = classifyBranchHistoryMarkers(refs, snapshots, primaryBranch);
+  const joined = historyMarkers.filter((marker) => marker.kind === 'joined');
+  const archivedMarkers = historyMarkers.filter((marker) => marker.kind === 'archived');
+  const archivedReachable = reachableSnapshotIds(
+    archivedMarkers.map((marker) => marker.target),
+    snapshots,
+  );
   const activeRoots = refs
     .filter(
       (ref) =>
@@ -41,12 +74,13 @@ export function classifyGraphSnapshots(
   const archivedOnly = new Set(
     [...archivedReachable].filter((id) => ids.has(id) && !activeReachable.has(id)),
   );
-  const archived = markers.map((marker) => ({
-    ...marker,
-    uniqueCount: [...reachableSnapshotIds([marker.target], snapshots)].filter(
+  const archived = archivedMarkers.map(({ branch, target }) => ({
+    branch,
+    target,
+    uniqueCount: [...reachableSnapshotIds([target], snapshots)].filter(
       (id) => ids.has(id) && !activeReachable.has(id),
     ).length,
-    targetAvailable: ids.has(marker.target),
+    targetAvailable: ids.has(target),
   }));
   const uncommitted = new Set(
     [...uncommittedInput].filter((id) => ids.has(id) && !shared.has(id)),
@@ -64,5 +98,13 @@ export function classifyGraphSnapshots(
       )
       .map((snapshot) => snapshot.id),
   );
-  return { pushed, unpushed, uncommitted, archivedOnly, archivedBranches: markers.length, archived };
+  return {
+    pushed,
+    unpushed,
+    uncommitted,
+    archivedOnly,
+    archivedBranches: archived.length,
+    joined,
+    archived,
+  };
 }

--- a/frontend/web/src/hooks.ts
+++ b/frontend/web/src/hooks.ts
@@ -7,7 +7,8 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { api } from './api';
 import type { User } from './types';
 import { sharedReachable, unsyncChains } from './onhold';
-import { archivedBranchMarkers, parseBranchLifecycleRef, projectBranchRefs } from './branchLifecycle';
+import { parseBranchLifecycleRef, projectBranchRefs } from './branchLifecycle';
+import { classifyBranchHistoryMarkers } from './graphStatus';
 import { firebaseEnabled, devIdpToken, firebaseEmailIdToken, firebaseEmailSignUp, firebaseGoogleIdToken, firebaseSignOut } from './auth';
 import { useT } from './i18n';
 
@@ -291,7 +292,7 @@ export function useDismissPending() {
 // useRepoView — single assembly point for repo-derived states shared by context/On Hold views.
 // Ensure "badge count = tab row count" is guaranteed by logic (onhold.ts) and input equality, so
 // exclude stash, hook capture leaves, and badge map must be created here only (review front #2).
-export function useRepoView(repoId: string | null) {
+export function useRepoView(repoId: string | null, primaryBranch?: string) {
   const rawRefs = useRefs(repoId).data ?? [];
   const refs = useMemo(() => projectBranchRefs(rawRefs), [rawRefs]);
   const allData = useAllSnapshots(repoId, true).data;
@@ -312,13 +313,13 @@ export function useRepoView(repoId: string | null) {
       list.push({ name: r.name, kind: r.kind });
       m.set(r.target, list);
     }
-    for (const marker of archivedBranchMarkers(refs)) {
+    for (const marker of classifyBranchHistoryMarkers(refs, snapshots, primaryBranch)) {
       const list = m.get(marker.target) ?? [];
-      list.push({ name: marker.branch, kind: 'archived' });
+      list.push({ name: marker.branch, kind: marker.kind });
       m.set(marker.target, list);
     }
     return m;
-  }, [refs]);
+  }, [refs, snapshots, primaryBranch]);
   // Hook capture leaves (hook: prefix) are remnants of progress state — typically excluding graph/AI bar. However, hook snapshots reachable from branch refs (absorbed into commits or directly referenced by ref) are part of the history and are displayed. Just removing the label (message prefix) breaks the commit walk, causing the head to disappear from the graph — the pin line to break and its child pending to appear orphaned (stash-dedup trap, same principle: determination based on reachability).
   const sharedIds = useMemo(() => sharedReachable(refs, snapshots), [refs, snapshots]);
   const committedSnapshots = useMemo(

--- a/frontend/web/src/i18n/locales/en.ts
+++ b/frontend/web/src/i18n/locales/en.ts
@@ -80,6 +80,8 @@ export const en: Messages = {
     memoryBadgeTitle: 'Has a stored memory digest — select to inspect the snapshot archive',
     archivedBranchBadge: 'archived · {branch}',
     archivedBranchTitle: 'Context from a deleted Git branch — history is preserved and can be restored with cxt branch restore',
+    joinedBranchBadge: 'joined · {branch}',
+    joinedBranchTitle: 'Git branch joined into the default branch — its context lineage and name remain in the graph after the Git ref is deleted',
     compactSummary: 'Context compaction summary (agent-written)',
     cxtSeedSummary: 'cxt seed summary (auto-generated — inherited context)',
     branchOff: '⎇ branch off (checkout -b)',

--- a/frontend/web/src/i18n/locales/ko.ts
+++ b/frontend/web/src/i18n/locales/ko.ts
@@ -83,6 +83,8 @@ export const ko = {
     memoryBadgeTitle: '저장된 메모리 digest 보유 — 선택하면 이 스냅샷의 원본 기록을 표시합니다',
     archivedBranchBadge: '보관됨 · {branch}',
     archivedBranchTitle: '삭제된 Git 브랜치의 컨텍스트 — 이력은 보존되며 cxt branch restore로 복구할 수 있습니다',
+    joinedBranchBadge: '합류됨 · {branch}',
+    joinedBranchTitle: '기본 브랜치에 합류한 Git 브랜치 — Git ref가 삭제되어도 컨텍스트 계보와 브랜치 이름은 그래프에 남습니다',
     compactSummary: '컨텍스트 압축 요약 (에이전트 생성)',
     cxtSeedSummary: 'cxt 시드 요약 (자동 생성 — 상속 컨텍스트)',
     branchOff: '⎇ 분기 (checkout -b)',

--- a/frontend/web/src/styles.css
+++ b/frontend/web/src/styles.css
@@ -276,6 +276,7 @@ button.copy.done { color: var(--ok); border-color: var(--ok); }
   border-radius: 99px; border: 1px solid var(--line); color: var(--muted); white-space: nowrap; }
 .ref-badge.branch { color: var(--ok); border-color: rgba(46, 125, 91, 0.35); }
 .ref-badge.tag { color: var(--ink); border-color: var(--faint); }
+.ref-badge.joined { color: #b77700; border-color: rgba(210, 153, 34, 0.45); border-style: dashed; }
 .ref-badge.archived { color: var(--faint); border-color: var(--faint); border-style: dashed; }
 /* Current branch tip — branch name is already provided in the dropdown (fill style = current position). */
 .ref-badge.head { background: var(--ok); border-color: var(--ok); color: #fff; }

--- a/frontend/web/tests/graph-status.test.ts
+++ b/frontend/web/tests/graph-status.test.ts
@@ -31,6 +31,7 @@ assert.deepEqual([...status.unpushed], [unpushed]);
 assert.deepEqual([...status.uncommitted], [uncommitted]);
 assert.deepEqual([...status.archivedOnly], [archived]);
 assert.equal(status.archivedBranches, 1);
+assert.deepEqual(status.joined, []);
 assert.deepEqual(status.archived, [
   { branch: 'feature/old', target: archived, uniqueCount: 1, targetAvailable: true },
 ]);
@@ -76,8 +77,12 @@ const graftRefs: Ref[] = [
   { kind: 'branch', name: 'main', repo_id: 'repo', target: graftedHead },
   refs[1],
 ];
-const graftStatus = classifyGraphSnapshots(graftRefs, graftSnapshots);
+const graftStatus = classifyGraphSnapshots(graftRefs, graftSnapshots, new Set(), 'main');
 assert.equal(graftStatus.pushed.has(archived), true, 'graft-reachable archived history stays visible');
 assert.equal(graftStatus.archivedOnly.has(archived), false, 'active graft history must not collapse');
-assert.equal(graftStatus.archived[0]?.uniqueCount, 0, 'fully shared archived history remains discoverable');
+assert.deepEqual(graftStatus.joined, [
+  { branch: 'feature/old', target: archived, kind: 'joined' },
+], 'a deleted source ref whose tip is on main is a joined historical branch');
+assert.deepEqual(graftStatus.archived, [], 'joined branches must not appear in the archive panel');
+assert.equal(graftStatus.archivedBranches, 0);
 assert.deepEqual([...graftStatus.unpushed], [localAboveGraft]);


### PR DESCRIPTION
## Summary
- classify deleted Git refs as joined history when their context tip remains reachable from the default branch
- keep joined branch names and lane styling visible instead of rendering them as archived/crossed out
- reserve the archive panel for context branches that are genuinely outside the default-branch lineage

## Verification
- `npm test`
- `npm run typecheck`
- `npm run check:i18n`
- `npm run build`
- `npm run test:e2e` (11 passed, 1 full-stack smoke skipped locally)