### PR TITLE
Make remote MCP the product default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,6 +118,7 @@ Thumbs.db
 !/docs/BRANCHING.md
 !/docs/CLI.md
 !/docs/INSTALLATION.md
+!/docs/MCP.md
 !/docs/RELEASING.md
 
 # Vim / Emacs

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ may have entered an agent session or Git history, revoke it immediately. See
 
 | Path | Purpose |
 |---|---|
-| `cli/` | Go `cxt` CLI, capture adapters, codecs, local object store, and optional local stdio MCP helper |
+| `cli/` | Go `cxt` CLI, capture adapters, codecs, local working replica, and explicit offline stdio MCP helper |
 | `backend/` | Go `cxtd` REST and remote Streamable HTTP MCP server with filesystem and PostgreSQL stores |
 | `frontend/web/` | Sole web runtime: React and TypeScript application, tests, and deployment config |
 | `schemas/` | OpenAPI, JSON Schema, and ordered PostgreSQL migrations |

--- a/backend/cmd/cxtd/main.go
+++ b/backend/cmd/cxtd/main.go
@@ -3,8 +3,9 @@
 // 'serve' starts the HTTP REST server; 'repack' performs offline-compatible FS
 // object maintenance. Frontend static assets are not served (CDN/Vercel).
 //
-// Store: Default build uses FSStore (file-based, --data directory). `go build -tags postgres` + CXT_POSTGRES_DSN
-// for PostgreSQL adapter (pgx). store.Open(factory) selects based on build tags.
+// Store: a loopback-bound development build may use FSStore. Every externally
+// bound server requires the PostgreSQL build and CXT_POSTGRES_DSN; production
+// can additionally set CXT_REQUIRE_POSTGRES=1 as a fail-closed assertion.
 package main
 
 import (
@@ -40,6 +41,10 @@ func isLoopback(addr string) bool {
 	}
 	ip := net.ParseIP(host)
 	return ip != nil && ip.IsLoopback()
+}
+
+func postgresRequired(addr, configured string) bool {
+	return envBool(configured) || !isLoopback(addr)
 }
 
 func main() {
@@ -78,7 +83,7 @@ func serve(ctx context.Context, args []string) error {
 	addr := flagOr(args, "--addr", os.Getenv("CXT_ADDR"), ":8080")
 	dataDir := flagOr(args, "--data", os.Getenv("CXT_DATA"), "./cxt-data")
 	dsn := os.Getenv("CXT_POSTGRES_DSN")
-	requirePostgres := envBool(os.Getenv("CXT_REQUIRE_POSTGRES"))
+	requirePostgres := postgresRequired(addr, os.Getenv("CXT_REQUIRE_POSTGRES"))
 
 	// Resolve and validate authentication before opening either storage backend.
 	// In particular, an unsafe dev-auth bind must fail without touching the FS
@@ -99,8 +104,9 @@ func serve(ctx context.Context, args []string) error {
 		log.Printf("warning: dev authentication trusts every token without verification (local development only)")
 	}
 
-	// Outbound adapter: local development may use FS, while production sets
-	// CXT_REQUIRE_POSTGRES=1 and fails before serving if the binary, DSN, or
+	// Outbound adapter: only loopback development may use FS. External binds
+	// require PostgreSQL even when an operator accidentally omits the explicit
+	// production assertion, and fail before serving if the binary, DSN, or
 	// database connection is unavailable.
 	st, err := store.Open(dataDir, dsn, requirePostgres)
 	if err != nil {

--- a/backend/cmd/cxtd/main_test.go
+++ b/backend/cmd/cxtd/main_test.go
@@ -1,0 +1,26 @@
+package main
+
+import "testing"
+
+func TestPostgresRequiredForEveryExternalBind(t *testing.T) {
+	tests := []struct {
+		addr       string
+		configured string
+		want       bool
+	}{
+		{addr: "127.0.0.1:8907", want: false},
+		{addr: "localhost:8907", want: false},
+		{addr: "[::1]:8907", want: false},
+		{addr: "127.0.0.1:8907", configured: "1", want: true},
+		{addr: "0.0.0.0:8907", want: true},
+		{addr: ":8907", want: true},
+		{addr: "10.0.0.5:8907", want: true},
+	}
+	for _, test := range tests {
+		t.Run(test.addr+"/"+test.configured, func(t *testing.T) {
+			if got := postgresRequired(test.addr, test.configured); got != test.want {
+				t.Fatalf("postgresRequired(%q, %q) = %v, want %v", test.addr, test.configured, got, test.want)
+			}
+		})
+	}
+}

--- a/backend/internal/adapters/delivery/mcp/oauth.go
+++ b/backend/internal/adapters/delivery/mcp/oauth.go
@@ -164,7 +164,7 @@ func (s *Server) authorize(w http.ResponseWriter, r *http.Request) {
 		scope = readScope
 	}
 	if scope != readScope || len(q.Get("state")) > 512 {
-		writeOAuthError(w, http.StatusBadRequest, "invalid_scope", "only context:read is supported")
+		writeOAuthError(w, http.StatusBadRequest, "invalid_scope", "only mcp:read is supported")
 		return
 	}
 	now := time.Now().UTC()
@@ -338,7 +338,7 @@ func (s *Server) token(w http.ResponseWriter, r *http.Request) {
 		code, consumeErr := s.oauth.ConsumeOAuthAuthorizationCode(
 			r.Context(), domain.HashToken(r.PostForm.Get("code")), clientID, r.PostForm.Get("redirect_uri"), pkceChallenge(verifier),
 		)
-		if consumeErr != nil || code.Resource != s.resource {
+		if consumeErr != nil || code.Resource != s.resource || code.Scope != readScope {
 			writeOAuthError(w, http.StatusBadRequest, "invalid_grant", "authorization code is invalid, expired, or already used")
 			return
 		}

--- a/backend/internal/adapters/delivery/mcp/protocol.go
+++ b/backend/internal/adapters/delivery/mcp/protocol.go
@@ -2,10 +2,23 @@ package mcp
 
 import (
 	"encoding/json"
+	"mime"
 	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
 
 	"github.com/wnsdy95/cxthub/backend/internal/domain"
 )
+
+func supportedProtocol(value string) bool {
+	switch value {
+	case "2024-11-05", "2025-03-26", latestProtocol:
+		return true
+	default:
+		return false
+	}
+}
 
 type rpcRequest struct {
 	JSONRPC string          `json:"jsonrpc"`
@@ -19,15 +32,28 @@ type rpcError struct {
 	Message string `json:"message"`
 }
 
-func (s *Server) mcpMethodNotAllowed(w http.ResponseWriter, _ *http.Request) {
+func (s *Server) mcpMethodNotAllowed(w http.ResponseWriter, r *http.Request) {
+	if !s.validMCPOrigin(w, r) {
+		return
+	}
 	w.Header().Set("Allow", "POST")
 	writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "stateless MCP endpoint accepts POST only"})
 }
 
 func (s *Server) mcpPost(w http.ResponseWriter, r *http.Request) {
+	if !s.validMCPOrigin(w, r) {
+		return
+	}
 	user, err := s.requestUser(r, false)
 	if err != nil {
 		s.mcpUnauthorized(w)
+		return
+	}
+	if !acceptsMediaType(r.Header.Get("Accept"), "application/json") ||
+		!acceptsMediaType(r.Header.Get("Accept"), "text/event-stream") {
+		writeJSON(w, http.StatusNotAcceptable, map[string]any{
+			"jsonrpc": "2.0", "error": rpcError{Code: -32600, Message: "Accept must include application/json and text/event-stream"}, "id": nil,
+		})
 		return
 	}
 	if !hasMediaType(r, "application/json") {
@@ -43,6 +69,18 @@ func (s *Server) mcpPost(w http.ResponseWriter, r *http.Request) {
 		})
 		return
 	}
+	if req.Method != "initialize" {
+		protocol := strings.TrimSpace(r.Header.Get("MCP-Protocol-Version"))
+		if protocol == "" {
+			protocol = "2025-03-26"
+		}
+		if !supportedProtocol(protocol) {
+			writeJSON(w, http.StatusBadRequest, map[string]any{
+				"jsonrpc": "2.0", "error": rpcError{Code: -32600, Message: "unsupported MCP-Protocol-Version"}, "id": requestID(req.ID),
+			})
+			return
+		}
+	}
 	result, rpcErr := s.dispatch(r, user, req)
 	if len(req.ID) == 0 || string(req.ID) == "null" {
 		w.WriteHeader(http.StatusAccepted)
@@ -57,6 +95,52 @@ func (s *Server) mcpPost(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, response)
 }
 
+func requestID(raw json.RawMessage) any {
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil
+	}
+	return raw
+}
+
+func acceptsMediaType(header, target string) bool {
+	for _, item := range strings.Split(header, ",") {
+		mediaType, params, err := mime.ParseMediaType(strings.TrimSpace(item))
+		if err != nil || !strings.EqualFold(mediaType, target) {
+			continue
+		}
+		if q, ok := params["q"]; ok {
+			quality, err := strconv.ParseFloat(q, 64)
+			if err != nil || quality <= 0 {
+				continue
+			}
+		}
+		return true
+	}
+	return false
+}
+
+// MCP clients such as Codex and Claude normally make server-to-server requests
+// and omit Origin. If a browser-originated request does include Origin, require
+// an exact match with CXT_PUBLIC_URL so the HTTP transport cannot be reached by
+// an unrelated website through DNS rebinding or ambient browser credentials.
+func (s *Server) validMCPOrigin(w http.ResponseWriter, r *http.Request) bool {
+	raw := strings.TrimSpace(r.Header.Get("Origin"))
+	if raw == "" {
+		return true
+	}
+	origin, err := url.Parse(raw)
+	public, publicErr := url.Parse(s.publicURL)
+	valid := err == nil && publicErr == nil && origin.User == nil && origin.RawQuery == "" && origin.Fragment == "" &&
+		(origin.Path == "" || origin.Path == "/") && strings.EqualFold(origin.Scheme, public.Scheme) && strings.EqualFold(origin.Host, public.Host)
+	if !valid {
+		writeJSON(w, http.StatusForbidden, map[string]any{
+			"jsonrpc": "2.0", "error": rpcError{Code: -32000, Message: "Origin is not allowed"}, "id": nil,
+		})
+		return false
+	}
+	return true
+}
+
 func (s *Server) dispatch(r *http.Request, user domain.User, req rpcRequest) (any, *rpcError) {
 	switch req.Method {
 	case "initialize":
@@ -65,8 +149,7 @@ func (s *Server) dispatch(r *http.Request, user domain.User, req rpcRequest) (an
 			ProtocolVersion string `json:"protocolVersion"`
 		}
 		_ = json.Unmarshal(req.Params, &params)
-		switch params.ProtocolVersion {
-		case "2024-11-05", "2025-03-26", latestProtocol:
+		if supportedProtocol(params.ProtocolVersion) {
 			protocol = params.ProtocolVersion
 		}
 		return map[string]any{

--- a/backend/internal/adapters/delivery/mcp/server.go
+++ b/backend/internal/adapters/delivery/mcp/server.go
@@ -1,5 +1,5 @@
 // Package mcp exposes CXTHub's cloud repository context as a stateless,
-// read-only Streamable HTTP MCP server. Unlike the optional local `cxt mcp`
+// read-only Streamable HTTP MCP server. Unlike `cxt mcp --local`
 // helper, this server reads through cxtd's shared storage (PostgreSQL in
 // production) and applies the same Workspace viewer boundary as the REST API.
 package mcp
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	readScope         = "context:read"
+	readScope         = "mcp:read"
 	sessionCookieName = "cxt_session"
 	latestProtocol    = "2025-06-18"
 )

--- a/backend/internal/adapters/delivery/mcp/server_test.go
+++ b/backend/internal/adapters/delivery/mcp/server_test.go
@@ -79,6 +79,17 @@ func decodeJSON[T any](t *testing.T, body io.Reader) T {
 	return value
 }
 
+func remoteMCPHeaders(token string) map[string]string {
+	headers := map[string]string{
+		"Content-Type": "application/json",
+		"Accept":       "application/json, text/event-stream",
+	}
+	if token != "" {
+		headers["Authorization"] = "Bearer " + token
+	}
+	return headers
+}
+
 func TestRemoteMCPDCRPKCERefreshAndWorkspaceIsolation(t *testing.T) {
 	ctx := context.Background()
 	st := store.NewFSStore(t.TempDir())
@@ -219,7 +230,7 @@ func TestRemoteMCPDCRPKCERefreshAndWorkspaceIsolation(t *testing.T) {
 
 	listCall := `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"repository_list","arguments":{}}}`
 	mcpResponse := mcpRequest(t, server.Handler(), http.MethodPost, "/mcp", strings.NewReader(listCall), map[string]string{
-		"Content-Type": "application/json", "Authorization": "Bearer " + tokens.AccessToken,
+		"Content-Type": "application/json", "Accept": "application/json, text/event-stream", "Authorization": "Bearer " + tokens.AccessToken,
 	})
 	if mcpResponse.Code != http.StatusOK || !strings.Contains(mcpResponse.Body.String(), "oauth-user/project/app") {
 		t.Fatalf("MCP authorized list = %d: %s", mcpResponse.Code, mcpResponse.Body.String())
@@ -228,7 +239,7 @@ func TestRemoteMCPDCRPKCERefreshAndWorkspaceIsolation(t *testing.T) {
 		t.Fatalf("private non-member repository leaked: %s", mcpResponse.Body.String())
 	}
 	ambiguousMCP := mcpRequest(t, server.Handler(), http.MethodPost, "/mcp", strings.NewReader(listCall+`{}`), map[string]string{
-		"Content-Type": "application/json", "Authorization": "Bearer " + tokens.AccessToken,
+		"Content-Type": "application/json", "Accept": "application/json, text/event-stream", "Authorization": "Bearer " + tokens.AccessToken,
 	})
 	if ambiguousMCP.Code != http.StatusBadRequest || !strings.Contains(ambiguousMCP.Body.String(), "invalid JSON-RPC request") {
 		t.Fatalf("MCP with trailing JSON = %d: %s", ambiguousMCP.Code, ambiguousMCP.Body.String())
@@ -260,7 +271,7 @@ func TestRemoteMCPDCRPKCERefreshAndWorkspaceIsolation(t *testing.T) {
 		t.Fatalf("revoke access = %d: %s", revoked.Code, revoked.Body.String())
 	}
 	revokedCall := mcpRequest(t, server.Handler(), http.MethodPost, "/mcp", strings.NewReader(listCall), map[string]string{
-		"Content-Type": "application/json", "Authorization": "Bearer " + refreshedTokens.AccessToken,
+		"Content-Type": "application/json", "Accept": "application/json, text/event-stream", "Authorization": "Bearer " + refreshedTokens.AccessToken,
 	})
 	if revokedCall.Code != http.StatusUnauthorized {
 		t.Fatalf("revoked access token MCP call = %d: %s", revokedCall.Code, revokedCall.Body.String())
@@ -301,8 +312,109 @@ func TestOAuthMetadataAdvertisesReadOnlyResourceAndRevocation(t *testing.T) {
 	}
 	metadata := mcpRequest(t, server.Handler(), http.MethodGet, "/.well-known/oauth-authorization-server", nil, nil)
 	if metadata.Code != http.StatusOK || !strings.Contains(metadata.Body.String(), `"revocation_endpoint":"https://cxthub.test/oauth/revoke"`) ||
-		!strings.Contains(metadata.Body.String(), `"context:read"`) {
+		!strings.Contains(metadata.Body.String(), `"mcp:read"`) {
 		t.Fatalf("authorization metadata = %d: %s", metadata.Code, metadata.Body.String())
+	}
+}
+
+func TestTokenExchangeRejectsAuthorizationCodeWithoutMCPReadScope(t *testing.T) {
+	ctx := context.Background()
+	st := store.NewFSStore(t.TempDir())
+	user := domain.User{ID: "legacy-scope-user", Email: "legacy@example.test", Name: "Legacy", Username: "legacy"}
+	if err := st.UpsertUser(ctx, user); err != nil {
+		t.Fatal(err)
+	}
+	client := domain.OAuthClient{
+		ID: "legacy-scope-client", Name: "Legacy MCP client",
+		RedirectURIs: []string{"http://127.0.0.1/callback"}, CreatedAt: time.Now().UTC(),
+	}
+	if err := st.CreateOAuthClient(ctx, client); err != nil {
+		t.Fatal(err)
+	}
+	verifier := strings.Repeat("v", 64)
+	request := domain.OAuthAuthorizationRequest{
+		ID: "legacy-scope-request", ClientID: client.ID, RedirectURI: client.RedirectURIs[0],
+		CodeChallenge: pkceChallenge(verifier), Resource: "https://cxthub.test/mcp", Scope: "legacy:read",
+		CreatedAt: time.Now().UTC(), ExpiresAt: time.Now().UTC().Add(5 * time.Minute),
+	}
+	if err := st.CreateOAuthAuthorizationRequest(ctx, request); err != nil {
+		t.Fatal(err)
+	}
+	rawCode := "legacy-authorization-code"
+	if _, err := st.ApproveOAuthAuthorizationRequest(ctx, request.ID, user.ID, domain.HashToken(rawCode), time.Now().UTC().Add(time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	identity := app.NewIdentityService(fixedVerifier{user: user}, st)
+	server, err := NewServer(fakeContextBackend{}, identity, st, "https://cxthub.test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	form := url.Values{
+		"grant_type": {"authorization_code"}, "client_id": {client.ID},
+		"redirect_uri": {client.RedirectURIs[0]}, "code": {rawCode},
+		"code_verifier": {verifier}, "resource": {"https://cxthub.test/mcp"},
+	}
+	response := mcpRequest(t, server.Handler(), http.MethodPost, "/oauth/token", strings.NewReader(form.Encode()), map[string]string{
+		"Content-Type": "application/x-www-form-urlencoded",
+	})
+	if response.Code != http.StatusBadRequest || !strings.Contains(response.Body.String(), "invalid_grant") {
+		t.Fatalf("legacy-scope token exchange = %d: %s", response.Code, response.Body.String())
+	}
+}
+
+func TestStreamableHTTPTransportGuards(t *testing.T) {
+	st := store.NewFSStore(t.TempDir())
+	user := domain.User{ID: "transport-user", Email: "transport@example.test", Name: "Transport", Username: "transport"}
+	id := app.NewIdentityService(fixedVerifier{user: user}, st)
+	if err := st.UpsertUser(context.Background(), user); err != nil {
+		t.Fatal(err)
+	}
+	pair, err := id.IssueMCPTokenPair(context.Background(), user.ID, "transport-client")
+	if err != nil {
+		t.Fatal(err)
+	}
+	server, err := NewServer(fakeContextBackend{}, id, st, "https://cxthub.test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload := `{"jsonrpc":"2.0","id":1,"method":"ping"}`
+
+	missingAccept := mcpRequest(t, server.Handler(), http.MethodPost, "/mcp", strings.NewReader(payload), map[string]string{
+		"Content-Type": "application/json", "Authorization": "Bearer " + pair.AccessToken,
+	})
+	if missingAccept.Code != http.StatusNotAcceptable {
+		t.Fatalf("missing transport Accept = %d: %s", missingAccept.Code, missingAccept.Body.String())
+	}
+
+	badOriginHeaders := remoteMCPHeaders(pair.AccessToken)
+	badOriginHeaders["Origin"] = "https://attacker.example"
+	badOrigin := mcpRequest(t, server.Handler(), http.MethodPost, "/mcp", strings.NewReader(payload), badOriginHeaders)
+	if badOrigin.Code != http.StatusForbidden {
+		t.Fatalf("foreign MCP Origin = %d: %s", badOrigin.Code, badOrigin.Body.String())
+	}
+
+	badProtocolHeaders := remoteMCPHeaders(pair.AccessToken)
+	badProtocolHeaders["MCP-Protocol-Version"] = "2099-01-01"
+	badProtocol := mcpRequest(t, server.Handler(), http.MethodPost, "/mcp", strings.NewReader(payload), badProtocolHeaders)
+	if badProtocol.Code != http.StatusBadRequest || !strings.Contains(badProtocol.Body.String(), "unsupported MCP-Protocol-Version") {
+		t.Fatalf("unsupported protocol = %d: %s", badProtocol.Code, badProtocol.Body.String())
+	}
+
+	validHeaders := remoteMCPHeaders(pair.AccessToken)
+	validHeaders["Origin"] = "https://cxthub.test"
+	validHeaders["MCP-Protocol-Version"] = latestProtocol
+	valid := mcpRequest(t, server.Handler(), http.MethodPost, "/mcp", strings.NewReader(payload), validHeaders)
+	if valid.Code != http.StatusOK {
+		t.Fatalf("valid Streamable HTTP request = %d: %s", valid.Code, valid.Body.String())
+	}
+
+	foreignGET := mcpRequest(t, server.Handler(), http.MethodGet, "/mcp", nil, map[string]string{"Origin": "https://attacker.example", "Accept": "text/event-stream"})
+	if foreignGET.Code != http.StatusForbidden {
+		t.Fatalf("foreign MCP GET Origin = %d: %s", foreignGET.Code, foreignGET.Body.String())
+	}
+	validGET := mcpRequest(t, server.Handler(), http.MethodGet, "/mcp", nil, map[string]string{"Accept": "text/event-stream"})
+	if validGET.Code != http.StatusMethodNotAllowed || validGET.Header().Get("Allow") != "POST" {
+		t.Fatalf("stateless MCP GET = %d allow=%q", validGET.Code, validGET.Header().Get("Allow"))
 	}
 }
 

--- a/backend/internal/adapters/store/fs_store_oauth_test.go
+++ b/backend/internal/adapters/store/fs_store_oauth_test.go
@@ -23,7 +23,7 @@ func TestFSOAuthAuthorizationCodeIsBoundAndConsumedOnce(t *testing.T) {
 	}
 	req := domain.OAuthAuthorizationRequest{
 		ID: "oauth_req_123", ClientID: client.ID, RedirectURI: client.RedirectURIs[0], State: "state",
-		CodeChallenge: "challenge", Resource: "https://cxthub.com/mcp", Scope: "context:read",
+		CodeChallenge: "challenge", Resource: "https://cxthub.com/mcp", Scope: "mcp:read",
 		CreatedAt: now, ExpiresAt: now.Add(10 * time.Minute),
 	}
 	if err := st.CreateOAuthAuthorizationRequest(ctx, req); err != nil {
@@ -60,7 +60,7 @@ func TestFSOAuthDenyConsumesConsentRequest(t *testing.T) {
 	}
 	req := domain.OAuthAuthorizationRequest{
 		ID: "oauth_req_456", ClientID: client.ID, RedirectURI: client.RedirectURIs[0], CodeChallenge: "challenge",
-		Resource: "https://cxthub.com/mcp", Scope: "context:read", CreatedAt: now, ExpiresAt: now.Add(time.Minute),
+		Resource: "https://cxthub.com/mcp", Scope: "mcp:read", CreatedAt: now, ExpiresAt: now.Add(time.Minute),
 	}
 	if err := st.CreateOAuthAuthorizationRequest(ctx, req); err != nil {
 		t.Fatal(err)
@@ -83,7 +83,7 @@ func TestFSOAuthExpiredRecordsAreRemovedLazily(t *testing.T) {
 	}
 	expired := domain.OAuthAuthorizationRequest{
 		ID: "oauth_req_expired", ClientID: client.ID, RedirectURI: client.RedirectURIs[0], CodeChallenge: "challenge",
-		Resource: "https://cxthub.com/mcp", Scope: "context:read", CreatedAt: now.Add(-2 * time.Minute), ExpiresAt: now.Add(-time.Minute),
+		Resource: "https://cxthub.com/mcp", Scope: "mcp:read", CreatedAt: now.Add(-2 * time.Minute), ExpiresAt: now.Add(-time.Minute),
 	}
 	if err := st.CreateOAuthAuthorizationRequest(ctx, expired); err != nil {
 		t.Fatal(err)
@@ -97,7 +97,7 @@ func TestFSOAuthExpiredRecordsAreRemovedLazily(t *testing.T) {
 
 	expiredCode := domain.OAuthAuthorizationCode{
 		CodeHash: "tkh_" + strings.Repeat("a", 64), ClientID: client.ID, RedirectURI: client.RedirectURIs[0], UserID: "user-expiry",
-		CodeChallenge: "challenge", Resource: "https://cxthub.com/mcp", Scope: "context:read",
+		CodeChallenge: "challenge", Resource: "https://cxthub.com/mcp", Scope: "mcp:read",
 		CreatedAt: now.Add(-2 * time.Minute), ExpiresAt: now.Add(-time.Minute),
 	}
 	codePath := oauthRecordPath(st.oauthCodesDir(), expiredCode.CodeHash)

--- a/backend/internal/adapters/store/open.go
+++ b/backend/internal/adapters/store/open.go
@@ -4,9 +4,10 @@ package store
 
 import "fmt"
 
-// Open opens the server store (default build: always uses FSStore).
+// Open opens the loopback-development store (default build: FSStore only).
 //
-// The Postgres adapter is gated with //go:build postgres. To build with the Postgres adapter, use `go build -tags postgres`. In this case, Open in open_postgres.go is used instead, and if a DSN is provided, it opens a PostgresStore.
+// The Postgres adapter is gated with //go:build postgres. External cxtd binds
+// always request PostgreSQL, so this build fails closed instead of serving FS.
 func Open(dataDir, dsn string, requirePostgres bool) (Store, error) {
 	if dsn != "" || requirePostgres {
 		return nil, fmt.Errorf("PostgreSQL storage requested but this cxtd binary was built without the postgres tag")

--- a/backend/internal/adapters/store/open_postgres.go
+++ b/backend/internal/adapters/store/open_postgres.go
@@ -7,8 +7,9 @@ import (
 	"fmt"
 )
 
-// Open(postgres build): if dsn exists, use PostgresStore, otherwise use FSStore.
-// `go build -tags postgres` + CXT_POSTGRES_DSN to activate.
+// Open(postgres build) uses PostgreSQL when a DSN is present. A missing DSN is
+// allowed only for a loopback development caller that did not require
+// PostgreSQL; cxtd marks every external bind as requirePostgres.
 func Open(dataDir, dsn string, requirePostgres bool) (Store, error) {
 	if dsn == "" {
 		if requirePostgres {

--- a/backend/internal/adapters/store/postgres_smoke_test.go
+++ b/backend/internal/adapters/store/postgres_smoke_test.go
@@ -239,7 +239,7 @@ func TestPGSmoke(t *testing.T) {
 	}
 	oauthRequest := domain.OAuthAuthorizationRequest{
 		ID: domain.NewID("oauth_req_"), ClientID: oauthClient.ID, RedirectURI: oauthClient.RedirectURIs[0],
-		CodeChallenge: "pg-smoke-challenge", Resource: "https://cxthub.test/mcp", Scope: "context:read",
+		CodeChallenge: "pg-smoke-challenge", Resource: "https://cxthub.test/mcp", Scope: "mcp:read",
 		CreatedAt: now, ExpiresAt: now.Add(10 * time.Minute),
 	}
 	if err := st.CreateOAuthAuthorizationRequest(ctx, oauthRequest); err != nil {

--- a/backend/internal/app/identity_service.go
+++ b/backend/internal/app/identity_service.go
@@ -662,7 +662,7 @@ func (s *IdentityService) IssueMCPTokenPair(ctx context.Context, userID, clientI
 	}
 	return domain.OAuthTokenPair{
 		AccessToken: access.Token, RefreshToken: refresh.Token,
-		ExpiresIn: int(mcpAccessTokenTTL.Seconds()), Scope: "context:read",
+		ExpiresIn: int(mcpAccessTokenTTL.Seconds()), Scope: "mcp:read",
 	}, nil
 }
 

--- a/cli/cmd/cxt/main.go
+++ b/cli/cmd/cxt/main.go
@@ -9,7 +9,7 @@
 //
 // Subcommands (domain model, client-specific):
 //
-//	cxt mcp                      → start stdio MCP server
+//	cxt mcp --local              → start the offline-development stdio MCP helper
 //	cxt hook --provider X --event Y → hook event handler (auto capture)
 //	cxt init|repo|save|list|fork|checkout|load|memorize|memory|push|pull → user CLI commands
 package main
@@ -74,6 +74,8 @@ func run(args []string) error {
 	}
 	switch args[1] {
 	case "mcp":
+		// PreflightArgs requires --local before adapter construction. The product
+		// MCP is the OAuth-protected remote cxtd endpoint, not this process.
 		return ctr.mcpServer.Run()
 	case "hook":
 		// hook safety contract (capture path): capture failures must not block agent sessions —
@@ -246,7 +248,8 @@ func buildContainer(cfg config) container {
 	coord := capture.NewCaptureCoordinator(saveSvc, cfg.Identity)
 
 	// --- driving adapters (delivery; client-specific: mcp/hook/cli) ---
-	// MCP is read-only 4-tool (list/fetch/memory/search) — writing is git hook automation.
+	// The explicit --local MCP helper is a read-only offline projection. The
+	// product MCP runs remotely in cxtd against shared cloud storage.
 	mcpSrv := delivmcp.NewServer(gitCtx, store, remote)
 	hookHdl := delivhook.NewHandler(coord)
 	clictr := &delivcli.Container{

--- a/cli/internal/adapters/delivery/cli/args.go
+++ b/cli/internal/adapters/delivery/cli/args.go
@@ -61,7 +61,7 @@ var commandArgSpecs = map[string]commandArgSpec{
 	"memorize":  {usage: "cxt memorize [<ref>] [--provider claude|codex]", flags: commandFlags([]string{"--provider"}, nil)},
 	"memory":    {usage: "cxt memory [<ref>] [--provider claude|codex]", flags: commandFlags([]string{"--provider"}, nil)},
 	"tag":       {usage: "cxt tag [<name> [ref]]"},
-	"mcp":       {usage: "cxt mcp"},
+	"mcp":       {usage: "cxt mcp --local", flags: commandFlags(nil, []string{"--local"})},
 	"hook":      {usage: "cxt hook --provider claude|codex --event <event>", flags: commandFlags([]string{"--provider", "--event"}, nil)},
 	"version":   {usage: "cxt version"},
 	"--version": {usage: "cxt --version"},
@@ -169,6 +169,10 @@ func validateCommandFlags(cmd string, args []string, spec commandArgSpec) error 
 
 	pos := positionals(args)
 	switch cmd {
+	case "mcp":
+		if len(pos) != 0 || !flagPresent(args, "--local") {
+			return fmt.Errorf("mcp: the product connector is https://cxthub.com/mcp; the stdio helper requires --local\nusage: %s", spec.usage)
+		}
 	case "branch":
 		if len(pos) != 2 || (pos[0] != "archive" && pos[0] != "restore") {
 			return fmt.Errorf("usage: %s", spec.usage)

--- a/cli/internal/adapters/delivery/cli/root.go
+++ b/cli/internal/adapters/delivery/cli/root.go
@@ -1059,7 +1059,7 @@ usage: cxt <command> [flags]
   Agent commands:
   claude [args...]          run Claude Code with branch context seeding
   codex [args...]           run Codex with branch context seeding
-  mcp                       start the read-only MCP server on stdio
+  mcp --local               start the offline-development MCP helper on stdio
   hook --provider P --event E
                             process a provider lifecycle event (integration use)
 

--- a/cli/internal/adapters/delivery/cli/root_help_test.go
+++ b/cli/internal/adapters/delivery/cli/root_help_test.go
@@ -172,6 +172,16 @@ func TestSubcommandSpecificFlagRestrictions(t *testing.T) {
 	}
 }
 
+func TestLocalMCPRequiresExplicitFlagBeforeComposition(t *testing.T) {
+	if handled, err := PreflightArgs([]string{"cxt", "mcp"}); handled || err == nil ||
+		!strings.Contains(err.Error(), "https://cxthub.com/mcp") || !strings.Contains(err.Error(), "--local") {
+		t.Fatalf("bare cxt mcp = handled %v, err %v", handled, err)
+	}
+	if handled, err := PreflightArgs([]string{"cxt", "mcp", "--local"}); handled || err != nil {
+		t.Fatalf("cxt mcp --local = handled %v, err %v", handled, err)
+	}
+}
+
 func TestHelpCommandTargetsSubcommands(t *testing.T) {
 	if handled, err := PreflightArgs([]string{"cxt", "help", "load"}); err != nil || !handled {
 		t.Fatalf("cxt help load = handled %v, err %v", handled, err)

--- a/cli/internal/adapters/delivery/mcp/integration_contract_test.go
+++ b/cli/internal/adapters/delivery/mcp/integration_contract_test.go
@@ -51,6 +51,22 @@ func TestIntegrationAssetsMatchReadOnlyMCPContract(t *testing.T) {
 	}
 
 	root := repoRoot(t)
+	for _, config := range []string{
+		"integrations/codex/config.snippet.toml",
+		"integrations/claude-code/.mcp.json",
+	} {
+		body, err := os.ReadFile(filepath.Join(root, config))
+		if err != nil {
+			t.Fatal(err)
+		}
+		text := string(body)
+		if !strings.Contains(text, "https://cxthub.com/mcp") {
+			t.Errorf("%s does not use the cloud MCP endpoint", config)
+		}
+		if strings.Contains(text, `args = ["mcp"]`) || strings.Contains(text, `"args": ["mcp"]`) {
+			t.Errorf("%s still makes local stdio the product default", config)
+		}
+	}
 	allowed := make(map[string]bool, len(wantTools))
 	for _, name := range wantTools {
 		allowed[name] = true

--- a/cli/internal/adapters/delivery/mcp/server.go
+++ b/cli/internal/adapters/delivery/mcp/server.go
@@ -1,6 +1,9 @@
 // Package mcp contains the stdio MCP server driver (domain model — read-only redefinition as of 2026-07-09).
 //
-// Started by the cxt mcp subcommand, Claude Code / Codex CLI etc. connect to stdio. The tool exposes only **read-only 4** — write (save/push/checkout/memorize) is automated git hooks and calling by an agent at any point could disrupt the thread. The goal is to use cxthub as a "team knowledge base that the agent queries during its session".
+// Started only by the explicit `cxt mcp --local` development command. The
+// product connector is cxtd's OAuth-protected Streamable HTTP endpoint and
+// reads shared cloud storage. This helper reads the current local replica and
+// exposes only four read-only tools for offline development.
 //
 // context_list    → current repo commit (snapshot) list (local store)
 // context_fetch   → metadata + memory summary + recent chat tail for a specific ref/commit
@@ -24,7 +27,8 @@ import (
 	"github.com/wnsdy95/cxthub/cli/internal/ports/outbound"
 )
 
-// ReadStore is the local store read set that MCP requires (consumer-defined — FileStore implements).
+// ReadStore is the local working-replica read set required by the explicit
+// offline helper (consumer-defined — FileStore implements).
 type ReadStore interface {
 	ListSnapshots(ctx context.Context, repoID, branch string) ([]domain.Snapshot, error)
 	GetSnapshot(ctx context.Context, id domain.ContentHash) (domain.Snapshot, error)

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -14,5 +14,6 @@ COPY schemas/db/migrations/ /app/migrations/
 USER nonroot:nonroot
 EXPOSE 8907
 # Production required env vars are injected by terraform (cloudrun.tf): CXT_AUTH/CXT_POSTGRES_DSN/…
-# Binding to 0.0.0.0 is only allowed with CXT_AUTH=firebase (dev auth guard — cmd/cxtd/main.go)
+# Binding to 0.0.0.0 requires both verified auth and PostgreSQL; missing DSN
+# fails before the HTTP listener starts (cmd/cxtd/main.go).
 ENTRYPOINT ["/app/cxtd", "serve", "--addr", "0.0.0.0:8907"]

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -13,9 +13,11 @@ Create these Google Secret Manager secrets before applying Terraform:
 | `cxt-postgres-dsn` | `CXT_POSTGRES_DSN` | PostgreSQL connection string |
 | `cxt-github-webhook-secret` | `CXT_GITHUB_WEBHOOK_SECRET` | Random GitHub webhook HMAC secret |
 
-Cloud Run also sets `CXT_REQUIRE_POSTGRES=1`. Production therefore refuses to
-start if the PostgreSQL build tag, DSN, live database connection, or migration
-directory is missing; it never falls back to the container filesystem.
+Every externally bound `cxtd` process requires PostgreSQL. Cloud Run also sets
+`CXT_REQUIRE_POSTGRES=1` as an explicit deployment assertion. Production
+therefore refuses to start if the PostgreSQL build tag, DSN, live database
+connection, or migration directory is missing; it never falls back to the
+container filesystem.
 It also sets `CXT_PUBLIC_URL=https://<domain>`, which is the OAuth issuer and
 protected-resource origin for the remote read-only MCP connector.
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -175,15 +175,17 @@ installed `codex` executable. The wrapper owns process restart/resume on a
 branch switch. It is optional for Codex app/IDE sessions, where lifecycle hooks
 preserve the live app session and apply one bounded memory handoff.
 
-### `cxt mcp`
+### `cxt mcp --local`
 
 ```text
-cxt mcp
+cxt mcp --local
 ```
 
-Starts the optional read-only **local** MCP helper on standard input/output. It
-reads the current repository's `.cxt` store and is distinct from the production
-`https://<host>/mcp` connector, which runs in `cxtd` against cloud PostgreSQL.
+Starts the optional read-only **offline-development** MCP helper on standard
+input/output. It reads the current repository's `.cxt` working replica and is
+distinct from the default product connector at `https://cxthub.com/mcp`, which
+runs in `cxtd` against cloud PostgreSQL. Bare `cxt mcp` is rejected so a local
+replica cannot be mistaken for the shared product data source.
 See [MCP connections](MCP.md). The local helper exposes:
 
 | Tool | Purpose |

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -191,11 +191,11 @@ so it cannot be passively captured by this integration. Use the Code tab or an
 explicit export/import workflow instead.
 
 To let Codex app or Claude app retrieve context already synchronized to the
-server, add `https://<host>/mcp` as a remote MCP/custom connector. This is an
-OAuth-protected Streamable HTTP service backed by `cxtd` and cloud PostgreSQL;
-it is separate from capture hooks and from the optional local `cxt mcp` stdio
-helper. See [MCP connections](MCP.md) for setup, permissions, and deployment
-boundaries.
+server, use the default product connector at `https://cxthub.com/mcp` (or the
+corresponding self-hosted origin). This is an OAuth-protected Streamable HTTP
+service backed by `cxtd` and cloud PostgreSQL; it is separate from capture hooks
+and from the explicit offline helper `cxt mcp --local`. See
+[MCP connections](MCP.md) for setup, permissions, and deployment boundaries.
 
 To initialize local-only storage without a remote:
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -1,0 +1,180 @@
+# MCP connections
+
+CXTHub's product MCP is the OAuth-protected Streamable HTTP endpoint at:
+
+```text
+https://cxthub.com/mcp
+```
+
+Codex, Claude, ChatGPT, and other remote MCP clients query the same cloud
+context that the CXTHub web application reads. The local `.cxt` directory is a
+CLI working replica and offline cache; it is not the product MCP database.
+
+## Architecture
+
+```text
+Codex / Claude / ChatGPT
+        │ Streamable HTTP + OAuth
+        ▼
+https://cxthub.com/mcp
+        │
+        ▼
+cxtd remote MCP delivery adapter
+        │
+        ├─ OAuth user resolution (`mcp:read`)
+        ├─ Workspace public/member/break-glass policy
+        ├─ read-only context application service
+        └─ bounded response projection
+        │
+        ▼
+Cloud PostgreSQL
+```
+
+The MCP adapter and REST adapter are composed in the same `cxtd` process for
+now. They share application services, repository objects, identity policy, and
+the production PostgreSQL store. This is a composition boundary, so MCP can be
+moved to a separate service later without changing its tool contract.
+
+## Read-only tools
+
+| Tool | Purpose |
+|---|---|
+| `repository_list` | Discover a bounded list of repositories visible to the signed-in user |
+| `context_list` | List committed context snapshots in one authorized repository |
+| `context_fetch` | Fetch bounded metadata, memory, and recent conversation text for a ref |
+| `memory_load` | Load the bounded memory projection at a ref or nearest reachable ancestor |
+| `context_search` | Search committed messages and readable conversation text in one repository |
+
+Every tool is marked read-only, non-destructive, and idempotent. There are no
+MCP tools for save, commit, checkout, fork, restore, push, pull, settings,
+secrets, membership, or break-glass administration.
+
+`repository_list` is the cloud-only discovery step. The four context tools
+then require an explicit `namespace/workspace/repository` selector so a remote
+client never depends on a workstation's current directory.
+
+## Authentication and authorization
+
+The connector uses an OAuth authorization-code flow with S256 PKCE, dynamic
+client registration, refresh-token rotation, and revocation. The only
+advertised scope is:
+
+```text
+mcp:read
+```
+
+The consent page uses the user's ordinary Firebase-backed CXTHub web session.
+MCP access and refresh capabilities are separately hashed, client-bound, and
+cannot be presented to ordinary REST endpoints.
+
+Repository visibility follows the context-viewing boundary:
+
+- public Workspace repositories are readable;
+- private Workspace repositories require at least Viewer membership;
+- Enterprise administration alone grants no repository context access;
+- an Enterprise Owner may use an active, reason-bound, expiring, audited
+  read-only break-glass grant;
+- all other private repositories are omitted without leaking their contents.
+
+## Codex and ChatGPT desktop
+
+The Codex app, Codex CLI, and IDE extension share MCP configuration. In the app,
+open **Settings → MCP servers**, choose **Streamable HTTP**, and enter the URL
+above. Authenticate when prompted.
+
+Equivalent `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.cxt]
+url = "https://cxthub.com/mcp"
+auth = "oauth"
+```
+
+You can trigger login explicitly with:
+
+```bash
+codex mcp login cxt
+```
+
+ChatGPT web does not read local Codex configuration. A hosted ChatGPT product
+uses a published/installed connector or plugin that points to the same remote
+MCP endpoint.
+
+Official Codex configuration reference:
+<https://developers.openai.com/codex/mcp>
+
+## Claude and Claude Code
+
+In Claude, add `https://cxthub.com/mcp` as a custom connector and complete the
+per-user connection. Claude reaches remote connectors from Anthropic's cloud,
+so a production server must be publicly reachable over HTTPS.
+
+Claude Code project configuration:
+
+```json
+{
+  "mcpServers": {
+    "cxt": {
+      "type": "http",
+      "url": "https://cxthub.com/mcp"
+    }
+  }
+}
+```
+
+Use `/mcp` in Claude Code to complete OAuth. Official references:
+
+- <https://support.claude.com/en/articles/11175166-get-started-with-custom-connectors-using-remote-mcp>
+- <https://code.claude.com/docs/en/mcp>
+
+## Explicit local helper
+
+For offline development, the CLI can expose the current repository's local
+working replica over stdio:
+
+```bash
+cxt mcp --local
+```
+
+This helper is intentionally not the default product connector. Bare
+`cxt mcp` fails with the remote endpoint and explicit local usage in its error
+message. The helper has no `repository_list`; its four context tools resolve
+the current local repository, and `context_search` may still use the configured
+origin.
+
+## Production storage invariant
+
+The production container is built with the PostgreSQL adapter. Any externally
+bound `cxtd` process requires PostgreSQL and fails before serving if
+`CXT_POSTGRES_DSN` is missing or unusable. Cloud Run additionally sets
+`CXT_REQUIRE_POSTGRES=1`, loads the DSN from Secret Manager, and applies the
+ordered migrations before accepting traffic.
+
+Filesystem storage remains available only to a loopback-bound development
+server and tests. It must not be treated as a production fallback.
+
+## HTTP transport contract
+
+The endpoint follows MCP Streamable HTTP protocol version `2025-06-18` and
+supports compatible `2024-11-05` and `2025-03-26` clients:
+
+- one `/mcp` endpoint accepts JSON-RPC POST requests;
+- GET returns `405 Method Not Allowed` because the server is stateless and does
+  not open an unsolicited SSE stream;
+- POST requires `Accept: application/json, text/event-stream`;
+- an included `Origin` must match `CXT_PUBLIC_URL`; server-to-server clients may
+  omit it;
+- an included `MCP-Protocol-Version` must be supported;
+- requests and tool outputs are bounded;
+- unauthenticated requests return `401` with protected-resource metadata.
+
+Transport specification:
+<https://modelcontextprotocol.io/specification/2025-06-18/basic/transports>
+
+## Capture is separate
+
+MCP only reads synchronized history. Codex and Claude coding sessions are
+captured through lifecycle/Git hooks, while the CLI maintains the local `.cxt`
+working replica and synchronizes it with `cxtd`. Connecting MCP does not grant
+the server access to a live desktop conversation and does not replace capture
+hooks.

--- a/frontend/web/e2e/ui-regressions.spec.ts
+++ b/frontend/web/e2e/ui-regressions.spec.ts
@@ -1142,7 +1142,7 @@ test('real cxtd completes remote MCP OAuth consent, PKCE, read-only call, and re
     code_challenge: challenge,
     code_challenge_method: 'S256',
     resource: `${origin}/mcp`,
-    scope: 'context:read',
+    scope: 'mcp:read',
     state: 'playwright-state',
   }).toString();
   await page.goto(authorize.toString());
@@ -1174,10 +1174,10 @@ test('real cxtd completes remote MCP OAuth consent, PKCE, read-only call, and re
   });
   expect(tokenResponse.ok()).toBe(true);
   const tokens = (await tokenResponse.json()) as { access_token: string; refresh_token: string; scope: string };
-  expect(tokens.scope).toBe('context:read');
+  expect(tokens.scope).toBe('mcp:read');
 
   const mcp = await api.post('/mcp', {
-    headers: { Authorization: `Bearer ${tokens.access_token}` },
+    headers: { Authorization: `Bearer ${tokens.access_token}`, Accept: 'application/json, text/event-stream' },
     data: { jsonrpc: '2.0', id: 1, method: 'tools/call', params: { name: 'repository_list', arguments: {} } },
   });
   expect(mcp.ok()).toBe(true);
@@ -1188,7 +1188,7 @@ test('real cxtd completes remote MCP OAuth consent, PKCE, read-only call, and re
   });
   expect(revoke.ok()).toBe(true);
   const afterRevoke = await api.post('/mcp', {
-    headers: { Authorization: `Bearer ${tokens.access_token}` },
+    headers: { Authorization: `Bearer ${tokens.access_token}`, Accept: 'application/json, text/event-stream' },
     data: { jsonrpc: '2.0', id: 2, method: 'ping' },
   });
   expect(afterRevoke.status()).toBe(401);

--- a/integrations/claude-code/.mcp.json
+++ b/integrations/claude-code/.mcp.json
@@ -1,8 +1,8 @@
 {
   "mcpServers": {
     "cxt": {
-      "command": "cxt",
-      "args": ["mcp"]
+      "type": "http",
+      "url": "https://cxthub.com/mcp"
     }
   }
 }

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -39,32 +39,39 @@ hooks into project settings without replacing existing entries. Those hooks
 capture Claude Code CLI sessions and the Claude Desktop Code tab. MCP is not
 required for capture.
 
-## Optional read-only MCP
+## Default cloud read-only MCP
 
-Merge the following project-scoped server into `.mcp.json`:
+Add `https://cxthub.com/mcp` as a custom connector in Claude, or merge the
+following project-scoped HTTP server into Claude Code's `.mcp.json`:
 
 ```json
 {
   "mcpServers": {
     "cxt": {
-      "command": "cxt",
-      "args": ["mcp"]
+      "type": "http",
+      "url": "https://cxthub.com/mcp"
     }
   }
 }
 ```
 
-The server exposes exactly four non-destructive tools:
+Use `/mcp` to complete OAuth. Claude's cloud connector reaches this public URL;
+it does not read the workstation's `.cxt` directory. The server exposes
+repository discovery plus four non-destructive context tools:
 
 | MCP tool | Purpose |
 |---|---|
-| `context_list` | List local context commits |
+| `repository_list` | List cloud repositories visible to the signed-in user |
+| `context_list` | List context commits in an authorized repository |
 | `context_fetch` | Read metadata, bounded memory, and recent chat for a ref |
 | `memory_load` | Read the bounded memory projection for a ref |
 | `context_search` | Search synchronized team context |
 
 There are no MCP tools for save, fork, checkout, provider-file restoration,
 memorize, push, or pull.
+
+For explicit offline development only, a local STDIO entry may use `command`:
+`"cxt"` with `args`: `["mcp", "--local"]`. It is not the product connector.
 
 ## Optional slash commands
 
@@ -88,5 +95,6 @@ Automatic capture remains hook-owned; agents should not call `cxt save` or
 
 - `cxt: command not found`: install `cxt`, or use its absolute path in
   `.mcp.json` when the desktop app has a restricted PATH.
-- MCP unavailable: run `cxt mcp` directly and inspect the project `.mcp.json`.
+- Remote MCP unavailable: inspect the connector URL and use `/mcp` to retry
+  OAuth. Run `cxt mcp --local` only when deliberately testing the offline helper.
 - Capture unavailable: rerun `cxt setup` and inspect `.claude/settings.json`.

--- a/integrations/codex/README.md
+++ b/integrations/codex/README.md
@@ -43,29 +43,38 @@ Hooks preserve existing configuration and are fail-open.
 Automatic capture is now active. The app does not need to be launched through
 `cxt codex`; hook payloads identify the exact Codex session and worktree.
 
-## Optional read-only MCP
+## Default cloud read-only MCP
 
-Merge this block into `~/.codex/config.toml`, or add the same STDIO server from
-the Codex app's MCP settings:
+Merge this block into `~/.codex/config.toml`, or add the same Streamable HTTP
+URL from the Codex app's MCP settings:
 
 ```toml
 [mcp_servers.cxt]
-command = "cxt"
-args = ["mcp"]
+url = "https://cxthub.com/mcp"
+auth = "oauth"
 ```
 
-Restart the client after changing MCP configuration. `cxt mcp` exposes exactly
-four tools:
+Restart the client, then authenticate the server. Codex desktop, CLI, and IDE
+share this URL-based configuration. The server reads the user's authorized
+repositories from CXTHub's cloud backend rather than the current machine's
+`.cxt` directory.
+
+The remote server exposes repository discovery plus four context tools:
 
 | MCP tool | Purpose |
 |---|---|
-| `context_list` | List local context commits |
+| `repository_list` | List cloud repositories visible to the signed-in user |
+| `context_list` | List context commits in an authorized repository |
 | `context_fetch` | Read metadata, bounded memory, and recent chat for a ref |
 | `memory_load` | Read the bounded memory projection for a ref |
 | `context_search` | Search synchronized team context |
 
-All four tools are marked read-only and non-destructive. There is no MCP tool
+All tools are marked read-only and non-destructive. There is no MCP tool
 for save, fork, checkout, provider-file restoration, memorize, push, or pull.
+
+For explicit offline development only, configure an STDIO server with
+`command = "cxt"` and `args = ["mcp", "--local"]`. That helper reads the local
+working replica and is not the product default.
 
 ## Optional custom prompts
 
@@ -80,7 +89,7 @@ manual mutation happens only in response to an explicit user action.
 ## Desktop behavior
 
 - Codex app sessions are captured by lifecycle and Git hooks after `cxt setup`.
-- The optional MCP server gives the app a read-only view of saved history.
+- The remote MCP server gives the app an OAuth-scoped read-only view of cloud history.
 - On a Git branch switch, the vendor-owned app session remains open and
   receives one bounded project-memory handoff; CXTHub does not replace the live
   rollout file.
@@ -91,8 +100,9 @@ manual mutation happens only in response to an explicit user action.
 
 - `cxt: command not found`: install `cxt` and ensure the app can resolve it from
   its PATH. An absolute command path is also valid in the MCP config.
-- MCP unavailable: run `cxt mcp` in a terminal and inspect Codex MCP settings or
-  `/mcp` after restarting the client.
+- Remote MCP unavailable: inspect `https://cxthub.com/.well-known/oauth-authorization-server`,
+  then use `codex mcp login cxt`. Use `cxt mcp --local` only when deliberately
+  testing the offline helper.
 - Capture unavailable: rerun `cxt setup`, then inspect Codex lifecycle hooks.
 - General ChatGPT web chats do not read local `config.toml`; local MCP applies
   to Codex-hosted desktop, CLI, and IDE clients.

--- a/integrations/codex/config.snippet.toml
+++ b/integrations/codex/config.snippet.toml
@@ -1,19 +1,19 @@
 # cxt — Codex host configuration snippet
 #
-# Merge this block into ~/.codex/config.toml to register the optional read-only
-# cxt MCP server. Codex desktop, CLI, and IDE clients on the same host share it.
+# Merge this block into ~/.codex/config.toml to register CXTHub's default
+# cloud-backed read-only MCP server. Codex desktop, CLI, and IDE clients on the
+# same host share it and complete OAuth through the CXTHub web login.
 # Hook registration is separate and is merged automatically by cxt setup.
 #
 # Note: ~/.codex/config.toml may contain sections like [mcp_servers.<name>], [plugins."..."], [projects."<path>"].
 # This block adds the cxt item to the [mcp_servers] section.
 
 # ---------------------------------------------------------------------------
-# MCP Server Registration — cxt read-only stdio server
+# MCP Server Registration — CXTHub remote Streamable HTTP server
 # ---------------------------------------------------------------------------
-# The cxt binary must be in your $PATH (verify with cxt --version).
 [mcp_servers.cxt]
-command = "cxt"
-args    = ["mcp"]
+url  = "https://cxthub.com/mcp"
+auth = "oauth"
 
 # ---------------------------------------------------------------------------
 # [projects] Section Guide (Optional)
@@ -30,6 +30,6 @@ args    = ["mcp"]
 # ---------------------------------------------------------------------------
 # Team Remote Server Configuration (Optional)
 # ---------------------------------------------------------------------------
-# MCP never pushes or pulls. Configure synchronization with the cxt CLI:
-#   cxt remote add origin https://<host>/<username>/<workspace>
+# MCP never pushes or pulls. Configure the local working replica separately:
+#   cxt remote add origin https://<host>/<namespace>/<workspace>/<repository>
 #   cxt login

--- a/schemas/openapi.yaml
+++ b/schemas/openapi.yaml
@@ -446,7 +446,7 @@ components:
       properties:
         id: { type: string }
         client_name: { type: string, maxLength: 128 }
-        scope: { type: string, const: context:read }
+        scope: { type: string, const: mcp:read }
         resource: { type: string, format: uri }
         redirect_uri: { type: string, format: uri }
         expires_at: { type: string, format: date-time }

--- a/scripts/deploy-preflight.sh
+++ b/scripts/deploy-preflight.sh
@@ -160,13 +160,56 @@ image_smoke() (
   need curl
   need docker
   local name="cxt-preflight-app-$$"
+  local missing_name="cxt-preflight-app-missing-dsn-$$"
+  local postgres_name="cxt-preflight-app-pg-$$"
+  local network_name="cxt-preflight-net-$$"
   local port=""
-  cleanup_app() { docker rm -f "$name" >/dev/null 2>&1 || true; }
+  cleanup_app() {
+    docker rm -f "$name" "$missing_name" "$postgres_name" >/dev/null 2>&1 || true
+    docker network rm "$network_name" >/dev/null 2>&1 || true
+  }
   trap cleanup_app EXIT
 
-  docker run -d --name "$name" \
+  docker network create "$network_name" >/dev/null
+
+  docker run -d --name "$missing_name" \
     -e CXT_AUTH=firebase -e CXT_FIREBASE_PROJECT=example-firebase-project \
     -e CXT_PUBLIC_URL=http://localhost:8907 \
+    cxtd:preflight --data /tmp/cxt-data >/dev/null
+  for _ in $(seq 1 40); do
+    [ "$(docker inspect "$missing_name" --format '{{.State.Running}}' 2>/dev/null || true)" = "false" ] && break
+    sleep 0.25
+  done
+  if [ "$(docker inspect "$missing_name" --format '{{.State.Running}}' 2>/dev/null || true)" != "false" ]; then
+    docker logs "$missing_name" >&2 || true
+    die "Production image served externally without PostgreSQL"
+  fi
+  if ! docker logs "$missing_name" 2>&1 | grep -q 'CXT_POSTGRES_DSN is required'; then
+    docker logs "$missing_name" >&2 || true
+    die "Production image did not explain its missing PostgreSQL DSN"
+  fi
+  pass "Production image fails closed without PostgreSQL"
+
+  docker run -d --name "$postgres_name" --network "$network_name" --network-alias postgres \
+    -e POSTGRES_USER=cxt -e POSTGRES_PASSWORD=cxt -e POSTGRES_DB=cxthub_test \
+    postgres:16 >/dev/null
+  for _ in $(seq 1 120); do
+    if docker exec "$postgres_name" psql -U cxt -d cxthub_test -tAc 'SELECT 1' >/dev/null 2>&1; then
+      break
+    fi
+    sleep 0.5
+  done
+  if ! docker exec "$postgres_name" psql -U cxt -d cxthub_test -tAc 'SELECT 1' >/dev/null 2>&1; then
+    docker logs "$postgres_name" >&2 || true
+    die "Production image PostgreSQL is not ready"
+  fi
+
+  docker run -d --name "$name" --network "$network_name" \
+    -e CXT_AUTH=firebase -e CXT_FIREBASE_PROJECT=example-firebase-project \
+    -e CXT_PUBLIC_URL=http://localhost:8907 \
+    -e CXT_REQUIRE_POSTGRES=1 \
+    -e CXT_POSTGRES_DSN='postgres://cxt:cxt@postgres:5432/cxthub_test?sslmode=disable' \
+    -e CXT_MIGRATIONS_DIR=/app/migrations \
     -p 127.0.0.1::8907 cxtd:preflight --data /tmp/cxt-data >/dev/null
   port="$(docker port "$name" 8907/tcp 2>/dev/null | awk -F: 'NR==1 {print $NF}' || true)"
   if [ -z "$port" ]; then
@@ -176,7 +219,7 @@ image_smoke() (
   for _ in $(seq 1 60); do
     if curl -fsS "http://127.0.0.1:${port}/api/v1/health" 2>/dev/null \
       | grep -q '"status":"ok"'; then
-      pass "Production image start/health"
+      pass "Production image starts against PostgreSQL"
       return
     fi
     sleep 0.25


### PR DESCRIPTION
## Summary
- make `https://cxthub.com/mcp` the default Codex and Claude integration, with OAuth scope `mcp:read`
- require `cxt mcp --local` for the offline stdio helper and document `.cxt` as a working replica/cache
- enforce Streamable HTTP Origin, Accept, and protocol-version contracts
- fail closed on every externally bound cxtd process without PostgreSQL
- verify the production image both rejects a missing DSN and starts against real PostgreSQL

## Verification
- `bash scripts/deploy-preflight.sh full`
- `CXT_E2E_FULLSTACK=1 npm run test:e2e` (15 passed)
- backend `go test -race ./...`
- CLI `go test -race ./...`
- web typecheck, unit, i18n, build, and `npm audit` (0 vulnerabilities)