### PR TITLE
Fix global hook activation in uninitialized repositories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and releases follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Keep global Codex and Claude lifecycle hooks inert in Git repositories that
+  have not run `cxt init` or `cxt setup`.
+- Preserve and quarantine directory-only `.cxt` residue from older hooks while
+  automatically registering `.cxt/` and `.cxtsecrets` in Git ignore files.
+
 ## [0.1.1] - 2026-07-29
 
 ### Changed

--- a/cli/internal/adapters/capture/app_sessions_test.go
+++ b/cli/internal/adapters/capture/app_sessions_test.go
@@ -40,6 +40,9 @@ func TestAppSessionRegistryIsWorktreeScopedAndNonDestructive(t *testing.T) {
 	if err := os.Mkdir(filepath.Join(primary, ".cxt"), 0o755); err != nil {
 		t.Fatal(err)
 	}
+	if err := os.WriteFile(filepath.Join(primary, ".cxt", "HEAD"), []byte("ref: refs/heads/main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	const primaryID = "claude-app-thread"
 	const linkedID = "codex-app-thread"

--- a/cli/internal/adapters/capture/coordinator_test.go
+++ b/cli/internal/adapters/capture/coordinator_test.go
@@ -227,6 +227,9 @@ func TestLinkedWorktreeCaptureUsesSharedStore(t *testing.T) {
 	if err := os.Mkdir(filepath.Join(primary, ".cxt"), 0o755); err != nil {
 		t.Fatal(err)
 	}
+	if err := os.WriteFile(filepath.Join(primary, ".cxt", "HEAD"), []byte("ref: refs/heads/main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	captureGitRun(t, primary, "worktree", "add", "-b", "app/session", linked)
 	primary, _ = filepath.EvalSymlinks(primary)
 	linked, _ = filepath.EvalSymlinks(linked)

--- a/cli/internal/adapters/capture/handoff_test.go
+++ b/cli/internal/adapters/capture/handoff_test.go
@@ -20,6 +20,9 @@ func TestSessionHandoffsAreIsolatedAndConsumedOnce(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(repo, ".cxt"), 0o755); err != nil {
 		t.Fatal(err)
 	}
+	if err := os.WriteFile(filepath.Join(repo, ".cxt", "HEAD"), []byte("ref: refs/heads/main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	const (
 		first  = "11111111-1111-4111-8111-111111111111"
 		second = "22222222-2222-4222-8222-222222222222"
@@ -45,6 +48,9 @@ func TestSessionHandoffWorktreeFallback(t *testing.T) {
 		t.Fatalf("git init: %v\n%s", err, out)
 	}
 	if err := os.MkdirAll(filepath.Join(repo, ".cxt"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, ".cxt", "HEAD"), []byte("ref: refs/heads/main\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	if err := WriteSessionHandoff(repo, nil, "fallback memory"); err != nil {

--- a/cli/internal/adapters/capture/session_affinity_test.go
+++ b/cli/internal/adapters/capture/session_affinity_test.go
@@ -57,6 +57,9 @@ func TestSessionAffinityUsesSharedStoreFromLinkedWorktree(t *testing.T) {
 	if err := os.Mkdir(filepath.Join(primary, ".cxt"), 0o755); err != nil {
 		t.Fatal(err)
 	}
+	if err := os.WriteFile(filepath.Join(primary, ".cxt", "HEAD"), []byte("ref: refs/heads/main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	const id = "44444444-4444-4444-8444-444444444444"
 	RecordSessionAffinity(primary, domain.ProviderCodex, id)

--- a/cli/internal/adapters/delivery/cli/githook.go
+++ b/cli/internal/adapters/delivery/cli/githook.go
@@ -31,6 +31,7 @@ import (
 	"github.com/wnsdy95/cxthub/cli/internal/adapters/boundary"
 	"github.com/wnsdy95/cxthub/cli/internal/adapters/capture"
 	"github.com/wnsdy95/cxthub/cli/internal/adapters/gitctx"
+	"github.com/wnsdy95/cxthub/cli/internal/adapters/githooks"
 	"github.com/wnsdy95/cxthub/cli/internal/adapters/providerfs"
 	"github.com/wnsdy95/cxthub/cli/internal/adapters/remotecfg"
 	"github.com/wnsdy95/cxthub/cli/internal/domain"
@@ -894,7 +895,18 @@ func runGitHook(ctx context.Context, c *Container, cwd string, rest []string) er
 		return nil
 	}
 	event, args := rest[0], rest[1:]
-	repoRoot := cxtRepoRoot(ctx, cwd)
+	// Git hooks can outlive a removed/partial cxt setup. Repair ignore rules for
+	// any existing directory, but never interpret directory presence alone as
+	// permission to capture. cxt init/setup writes .cxt/HEAD before hooks exist.
+	state := gitctx.InspectContextRoot(ctx, cwd)
+	if !state.GitRepository || !state.Exists {
+		return nil
+	}
+	_ = githooks.EnsureIgnored(state.Root)
+	if !state.Initialized {
+		return nil
+	}
+	repoRoot := state.Root
 
 	switch event {
 	case "ref-prepare":

--- a/cli/internal/adapters/delivery/cli/githook_activation_test.go
+++ b/cli/internal/adapters/delivery/cli/githook_activation_test.go
@@ -1,0 +1,79 @@
+package cli
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func activationTestGit(t *testing.T, cwd string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", cwd}, args...)...)
+	cmd.Env = append(os.Environ(), "GIT_CONFIG_NOSYSTEM=1")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func TestGitHookDoesNotCreateUnconnectedStore(t *testing.T) {
+	repo := t.TempDir()
+	activationTestGit(t, repo, "init", "-b", "main")
+
+	if err := runGitHook(context.Background(), &Container{}, repo, []string{"post-commit"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Lstat(filepath.Join(repo, ".cxt")); !os.IsNotExist(err) {
+		t.Fatalf("git hook created an unconnected .cxt store: %v", err)
+	}
+}
+
+func TestGitHookQuarantinesDirectoryOnlyResidue(t *testing.T) {
+	repo := t.TempDir()
+	activationTestGit(t, repo, "init", "-b", "main")
+	residue := filepath.Join(repo, ".cxt", "capture")
+	if err := os.MkdirAll(residue, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	legacy := filepath.Join(residue, "legacy.turn")
+	if err := os.WriteFile(legacy, []byte("keep me\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// The nil service container is intentional: directory-only residue must be
+	// rejected before an event reaches any context use case.
+	if err := runGitHook(context.Background(), &Container{}, repo, []string{"post-commit"}); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := os.ReadFile(legacy); err != nil || string(got) != "keep me\n" {
+		t.Fatalf("legacy residue was mutated: %q, %v", got, err)
+	}
+	if _, err := os.Stat(filepath.Join(repo, ".cxt", "HEAD")); !os.IsNotExist(err) {
+		t.Fatalf("git hook promoted residue into an initialized store: %v", err)
+	}
+	ignore, err := os.ReadFile(filepath.Join(repo, ".gitignore"))
+	if err != nil || !strings.Contains(string(ignore), ".cxt/") {
+		t.Fatalf(".gitignore was not repaired: %q, %v", ignore, err)
+	}
+	if got := activationTestGit(t, repo, "check-ignore", ".cxt/probe"); got == "" {
+		t.Fatal("legacy .cxt residue remains visible to git")
+	}
+}
+
+func TestHooksInstallRequiresInitializedStore(t *testing.T) {
+	repo := t.TempDir()
+	activationTestGit(t, repo, "init", "-b", "main")
+	t.Chdir(repo)
+
+	err := Run(&Container{}, []string{"cxt", "hooks", "install"})
+	if err == nil || !strings.Contains(err.Error(), "run 'cxt init' first") {
+		t.Fatalf("hooks install error = %v", err)
+	}
+	if _, statErr := os.Lstat(filepath.Join(repo, ".cxt")); !os.IsNotExist(statErr) {
+		t.Fatalf("hooks install created an uninitialized store: %v", statErr)
+	}
+}

--- a/cli/internal/adapters/delivery/cli/githook_app_test.go
+++ b/cli/internal/adapters/delivery/cli/githook_app_test.go
@@ -92,6 +92,9 @@ func TestUnmanagedAppBranchSwitchPreservesProviderSession(t *testing.T) {
 	if err := os.Mkdir(filepath.Join(repo, ".cxt"), 0o755); err != nil {
 		t.Fatal(err)
 	}
+	if err := os.WriteFile(filepath.Join(repo, ".cxt", "HEAD"), []byte("ref: refs/heads/main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	const sessionID = "12345678-1234-4abc-8def-1234567890ab"
 	sessionDir := filepath.Join(home, ".codex", "sessions", "2026", "08", "31")

--- a/cli/internal/adapters/delivery/cli/githook_briefing_test.go
+++ b/cli/internal/adapters/delivery/cli/githook_briefing_test.go
@@ -273,6 +273,9 @@ func newPostMergeBriefingRepo(t *testing.T) string {
 	if err := os.MkdirAll(filepath.Join(repo, ".cxt"), 0o755); err != nil {
 		t.Fatal(err)
 	}
+	if err := os.WriteFile(filepath.Join(repo, ".cxt", "HEAD"), []byte("ref: refs/heads/main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	t.Setenv("CXT_REMOTE", "https://cxthub.test/acme/project")
 	return repo
 }

--- a/cli/internal/adapters/delivery/cli/root.go
+++ b/cli/internal/adapters/delivery/cli/root.go
@@ -25,6 +25,7 @@ import (
 	"github.com/wnsdy95/cxthub/cli/internal/adapters/authcfg"
 	"github.com/wnsdy95/cxthub/cli/internal/adapters/backendclient"
 	"github.com/wnsdy95/cxthub/cli/internal/adapters/capture"
+	"github.com/wnsdy95/cxthub/cli/internal/adapters/gitctx"
 	"github.com/wnsdy95/cxthub/cli/internal/adapters/githooks"
 	"github.com/wnsdy95/cxthub/cli/internal/adapters/providerfs"
 	"github.com/wnsdy95/cxthub/cli/internal/adapters/remotecfg"
@@ -598,6 +599,13 @@ func Run(c *Container, args []string) error {
 	case "hooks":
 		switch firstPositional(rest) {
 		case "install":
+			state := gitctx.InspectContextRoot(ctx, cwd)
+			if state.GitRepository && state.Exists {
+				_ = githooks.EnsureIgnored(state.Root)
+			}
+			if !state.GitRepository || !state.Initialized {
+				return fmt.Errorf("cxt repository is not initialized — run 'cxt init' first")
+			}
 			installed, err := githooks.Install(cwd)
 			if err != nil {
 				return err

--- a/cli/internal/adapters/delivery/hook/handler.go
+++ b/cli/internal/adapters/delivery/hook/handler.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/wnsdy95/cxthub/cli/internal/adapters/capture"
 	"github.com/wnsdy95/cxthub/cli/internal/adapters/gitctx"
+	"github.com/wnsdy95/cxthub/cli/internal/adapters/githooks"
 	"github.com/wnsdy95/cxthub/cli/internal/adapters/remotecfg"
 	"github.com/wnsdy95/cxthub/cli/internal/domain"
 )
@@ -93,6 +94,23 @@ func (h *Handler) Run(provider domain.ProviderKind, event string) error {
 		path = p.RolloutPath
 	}
 
+	// Codex hooks are registered globally, so they run in every repository.
+	// Repair ignore rules for any existing store (including legacy residue),
+	// then require cxt init/setup's durable HEAD marker before writing capture
+	// state. A bare .cxt directory is not user opt-in.
+	switch event {
+	case "SessionStart", "UserPromptSubmit", "Stop", "SessionEnd":
+	default:
+		return nil
+	}
+	state := gitctx.InspectContextRoot(ctx, cwd)
+	if state.GitRepository && state.Exists {
+		_ = githooks.EnsureIgnored(state.Root)
+	}
+	if !state.GitRepository || !state.Initialized {
+		return nil
+	}
+
 	switch event {
 	case "SessionStart":
 		_ = capture.TrackAppSession(cwd, provider, p.SessionID, path)
@@ -118,9 +136,8 @@ func (h *Handler) Run(provider domain.ProviderKind, event string) error {
 			spawnPendingSync(cwd)
 		}
 		return err
-	default:
-		return nil
 	}
+	return nil
 }
 
 // emitBriefing consumes the current terminal's identifier-only team context

--- a/cli/internal/adapters/delivery/hook/handler_test.go
+++ b/cli/internal/adapters/delivery/hook/handler_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -21,10 +22,85 @@ func (r *recSave) Save(_ context.Context, in inbound.SaveInput) (inbound.SaveOut
 	return inbound.SaveOutput{SnapshotID: "sha256:x", Branch: "main"}, nil
 }
 
+func hookTestGit(t *testing.T, cwd string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", cwd}, args...)...)
+	cmd.Env = append(os.Environ(), "GIT_CONFIG_NOSYSTEM=1")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func initHookContext(t *testing.T, repo string) {
+	t.Helper()
+	hookTestGit(t, repo, "init", "-b", "main")
+	if err := os.MkdirAll(filepath.Join(repo, ".cxt"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, ".cxt", "HEAD"), []byte("ref: refs/heads/main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestGlobalAgentHookDoesNotCreateStoreInUnconnectedGitRepository(t *testing.T) {
+	repo := t.TempDir()
+	hookTestGit(t, repo, "init", "-b", "main")
+	rs := &recSave{}
+	h := NewHandler(capture.NewCaptureCoordinator(rs, domain.TeamIdentity{}))
+	h.stdin = strings.NewReader(`{"session_id":"unconnected","cwd":"` + repo + `","prompt":"continue"}`)
+	if err := h.Run(domain.ProviderCodex, "UserPromptSubmit"); err != nil {
+		t.Fatal(err)
+	}
+	if len(rs.calls) != 0 {
+		t.Fatalf("unconnected repository captured: %+v", rs.calls)
+	}
+	if _, err := os.Lstat(filepath.Join(repo, ".cxt")); !os.IsNotExist(err) {
+		t.Fatalf("global agent hook created .cxt: %v", err)
+	}
+}
+
+func TestGlobalAgentHookQuarantinesDirectoryOnlyResidue(t *testing.T) {
+	repo := t.TempDir()
+	hookTestGit(t, repo, "init", "-b", "main")
+	residue := filepath.Join(repo, ".cxt", "capture")
+	if err := os.MkdirAll(residue, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	legacy := filepath.Join(residue, "legacy.turn")
+	if err := os.WriteFile(legacy, []byte("keep me\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	rs := &recSave{}
+	h := NewHandler(capture.NewCaptureCoordinator(rs, domain.TeamIdentity{}))
+	h.stdin = strings.NewReader(`{"session_id":"legacy-residue","cwd":"` + repo + `","prompt":"must not capture"}`)
+	if err := h.Run(domain.ProviderCodex, "UserPromptSubmit"); err != nil {
+		t.Fatal(err)
+	}
+	if len(rs.calls) != 0 {
+		t.Fatalf("directory-only residue captured: %+v", rs.calls)
+	}
+	if _, err := os.Stat(filepath.Join(repo, ".cxt", "HEAD")); !os.IsNotExist(err) {
+		t.Fatalf("hook promoted residue into an initialized store: %v", err)
+	}
+	if got, err := os.ReadFile(legacy); err != nil || string(got) != "keep me\n" {
+		t.Fatalf("legacy residue was mutated: %q, %v", got, err)
+	}
+	ignore, err := os.ReadFile(filepath.Join(repo, ".gitignore"))
+	if err != nil || !strings.Contains(string(ignore), ".cxt/") {
+		t.Fatalf(".gitignore was not repaired: %q, %v", ignore, err)
+	}
+	if got := hookTestGit(t, repo, "check-ignore", ".cxt/probe"); got == "" {
+		t.Fatal("legacy .cxt residue remains visible to git")
+	}
+}
+
 // TestHandlerStopWithPayload fixes the flow where Stop capture continues from the transcript path/cwd (capture path — detection omission path).
 func TestHandlerStopWithPayload(t *testing.T) {
 	cwd := t.TempDir()
-	_ = os.MkdirAll(filepath.Join(cwd, ".cxt"), 0o755)
+	initHookContext(t, cwd)
 	session := filepath.Join(t.TempDir(), "s.jsonl")
 	if err := os.WriteFile(session, []byte("{}\n"), 0o644); err != nil {
 		t.Fatal(err)
@@ -43,7 +119,7 @@ func TestHandlerStopWithPayload(t *testing.T) {
 // TestHandlerPromptHint fixes the flow from UserPromptSubmit to the next capture message hint.
 func TestHandlerPromptHint(t *testing.T) {
 	cwd := t.TempDir()
-	_ = os.MkdirAll(filepath.Join(cwd, ".cxt"), 0o755)
+	initHookContext(t, cwd)
 	session := filepath.Join(t.TempDir(), "s.jsonl")
 	_ = os.WriteFile(session, []byte("{}\n"), 0o644)
 	rs := &recSave{}
@@ -80,7 +156,7 @@ func TestHandlerUnknownEventNoop(t *testing.T) {
 // The UserPromptSubmit hook consumes its scoped briefing queue and outputs hookSpecificOutput JSON to stdout (model transmission channel), and in the second utterance, nothing is output.
 func TestHandlerBriefingEmission(t *testing.T) {
 	cwd := t.TempDir()
-	_ = os.MkdirAll(filepath.Join(cwd, ".cxt"), 0o755)
+	initHookContext(t, cwd)
 	noticeID := domain.HashContent([]byte("handler pull briefing"))
 	if err := capture.WritePullBriefing(cwd, "main", []domain.ContentHash{noticeID}); err != nil {
 		t.Fatal(err)
@@ -122,7 +198,7 @@ func TestHandlerBriefingEmission(t *testing.T) {
 
 func TestHandlerEmitsOnlyMatchingAppSessionHandoff(t *testing.T) {
 	cwd := t.TempDir()
-	_ = os.MkdirAll(filepath.Join(cwd, ".cxt"), 0o755)
+	initHookContext(t, cwd)
 	const (
 		first  = "11111111-1111-4111-8111-111111111111"
 		second = "22222222-2222-4222-8222-222222222222"
@@ -153,9 +229,7 @@ func TestHandlerTracksOpaqueAppSessionUntilSessionEnd(t *testing.T) {
 	cwd := t.TempDir()
 	home := t.TempDir()
 	t.Setenv("HOME", home)
-	if err := os.MkdirAll(filepath.Join(cwd, ".cxt"), 0o755); err != nil {
-		t.Fatal(err)
-	}
+	initHookContext(t, cwd)
 	const hookSessionID = "codex-thread-opaque-id"
 	const nativeID = "33333333-3333-4333-8333-333333333333"
 	dir := filepath.Join(home, ".codex", "sessions", "2026", "08", "31")

--- a/cli/internal/adapters/gitctx/repository_roots.go
+++ b/cli/internal/adapters/gitctx/repository_roots.go
@@ -49,27 +49,85 @@ func ResolveRepositoryRoots(ctx context.Context, cwd string) (RepositoryRoots, e
 	return RepositoryRoots{WorktreeRoot: worktree, SharedRoot: canonicalRoot(shared)}, nil
 }
 
-// ContextRoot returns the real directory that owns an initialized .cxt store.
-// The primary worktree wins when both a primary and linked worktree contain
-// state, preventing a split repository. Outside Git, the exact cwd retains the
-// legacy opt-in behavior used by isolated adapters and tests.
-func ContextRoot(ctx context.Context, cwd string) (string, bool) {
+// contextRootCandidates returns the primary and linked-worktree locations that
+// may own cxt state. The primary worktree is checked first so repository-wide
+// state cannot silently split across linked worktrees.
+func contextRootCandidates(ctx context.Context, cwd string) ([]string, bool) {
 	candidates := []string{}
 	if roots, err := ResolveRepositoryRoots(ctx, cwd); err == nil {
 		candidates = append(candidates, roots.SharedRoot)
 		if roots.WorktreeRoot != roots.SharedRoot {
 			candidates = append(candidates, roots.WorktreeRoot)
 		}
+		return candidates, true
 	} else {
 		candidates = append(candidates, canonicalRoot(cwd))
 	}
-	for _, root := range candidates {
-		info, err := os.Lstat(filepath.Join(root, ".cxt"))
-		if err == nil && info.Mode()&os.ModeSymlink == 0 && info.IsDir() {
-			return root, true
+	return candidates, false
+}
+
+func regularPath(path string) bool {
+	info, err := os.Lstat(path)
+	return err == nil && info.Mode()&os.ModeSymlink == 0 && info.Mode().IsRegular()
+}
+
+func contextDirectory(root string) bool {
+	info, err := os.Lstat(filepath.Join(root, ".cxt"))
+	return err == nil && info.Mode()&os.ModeSymlink == 0 && info.IsDir()
+}
+
+// ContextRootState separates harmless directory residue from an initialized
+// context store without resolving Git roots more than once on hook hot paths.
+type ContextRootState struct {
+	Root          string
+	Exists        bool
+	Initialized   bool
+	GitRepository bool
+}
+
+// InspectContextRoot resolves the preferred initialized store first, then a
+// directory-only residue location for ignore migration. Outside Git, an
+// existing directory retains the isolated-adapter opt-in behavior.
+func InspectContextRoot(ctx context.Context, cwd string) ContextRootState {
+	candidates, gitRepo := contextRootCandidates(ctx, cwd)
+	if gitRepo {
+		for _, root := range candidates {
+			if contextDirectory(root) && regularPath(filepath.Join(root, ".cxt", "HEAD")) {
+				return ContextRootState{Root: root, Exists: true, Initialized: true, GitRepository: true}
+			}
 		}
 	}
-	return "", false
+	for _, root := range candidates {
+		if contextDirectory(root) {
+			return ContextRootState{
+				Root: root, Exists: true, Initialized: !gitRepo, GitRepository: gitRepo,
+			}
+		}
+	}
+	return ContextRootState{GitRepository: gitRepo}
+}
+
+// ExistingContextRoot returns a real .cxt directory even when it is only
+// residue from an old/global hook and was never initialized. Callers use this
+// solely for safe migration tasks such as adding ignore rules; it must not be
+// used as permission to capture or mutate context state.
+func ExistingContextRoot(ctx context.Context, cwd string) (string, bool) {
+	state := InspectContextRoot(ctx, cwd)
+	return state.Root, state.Exists
+}
+
+// ContextRoot returns the real directory that owns an initialized .cxt store.
+// A directory alone is not initialization: global Codex/Claude hooks run in
+// every repository, and legacy versions could leave capture sidecars behind.
+// cxt init/setup always writes .cxt/HEAD before installing hooks, making HEAD
+// the durable opt-in marker. Outside Git, the directory-only behavior remains
+// for isolated adapter use; production capture is Git-repository scoped.
+func ContextRoot(ctx context.Context, cwd string) (string, bool) {
+	state := InspectContextRoot(ctx, cwd)
+	if !state.Initialized {
+		return "", false
+	}
+	return state.Root, true
 }
 
 func canonicalRoot(path string) string {

--- a/cli/internal/adapters/gitctx/repository_roots_test.go
+++ b/cli/internal/adapters/gitctx/repository_roots_test.go
@@ -40,6 +40,9 @@ func TestResolveRepositoryRootsSharesPrimaryContextWithLinkedWorktree(t *testing
 	if err := os.Mkdir(filepath.Join(primary, ".cxt"), 0o755); err != nil {
 		t.Fatal(err)
 	}
+	if err := os.WriteFile(filepath.Join(primary, ".cxt", "HEAD"), []byte("ref: refs/heads/main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	gitTestRun(t, primary, "worktree", "add", "-b", "app/session", linked)
 	primary = canonicalRoot(primary)
 	linked = canonicalRoot(linked)
@@ -65,6 +68,28 @@ func TestResolveRepositoryRootsSharesPrimaryContextWithLinkedWorktree(t *testing
 	}
 	if repo.LocalPath != primary {
 		t.Fatalf("repo local path=%q, want shared root %q", repo.LocalPath, primary)
+	}
+}
+
+func TestContextRootRequiresInitializedHeadInGitRepository(t *testing.T) {
+	repo := t.TempDir()
+	gitTestRun(t, repo, "init", "-b", "main")
+	if err := os.Mkdir(filepath.Join(repo, ".cxt"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if root, ok := ExistingContextRoot(context.Background(), repo); !ok || root != canonicalRoot(repo) {
+		t.Fatalf("existing root=%q ok=%v, want residue root %q", root, ok, canonicalRoot(repo))
+	}
+	if root, ok := ContextRoot(context.Background(), repo); ok || root != "" {
+		t.Fatalf("directory-only residue enabled capture: root=%q ok=%v", root, ok)
+	}
+
+	if err := os.WriteFile(filepath.Join(repo, ".cxt", "HEAD"), []byte("ref: refs/heads/main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if root, ok := ContextRoot(context.Background(), repo); !ok || root != canonicalRoot(repo) {
+		t.Fatalf("initialized root=%q ok=%v, want %q", root, ok, canonicalRoot(repo))
 	}
 }
 

--- a/cli/internal/adapters/githooks/githooks.go
+++ b/cli/internal/adapters/githooks/githooks.go
@@ -119,6 +119,9 @@ func Install(repoRoot string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
+	if err := EnsureIgnored(repoRoot); err != nil {
+		return nil, err
+	}
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return nil, err
 	}
@@ -174,6 +177,19 @@ func Uninstall(repoRoot string) error {
 var cxtIgnoreEntries = []string{
 	".cxt/",       // local context store (snapshots, objects, rewrite map, backup stack)
 	".cxtsecrets", // list of secret values (plaintext) — forbidden in git and cxthub
+}
+
+// EnsureIgnored attempts both the repository-shared and local-only ignore
+// defenses. One successful defense is sufficient to keep Git clean (a
+// read-only or symlinked project .gitignore must not disable otherwise-safe
+// hooks). Lifecycle hooks call this for initialized stores and legacy residue.
+func EnsureIgnored(repoRoot string) error {
+	_, gitignoreErr := EnsureGitignore(repoRoot)
+	excludeErr := EnsureExcluded(repoRoot)
+	if gitignoreErr != nil && excludeErr != nil {
+		return fmt.Errorf("update .gitignore: %v; update git exclude: %w", gitignoreErr, excludeErr)
+	}
+	return nil
 }
 
 // EnsureGitignore appends the cxt commit prohibition list to the bottom of .gitignore.

--- a/cli/internal/adapters/githooks/githooks_security_test.go
+++ b/cli/internal/adapters/githooks/githooks_security_test.go
@@ -78,6 +78,52 @@ func TestInstallRefusesSymlinkedHookTarget(t *testing.T) {
 	}
 }
 
+func TestInstallRegistersCxtIgnoreRules(t *testing.T) {
+	repo := t.TempDir()
+	if out, err := exec.Command("git", "init", "-q", repo).CombinedOutput(); err != nil {
+		t.Skipf("git init unavailable: %v (%s)", err, out)
+	}
+	if _, err := Install(repo); err != nil {
+		t.Fatal(err)
+	}
+	gitignore, err := os.ReadFile(filepath.Join(repo, ".gitignore"))
+	if err != nil || !strings.Contains(string(gitignore), ".cxt/") || !strings.Contains(string(gitignore), ".cxtsecrets") {
+		t.Fatalf("tracked ignore rules = %q, %v", gitignore, err)
+	}
+	excludePath, err := exec.Command("git", "-C", repo, "rev-parse", "--path-format=absolute", "--git-path", "info/exclude").Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+	exclude, err := os.ReadFile(strings.TrimSpace(string(excludePath)))
+	if err != nil || !strings.Contains(string(exclude), ".cxt/") || !strings.Contains(string(exclude), ".cxtsecrets") {
+		t.Fatalf("local exclude rules = %q, %v", exclude, err)
+	}
+}
+
+func TestInstallFallsBackToLocalExcludeForSymlinkedGitignore(t *testing.T) {
+	repo := t.TempDir()
+	if out, err := exec.Command("git", "init", "-q", repo).CombinedOutput(); err != nil {
+		t.Skipf("git init unavailable: %v (%s)", err, out)
+	}
+	outside := filepath.Join(t.TempDir(), "outside-ignore")
+	if err := os.WriteFile(outside, []byte("keep\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(repo, ".gitignore")); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	if _, err := Install(repo); err != nil {
+		t.Fatalf("safe local exclude fallback failed: %v", err)
+	}
+	if got, err := os.ReadFile(outside); err != nil || string(got) != "keep\n" {
+		t.Fatalf("symlink target changed: %q, %v", got, err)
+	}
+	cmd := exec.Command("git", "-C", repo, "check-ignore", ".cxt/probe")
+	if out, err := cmd.CombinedOutput(); err != nil || !strings.Contains(string(out), ".cxt/probe") {
+		t.Fatalf("local exclude did not protect .cxt: %v (%s)", err, out)
+	}
+}
+
 func TestHookScriptQuotesExecutablePathForShell(t *testing.T) {
 	dir := t.TempDir()
 	marker := filepath.Join(dir, "injected")

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -76,6 +76,12 @@ the exact session and linked worktree, and CXTHub stores all worktrees in the
 primary repository's shared `.cxt`. Concurrent app sessions retain independent
 capture cursors and pending pointers.
 
+Codex's provider hook is global, but cxt activation is not. A Git repository is
+capture-enabled only after `cxt init` or `cxt setup` creates `.cxt/HEAD`.
+Directory-only residue from older hooks is kept intact and automatically added
+to both `.gitignore` and `.git/info/exclude`; it is not treated as an initialized
+context store.
+
 ## Repository and authentication
 
 ### `cxt init`
@@ -547,6 +553,8 @@ post-rewrite
 ```
 
 Existing user hooks are chained and restored on uninstall.
+Installation requires an initialized store (`cxt init` or `cxt setup`) and
+repairs both `.gitignore` and `.git/info/exclude` before writing hook scripts.
 
 After `git pull` or merge, the post-merge hook first fetches new team context
 without moving the active local context ref. A merged branch context is then

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -161,6 +161,13 @@ Code settings are written under the repository's `.claude/` directory. Codex
 hooks are merged into `~/.codex/hooks.json`; Codex may require a one-time `/hooks`
 approval.
 
+The Codex hook registration is global, but capture remains repository opt-in.
+Only `cxt init` or `cxt setup` writes the `.cxt/HEAD` activation marker. In any
+other Git repository the hook is a no-op and does not create `.cxt`. If a
+legacy version left a partial `.cxt` directory behind, the next hook preserves
+its contents, adds `.cxt/` and `.cxtsecrets` to `.gitignore` and
+`.git/info/exclude`, and leaves capture disabled until explicit initialization.
+
 Those lifecycle hooks apply to both provider CLIs and supported app surfaces:
 
 - Codex app and Codex IDE sessions that emit Codex lifecycle hooks;

--- a/scripts/e2e-sync.sh
+++ b/scripts/e2e-sync.sh
@@ -9,6 +9,7 @@
 #   D. repo2 commits new session C                              → session boundary metadata
 #   E. repo1 runs post-merge                                    → fetch-only, preserving local refs
 #   F. repo1 pushes after both sides moved                      → automatic rebase-graft
+#   J2. global app hooks in unconnected repositories            → no store creation + residue quarantine
 #   K. oversized single event                                  → v2 bounded push/pull + v1 fallback
 #
 # Run with isolated TMP, HOME, and a randomized port; no local state is retained.
@@ -486,6 +487,20 @@ cxt setup --no-login >"$TMP/setup2.out" 2>&1
 H2=$(shasum "$HOME/.codex/hooks.json" .claude/settings.json | shasum)
 expect "setup idempotence: hook file unchanged" "$H2" "$H1"
 expect "setup idempotence: already registered reported" "$(grep -c 'already registered' "$TMP/setup2.out")" 2
+
+echo "── J2. Global app hook: unconnected no-op + legacy residue quarantine"
+mkdir -p "$TMP/unconnected"; cd "$TMP/unconnected"; git init -q
+printf '%s' "{\"session_id\":\"unconnected\",\"cwd\":\"$TMP/unconnected\",\"prompt\":\"continue\"}" |
+  cxt hook --provider codex --event UserPromptSubmit
+expect "global app hook does not create .cxt before init" "$([ ! -e .cxt ] && echo yes)" yes
+
+mkdir -p "$TMP/residue"; cd "$TMP/residue"; git init -q; mkdir -p .cxt/capture
+printf '%s' "{\"session_id\":\"legacy-residue\",\"cwd\":\"$TMP/residue\",\"prompt\":\"continue\"}" |
+  cxt hook --provider codex --event UserPromptSubmit
+expect "directory-only residue is not promoted to an initialized store" "$([ ! -e .cxt/HEAD ] && echo yes)" yes
+expect "directory-only residue receives tracked ignore protection" "$(grep -c '^\.cxt/$' .gitignore 2>/dev/null)" 1
+expect "directory-only residue receives local ignore protection" "$(git check-ignore .cxt/probe 2>/dev/null | grep -c '^\.cxt/probe$')" 1
+expect "directory-only residue does not grow capture state" "$(find .cxt -type f | wc -l | tr -d ' ')" 0
 
 echo "── K. Chunk CAS v2: oversized event push/pull + old-client fallback"
 git clone -q "$TMP/bare.git" "$TMP/repo4"


### PR DESCRIPTION
## Summary

- require the durable .cxt/HEAD marker before provider or managed Git hooks can capture
- keep global Codex/Claude hooks inert in uninitialized Git repositories
- preserve directory-only legacy residue while repairing .gitignore and .git/info/exclude
- require cxt init/setup before manual Git-hook installation
- retain linked-worktree sharing and add unit, race, real-binary, and sync E2E coverage

## Verification

- go test ./... (CLI)
- go vet ./... (CLI)
- targeted go test -race
- bash scripts/e2e-sync.sh
- bash scripts/public-preflight.sh tree
- real binary: fresh, residue-only, and initialized Git repositories

Closes #141